### PR TITLE
feat: sync skills with latest project changes (March 2026)

### DIFF
--- a/agents/acko-cluster-debugger.md
+++ b/agents/acko-cluster-debugger.md
@@ -22,6 +22,8 @@ kubectl get asc <name> -n <ns> -o jsonpath='{.status.phase}'
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.phaseReason}'
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions}' | jq .
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.size}'
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.migrationStatus}' | jq .
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.aerospikeClusterSize}'
 ```
 
 ### Step 2: Branch Based on Phase
@@ -44,11 +46,15 @@ Check for:
 #### If Phase = `WaitingForMigration`
 
 ```bash
-# Pick any running pod
+# Check cluster-level migration status
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.migrationStatus}' | jq .
+# Per-pod migration partitions
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq 'to_entries[] | {pod: .key, migrating: .value.migratingPartitions}'
+# Direct asinfo check
 kubectl exec -n <ns> <pod> -c aerospike-server -- asinfo -v 'statistics' | tr ';' '\n' | grep migrate
 ```
 
-This is usually normal during scale-down. Report the migration progress and advise waiting.
+This is usually normal during scale-down. Report `migrationStatus.remainingPartitions` progress and advise waiting.
 
 #### If Phase = `InProgress` (Stuck > 5 Minutes)
 
@@ -140,9 +146,10 @@ After identifying the root cause, suggest the specific fix:
 | CE constraint violation | Fix CR to comply (size<=8, namespaces<=2, no xdr/tls, CE image) |
 | Circuit breaker active | Fix root cause; operator auto-retries with backoff |
 | Dynamic config failed | Set enableDynamicConfigUpdate: false for rolling restart |
-| Split cluster | Verify network connectivity, check cluster-name consistency |
+| Split cluster | Verify network connectivity, check cluster-name consistency. Compare `status.aerospikeClusterSize` with `status.size` |
 | Stop writes | Increase storage capacity or reduce data volume |
 | ACL sync error | Verify Secret exists with correct password key |
+| Operations stuck | Clear operations: `kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"operations":null}}'` |
 
 ## CE 8.1 Common Pitfalls
 

--- a/skills/acko-deploy/reference/cr-spec-fields.md
+++ b/skills/acko-deploy/reference/cr-spec-fields.md
@@ -18,6 +18,8 @@ Complete field reference for the AerospikeCluster Custom Resource.
 | `spec.templateRef.name` | string | No | Reference an AerospikeClusterTemplate |
 | `spec.overrides` | object | No | Override template fields (only with templateRef) |
 | `spec.operations` | list | No | On-demand operations (WarmRestart, PodRestart) |
+| `spec.k8sNodeBlockList` | list[string] | No | Block scheduling on specific K8s nodes (for node drain) |
+| `spec.seedsFinderServices.loadBalancer` | object | No | Create LoadBalancer Service for external seed discovery |
 
 ## aerospikeConfig Section
 
@@ -55,9 +57,15 @@ Complete field reference for the AerospikeCluster Custom Resource.
 | Field | Type | Description |
 |-------|------|-------------|
 | `podSpec.aerospikeContainer.resources` | object | CPU/memory requests and limits |
+| `podSpec.aerospikeContainer.securityContext` | object | Container-level security context (runAsUser, runAsGroup, privileged, readOnlyRootFilesystem, allowPrivilegeEscalation, runAsNonRoot) |
+| `podSpec.readinessGateEnabled` | bool | Enable custom readiness gate `acko.io/aerospike-ready` (triggers rolling restart when toggled) |
 | `rackConfig.racks[]` | list | Rack definitions with zone/node affinity |
+| `rackConfig.racks[].revision` | string | Per-rack revision string; changing triggers rack-specific rolling restart |
 | `rackConfig.namespaces` | list | Namespaces using rack-aware replication |
 | `monitoring.enabled` | bool | Inject Prometheus exporter sidecar |
 | `monitoring.serviceMonitor.enabled` | bool | Create ServiceMonitor for Prometheus Operator |
