### PR TITLE
docs: add batch_write() skill reference and in_doubt field

### DIFF
--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -85,6 +85,11 @@ batch = client.batch_read(keys)  # or batch_read(keys, bins=["name"])
 for br in batch.batch_records:
     if br.result == 0 and br.record is not None: print(br.record.bins)
 
+records = [(k, {"name": f"user_{i}", "score": i * 10}) for i, k in enumerate(keys)]
+results = client.batch_write(records, retry=3)  # per-record bins, auto-retry transient failures
+for br in results.batch_records:
+    if br.result != 0: print(f"Failed: {br.key}, in_doubt={br.in_doubt}")
+
 results = client.batch_operate(keys, [{"op": aerospike_py.OPERATOR_INCR, "bin": "views", "val": 1}])
 for br in results.batch_records:
     if br.result == 0 and br.record is not None: print(br.record.bins)

--- a/skills/aerospike-py-api/reference/types.md
+++ b/skills/aerospike-py-api/reference/types.md
@@ -48,7 +48,7 @@ _, meta, bins = record     # tuple unpacking
 | ttl | int | Seconds until expiration |
 
 ### BatchRecord
-`(key: AerospikeKey | None, result: int, record: Record | None)`
+`(key: AerospikeKey | None, result: int, record: Record | None, in_doubt: bool)`
 
 Per-record result from batch operations. `result` is 0 on success.
 
@@ -57,11 +57,12 @@ Per-record result from batch operations. `result` is 0 on success.
 | key | AerospikeKey \| None | Record key |
 | result | int | Per-record result code (0 = success) |
 | record | Record \| None | Record data (`None` if failed) |
+| in_doubt | bool | `True` if the write may have completed despite the error (e.g., timeout after send). Check before retrying to avoid duplicates. |
 
 ### BatchRecords
 `(batch_records: list[BatchRecord])`
 
-Container returned by all batch operations: `batch_read`, `batch_operate`, `batch_remove`, `batch_write_numpy`.
+Container returned by all batch operations: `batch_read`, `batch_write`, `batch_operate`, `batch_remove`, `batch_write_numpy`.
 
 ```python
 results = client.batch_operate(keys, ops)
@@ -122,7 +123,7 @@ Returned by `info_all`. One result per cluster node.
 | `operate_ordered()` | `OperateOrderedResult` |
 | `info_all()` | `list[InfoNodeResult]` |
 | `batch_read()` | `BatchRecords` \| `NumpyBatchRecords` |
-| `batch_operate()`, `batch_remove()` | `BatchRecords` |
+| `batch_write()`, `batch_operate()`, `batch_remove()` | `BatchRecords` |
 | `batch_write_numpy()` | `BatchRecords` |
 | `Query.results()` | `list[Record]` |
 

--- a/skills/aerospike-py-api/reference/write.md
+++ b/skills/aerospike-py-api/reference/write.md
@@ -108,6 +108,43 @@ for br in results.batch_records:
         print(br.record.bins)
 ```
 
+### batch_write(records, policy=None, retry=0) -> BatchRecords
+
+Write multiple records with per-record bins in a single batch call. Each record is a `(key, bins)` tuple. Unlike `batch_operate()` (same ops for all keys), each record can have different bins.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `records` | `list[tuple[Key, dict]]` | required | List of `(key, bins)` tuples |
+| `policy` | `dict` | `None` | Optional BatchPolicy |
+| `retry` | `int` | `0` | Max retries for transient failures (Full Jitter backoff) |
+
+**Returns:** `BatchRecords` — each `BatchRecord` has `.result` (0=OK), `.in_doubt` (bool), `.record`.
+
+**Retryable errors:** Timeout, DeviceOverload, KeyBusy, ServerMemError, PartitionUnavailable.
+
+```python
+# Basic usage
+records = [
+    (("test", "demo", "user1"), {"name": "Alice", "age": 30}),
+    (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
+]
+results = client.batch_write(records)
+
+# With retry
+results = client.batch_write(records, retry=3)
+
+# Async
+results = await async_client.batch_write(records, retry=3)
+
+# Error handling with in_doubt
+for br in results.batch_records:
+    if br.result != 0:
+        if br.in_doubt:
+            print(f"Write may have completed: {br.key}")  # don't blindly retry
+        else:
+            print(f"Write definitely failed: {br.key}, code={br.result}")
+```
+
 ### batch_remove(keys, policy=None) -> BatchRecords
 
 Delete multiple records in a single network call.


### PR DESCRIPTION
## Summary

- Add `batch_write(records, policy, retry)` reference to `write.md` with parameter table, sync/async examples, retry + in_doubt error handling patterns
- Update `BatchRecord` in `types.md` with `in_doubt: bool` field documentation
- Add `batch_write` example to `SKILL.md` Section 5 (Batch Operations)

Companion to aerospike-ce-ecosystem/aerospike-py#258

## Test plan

- [x] Skill content reviewed for accuracy against aerospike-py implementation