+| `monitoring.env` | list[EnvVar] | Custom environment variables for exporter container |
+| `monitoring.metricLabels` | map[string]string | Custom metric labels (injected via METRIC_LABELS env var) |
+| `monitoring.prometheusRule` | object | Custom PrometheusRule alert definitions |
 | `aerospikeAccessControl` | object | Roles and users for ACL |
 | `aerospikeNetworkPolicy` | object | Access type configuration (pod/hostInternal/hostExternal) |

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acko-operations
-description: "MUST USE for any modification, debugging, or management of existing Aerospike Kubernetes clusters. Contains ACKO-specific procedures, kubectl commands, and troubleshooting decision trees that prevent data loss during operations. Without this skill, common operations like scaling and upgrades risk incorrect spec patches, webhook rejections, or missed warm restart procedures. Triggers on: scale up/down Aerospike cluster, rolling upgrade, dynamic config change (proto-fd-max, transaction-threads), warm/cold restart, ACL user management, pause/resume, CrashLoopBackOff debugging, phase=Error troubleshooting, asinfo commands, cluster status checks. Covers all ACKO Day-2 operations with verified step-by-step procedures."
+description: "MUST USE for any modification, debugging, or management of existing Aerospike Kubernetes clusters. Contains ACKO-specific procedures, kubectl commands, and troubleshooting decision trees that prevent data loss during operations. Without this skill, common operations like scaling and upgrades risk incorrect spec patches, webhook rejections, or missed warm restart procedures. Triggers on: scale up/down Aerospike cluster, rolling upgrade, dynamic config change (proto-fd-max, transaction-threads), warm/cold restart, ACL user management, pause/resume, clone cluster, clear operations, migration status, CrashLoopBackOff debugging, phase=Error troubleshooting, asinfo commands, cluster status checks. Covers all ACKO Day-2 operations with verified step-by-step procedures."
 ---
 
 # ACKO Day-2 Operations & Troubleshooting
@@ -42,7 +42,11 @@ If migration is in progress, scale-down is automatically deferred and retried af
 
 **Verification**:
 ```bash
-# Check migration status
+# Check migration status (cluster-level)
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.migrationStatus}' | jq .
+# Per-node migration partitions
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq '.[].migratingPartitions'
+# Direct asinfo check
 kubectl exec -n <ns> <pod> -c aerospike-server -- asinfo -v 'statistics' | tr ';' '\n' | grep migrate
 ```
 
@@ -286,25 +290,53 @@ kubectl get events -n <ns> --field-selector reason=TemplateDrifted
 
 ---
 
-## 9. Network Configuration
+## 9. Clone Cluster
+
+Create a copy of an existing cluster with a new name (via aerospike-cluster-manager API or manually):
+
+```bash
+# Manual clone: export existing CR, strip status/operations, change name
+kubectl get asc <source> -n <ns> -o json | \
+  jq 'del(.status, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .spec.operations, .spec.paused) | .metadata.name = "<new-name>"' | \
+  kubectl apply -f -
+```
+
+The clone preserves the full spec (aerospikeConfig, storage, monitoring, ACL) but strips `operations` and `paused` fields.
+
+---
+
+## 10. Clear Stuck Operations
+
+If an operation is stuck in `InProgress` and blocking new operations:
+
+```bash
+# Remove operations from spec to unblock
+kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"operations":null}}'
+```
+
+Via aerospike-cluster-manager API: `DELETE /api/k8s/clusters/{namespace}/{name}/operations`
+
+---
+
+## 11. Network Configuration
 
 Detail: `./reference/operations.md` (Section 8: Network)
 
 ---
 
-## 10. PDB and Maintenance
+## 12. PDB and Maintenance
 
 Detail: `./reference/operations.md` (Section 9: PDB / Maintenance)
 
 ---
 
-## 11. Readiness Gate
+## 13. Readiness Gate
 
 Detail: `./reference/operations.md` (Section 7: Readiness Gate)
 
 ---
 
-## 12. Troubleshooting Decision Tree
+## 14. Troubleshooting Decision Tree
 
 Use this decision tree to diagnose cluster issues systematically.
 
@@ -430,7 +462,7 @@ Use this decision tree to diagnose cluster issues systematically.
 
 ---
 
-## 13. Diagnostic Commands Quick Reference
+## 15. Diagnostic Commands Quick Reference
 
 Detail: `./reference/diagnostic-commands.md`
 

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -471,6 +471,6 @@ Detail: `./reference/diagnostic-commands.md`
 ## Reference Documents
 
 - [Operations Reference](./reference/operations.md) -- Detailed Day-2 operations with all kubectl commands
-- [Events Reference](./reference/events.md) -- All 31 Kubernetes events emitted by ACKO
+- [Events Reference](./reference/events.md) -- All 37 Kubernetes events emitted by ACKO
 - [Troubleshooting Reference](./reference/troubleshooting.md) -- Symptom-based diagnostic table with commands
 - [Validation Rules Reference](./reference/validation-rules.md) -- 53 webhook errors + 15 warnings

--- a/skills/acko-operations/reference/events.md
+++ b/skills/acko-operations/reference/events.md
@@ -1,6 +1,6 @@
 # Kubernetes Events Reference
 
-Complete list of all 31 Kubernetes events emitted by the ACKO operator.
+Complete list of all 37 Kubernetes events emitted by the ACKO operator.
 
 ---
 

--- a/skills/acko-operations/reference/operations.md
+++ b/skills/acko-operations/reference/operations.md
@@ -263,7 +263,24 @@ kubectl -n aerospike-operator logs -l control-plane=controller-manager --tail=10
 
 ---
 
-## 11. Cluster Deletion
+## 11. Migration Status
+
+The operator tracks data migration at both cluster and pod level:
+
+```bash
+# Cluster-level migration status
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.migrationStatus}' | jq .
+# Output: {"inProgress": true, "remainingPartitions": 1024, "lastChecked": "2026-03-24T..."}
+
+# Per-pod migration partitions
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq 'to_entries[] | {pod: .key, migrating: .value.migratingPartitions}'
+```
+
+The operator defers destructive actions (scale-down, pod removal) until `migrationStatus.inProgress` is `false`.
+
+---
+
+## 12. Cluster Deletion
 
 ```bash
 kubectl delete asc <name> -n <ns>

--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aerospike-py-api
-description: "MUST USE when writing any Python code with aerospike-py or aerospike_py. This is a Rust/PyO3 library with UNCONVENTIONAL patterns that differ from typical Python clients — exceptions live on the module (aerospike_py.RecordNotFound, NOT aerospike_py.exception.RecordNotFound), return types are NamedTuples (record.bins, record.meta.gen, NOT tuple unpacking), and policies use module-level constants (aerospike_py.POLICY_EXISTS_CREATE_ONLY). Without this skill, code will use wrong import paths, wrong return type patterns, and miss critical features like expression filters (exp module), batch operations, CDT list/map, operate_ordered, Prometheus get_metrics(), OpenTelemetry tracing, NumPy integration, and admin APIs. Triggers on: aerospike-py, aerospike_py, AsyncClient, Python + Aerospike, put/get/query/batch with Aerospike."
+description: "MUST USE when writing any Python code with aerospike-py or aerospike_py. This is a Rust/PyO3 library with UNCONVENTIONAL patterns that differ from typical Python clients — exceptions live on the module (aerospike_py.RecordNotFound, NOT aerospike_py.exception.RecordNotFound), return types are NamedTuples (record.bins, record.meta.gen, NOT tuple unpacking), and policies use module-level constants (aerospike_py.POLICY_EXISTS_CREATE_ONLY). Without this skill, code will use wrong import paths, wrong return type patterns, and miss critical features like expression filters (exp module), batch operations, CDT list/map/bit/hll, operate_ordered, backpressure (max_concurrent_operations), Prometheus get_metrics(), OpenTelemetry tracing, NumPy integration, and admin APIs. Triggers on: aerospike-py, aerospike_py, AsyncClient, Python + Aerospike, put/get/query/batch with Aerospike."
 ---
 
 ## Installation
@@ -105,6 +105,7 @@ result = client.operate_ordered(key, ops)  # preserves operation order in result
 
 ```python
 from aerospike_py import list_operations as lop, map_operations as mop
+from aerospike_py import bit_operations as bop, hll_operations as hop
 
 record = client.operate(key, [
     lop.list_append("mylist", "val"), lop.list_get("mylist", 0), lop.list_size("mylist"),
@@ -113,6 +114,10 @@ record = client.operate(key, [
     mop.map_put("mymap", "k1", "v1"),
     mop.map_get_by_key("mymap", "k1", aerospike_py.MAP_RETURN_VALUE),
 ])
+# Bit operations (bitwise manipulation on bytes bins)
+record = client.operate(key, [bop.bit_set("flags", 0, 8, b"\xff"), bop.bit_count("flags", 0, 64)])
+# HyperLogLog (cardinality estimation)
+record = client.operate(key, [hop.hll_add("visitors", ["u1", "u2"], 10), hop.hll_get_count("visitors")])
 ```
 
 Detail: `./reference/write.md` | `./reference/constants.md`
@@ -154,6 +159,9 @@ Detail: `./reference/read.md`
 # User management
 client.admin_create_user("user1", "pass", ["read-write"])
 client.admin_drop_user("user1")
+
+# Cluster topology (sync call on both sync/async clients)
+nodes = client.get_node_names()  # list[str] — NOT awaitable, always sync
 
 # Info
 results = client.info_all("namespaces")  # list[InfoNodeResult]

--- a/skills/aerospike-py-api/reference/admin.md
+++ b/skills/aerospike-py-api/reference/admin.md
@@ -173,6 +173,17 @@ Notes:
 
 ---
 
+## Cluster Topology
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| get_node_names | () -> list[str] | Return node name list. **Sync on both Client and AsyncClient** (lock-free, no I/O). |
+
+```python
+nodes = client.get_node_names()          # sync client
+nodes = async_client.get_node_names()    # async client — NOT awaitable, always sync
+```
+
 ## Info & Truncate
 
 | Method | Signature | Description |
@@ -342,6 +353,7 @@ All exceptions are importable from `aerospike_py` or `aerospike_py.exception`.
 ```
 AerospikeError
 +-- ClientError
+|   +-- BackpressureError
 +-- ClusterError
 +-- InvalidArgError
 +-- AerospikeTimeoutError

--- a/skills/aerospike-py-api/reference/client-config.md
+++ b/skills/aerospike-py-api/reference/client-config.md
@@ -25,6 +25,8 @@ Import from `aerospike_py.types`. Used by `aerospike.client(config)` and `AsyncC
 | conn_pools_per_node | int | 1 | Connection pools per node |
 | tend_interval | int | 1000 | Cluster tend interval (ms) |
 | use_services_alternate | bool | false | Use alternate service addresses |
+| max_concurrent_operations | int | 0 (disabled) | Max in-flight operations (backpressure via Tokio Semaphore). Raises `BackpressureError` when exceeded. |
+| operation_queue_timeout_ms | int | 0 (no timeout) | Timeout (ms) for waiting on an operation permit when backpressure is active |
 
 ### Basic Example
 
@@ -159,6 +161,20 @@ results = client.query("test", "demo").results(
 ```
 
 The policy key for expression filters is always `"filter_expression"`.
+
+### Backpressure (Operation Concurrency Limiting)
+
+Limit in-flight operations to prevent connection pool exhaustion under high load:
+
+```python
+config: ClientConfig = {
+    "hosts": [("127.0.0.1", 3000)],
+    "max_concurrent_operations": 64,       # Max 64 concurrent operations
+    "operation_queue_timeout_ms": 5000,    # Wait up to 5s for a permit
+}
+```
+
+When the limit is reached, new operations raise `BackpressureError` (or wait up to `operation_queue_timeout_ms`). Recommended for FastAPI / high-concurrency services.
 
 ### Tokio Runtime Workers
 

--- a/skills/aerospike-py-api/reference/observability.md
+++ b/skills/aerospike-py-api/reference/observability.md
@@ -91,6 +91,8 @@ Operation-level metrics collected in Rust and exposed in Prometheus text format.
 | start_metrics_server(port=9464) | Start background HTTP server at `/metrics` |
 | get_metrics() -> str | Get current metrics in Prometheus text format |
 | stop_metrics_server() | Stop the metrics server |
+| set_metrics_enabled(enabled: bool) | Enable/disable metrics collection. Useful for benchmarking without overhead. |
+| is_metrics_enabled() -> bool | Check if metrics collection is currently enabled |
 
 ```python
 import aerospike_py

--- a/skills/aerospike-py-fastapi/SKILL.md
+++ b/skills/aerospike-py-fastapi/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: aerospike-py-fastapi
+description: "MUST USE for building FastAPI/REST API applications with Aerospike database. Contains production-ready patterns for aerospike-py (Rust/PyO3 async client) that CANNOT be inferred from general knowledge: correct AsyncClient lifespan management, FastAPI Depends injection for client, aerospike_py exception-to-HTTP-status mapping (RecordNotFound→404, RecordExistsError→409, BackpressureError→503), POLICY_EXISTS_CREATE_ONLY/UPDATE_ONLY for CRUD semantics, NamedTuple attribute access (record.bins not tuple unpacking), and global AerospikeError handler. Without this skill, generated code uses wrong import paths, missing DI patterns, and lacks backpressure/metrics/health checks. Triggers on: FastAPI + Aerospike, REST API + aerospike-py, CRUD API with Aerospike, web server/HTTP service backed by Aerospike NoSQL, uvicorn + Aerospike."
+---
+
+## 1. App Structure (Lifespan + DI)
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, Request, Depends
+from aerospike_py import AsyncClient
+import aerospike_py
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    client = AsyncClient({
+        "hosts": [("127.0.0.1", 3000)],
+        "max_concurrent_operations": 64,      # backpressure
+        "operation_queue_timeout_ms": 5000,
+    })
+    aerospike_py.init_tracing()                # OpenTelemetry (optional)
+    await client.connect()
+    app.state.aerospike = client
+    yield
+    await client.close()
+    aerospike_py.shutdown_tracing()
+
+app = FastAPI(lifespan=lifespan)
+
+def get_client(request: Request) -> AsyncClient:
+    return request.app.state.aerospike
+```
+
+## 2. CRUD Endpoints
+
+```python
+from fastapi.responses import JSONResponse
+
+NS, SET = "app", "records"
+
+@app.post("/records/{pk}", status_code=201)
+async def create(pk: str, body: dict, client: AsyncClient = Depends(get_client)):
+    try:
+        await client.put((NS, SET, pk), body,
+                         policy={"exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY})
+        return {"key": pk}
+    except aerospike_py.RecordExistsError:
+        return JSONResponse(status_code=409, content={"error": "already exists"})
+
+@app.get("/records/{pk}")
+async def read(pk: str, client: AsyncClient = Depends(get_client)):
+    try:
+        record = await client.get((NS, SET, pk))
+        return record.bins                     # NamedTuple attribute access
+    except aerospike_py.RecordNotFound:
+        return JSONResponse(status_code=404, content={"error": "not found"})
+
+@app.put("/records/{pk}")
+async def update(pk: str, body: dict, client: AsyncClient = Depends(get_client)):
+    try:
+        await client.put((NS, SET, pk), body,
+                         policy={"exists": aerospike_py.POLICY_EXISTS_UPDATE_ONLY})
+        return {"key": pk}
+    except aerospike_py.RecordNotFound:
+        return JSONResponse(status_code=404, content={"error": "not found"})
+
+@app.delete("/records/{pk}", status_code=204)
+async def delete(pk: str, client: AsyncClient = Depends(get_client)):
+    try:
+        await client.remove((NS, SET, pk))
+    except aerospike_py.RecordNotFound:
+        return JSONResponse(status_code=404, content={"error": "not found"})
+```
+
+## 3. Global Error Handler
+
+```python
+@app.exception_handler(aerospike_py.BackpressureError)
+async def backpressure_handler(request, exc):
+    return JSONResponse(status_code=503, content={"error": "server busy, retry later"})
+
+@app.exception_handler(aerospike_py.AerospikeError)
+async def aerospike_error_handler(request, exc):
+    return JSONResponse(status_code=500, content={"error": str(exc)})
+```
+
+## 4. Exception → HTTP Status Mapping
+
+| Exception | HTTP Status | Meaning |
+|-----------|-------------|---------|
+| `RecordNotFound` | 404 | Record does not exist |
+| `RecordExistsError` | 409 | Record already exists (CREATE_ONLY) |
+| `RecordGenerationError` | 409 | Optimistic lock conflict |
+| `BackpressureError` | 503 | Too many concurrent operations |
+| `AerospikeTimeoutError` | 504 | Operation timed out |
+| `AerospikeError` | 500 | Catch-all server error |
+
+## 5. Health Check
+
+```python
+@app.get("/health")
+async def health(client: AsyncClient = Depends(get_client)):
+    try:
+        nodes = client.get_node_names()   # sync call, NOT awaitable
+        return {"status": "ok", "nodes": len(nodes)}
+    except Exception:
+        return JSONResponse(status_code=503, content={"status": "unhealthy"})
+```
+
+## 6. Metrics Endpoint
+
+```python
+from fastapi import Response
+
+@app.get("/metrics")
+async def metrics():
+    return Response(
+        content=aerospike_py.get_metrics(),
+        media_type="text/plain; version=0.0.4",
+    )
+```
+
+Or use the built-in server: `aerospike_py.start_metrics_server(port=9464)` in lifespan.
+
+## 7. Key Patterns
+
+- **Lifespan**: Create `AsyncClient` in lifespan, store on `app.state`, close on shutdown
+- **DI**: Use `Depends(get_client)` for every endpoint — never create client per-request
+- **Exceptions on module**: `aerospike_py.RecordNotFound` (NOT `aerospike_py.exception.RecordNotFound`)
+- **NamedTuple returns**: `record.bins`, `record.meta.gen` (NOT tuple unpacking)
+- **get_node_names()**: Always sync, even on AsyncClient
+- **Backpressure**: Set `max_concurrent_operations` to prevent connection pool exhaustion
+
+Detail: `../aerospike-py-api/reference/client-config.md` | `../aerospike-py-api/reference/admin.md`


### PR DESCRIPTION
## Summary
- aerospike-py-api skill: Add bit/hll CDT operations, `get_node_names()` sync method, `BackpressureError` exception, backpressure config params
- ACKO operations skill: Add migration status tracking, cluster clone, clear stuck operations, new CR spec fields (container security context, readiness gate, rack revision, monitoring env/metricLabels/prometheusRule)
- acko-cluster-debugger agent: Enhanced migration status checks, split-brain detection via `aerospikeClusterSize`, stuck operations remediation

## Context
Syncs plugin skills with recent changes across:
- **aerospike-py**: backpressure system (Semaphore), bit/hll CDT ops, `get_node_names()` sync change, aerospike-core alpha.10
- **ACKO operator**: `MigrationStatus` struct, container security context, monitoring env/metricLabels, rack revision, readiness gate
- **aerospike-cluster-manager**: cluster clone endpoint, clear operations endpoint, edit dialog enhancements

## Test plan
- [ ] Verify skill triggering accuracy for new keywords (backpressure, clone, clear operations)
- [ ] Check that code examples compile/run correctly against aerospike-py 0.0.4
- [ ] Validate CR spec field references match ACKO v1alpha1 types