### PR TITLE
feat: sync skills with aerospike-py and ACKO upstream (April 2026)

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -36,6 +36,18 @@
       "prompt": "Add proper error handling to the FastAPI app: 404 for not found, 409 for duplicates, 503 for connection issues",
       "expected_output": "Correct HTTP status codes returned",
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "An Aerospike cluster has fallen into phase=ConfigDegraded. The dynamic config rollback appears to have failed -- walk me through recovery",
+      "expected_output": "Inspect the DynamicConfigDegraded condition and status.pods[*].dynamicConfigChanges, then advise the user NOT to toggle enableDynamicConfigUpdate but to let the operator cold-restart on the next reconcile. If the loop persists, recommend reverting the spec to a known-good value",
+      "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "Implement a FastAPI readiness probe using client.ping() and add an endpoint that creates multiple records via batch_write. If any record is in_doubt, signal 503 so the client reconciles state",
+      "expected_output": "/health/ready uses await client.ping(); /records:batchWrite calls client.batch_write(...); inspects BatchRecord.in_doubt and returns 503 when any in_doubt items are present, else a normal response",
+      "files": []
     }
   ]
 }

--- a/skills/acko-config-reference/SKILL.md
+++ b/skills/acko-config-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acko-config-reference
-description: "Aerospike CE 8.1 configuration parameters, CRD YAML mapping, and ACKO operator auto-processing rules. Background reference for Aerospike cluster configuration on Kubernetes. Automatically consulted when configuring Aerospike CE 8.1 parameters, writing AerospikeCluster CRD YAML, or understanding breaking changes from 7.x to 8.1."
+description: "Aerospike CE 8.1 configuration parameters, CRD YAML mapping, ACKO operator auto-processing rules, AerospikeCluster status phases/conditions, and webhook validation rules. Background reference for Aerospike cluster configuration on Kubernetes. Automatically consulted when configuring CE 8.1 parameters, writing AerospikeCluster CRD YAML, looking up status phase/condition meanings (Completed, ConfigDegraded, ReconcileHealthy), or understanding breaking changes from 7.x to 8.1."
 user-invocable: false
 ---
 
@@ -26,14 +26,17 @@ Verify these items before deploying an Aerospike CE 8.1 cluster on Kubernetes.
 | 8 | Console logging | Enables `kubectl logs` integration |
 | 9 | `nsup-period` + `default-ttl` | `nsup-period=0` + `default-ttl!=0` causes startup failure |
 | 10 | CE image only | `aerospike:ce-8.1.1.1` (enterprise/ee-/ent- rejected by webhook) |
+| 11 | `aerospikeConfig` map/list shape | `service`/`network` must be maps; `logging` must be a list; namespace entries must be maps with `name` key (webhook strengthened April 2026) |
+| 12 | `MetricLabels` TOML safety | Values are TOML double-quote-wrapped and backslash-escaped; control chars rejected by webhook |
 
 ---
 
-## Critical Breaking Changes (Top 3)
+## Critical Breaking Changes (Top 4)
 
 1. **`info { port 3003 }` removed** -- causes parse error and CrashLoopBackOff. Use `admin { port 3008 }`.
 2. **`memory-size` replaced by `data-size`** -- must be inside `storage-engine memory {}` block, minimum 512 MiB.
 3. **`write-block-size` replaced by `flush-size`** -- internal write-block fixed at 8M in 7.1+.
+4. **Webhook strengthened (April 2026)** -- CR rejected at admission if `aerospikeConfig.service`/`network` is not a map, `logging` is not a list, namespace entries are not maps with `name` key, or `MetricLabels` contains control chars. See `reference/webhook-validation.md`.
 
 Full reference: `reference/breaking-changes-7x-to-8.md`
 
@@ -47,7 +50,8 @@ Full reference: `reference/breaking-changes-7x-to-8.md`
 | 8.1 parameter defaults, network ports, dynamic config commands | `reference/parameters-8.md` |
 | Byte value conversion table (human-readable to integer) | `reference/byte-values.md` |
 | Webhook validation rules and CE constraints | `reference/webhook-validation.md` |
-| CRD-to-conf mapping, operator auto-processing, ACL config | `reference/crd-mapping.md` |
+| CRD-to-conf mapping, operator auto-processing, ACL config, status fields | `reference/crd-mapping.md` |
+| AerospikeCluster phases & conditions (Completed, ConfigDegraded, ReconcileHealthy, etc.) | `reference/conditions-and-phases.md` |
 
 ## Examples
 

--- a/skills/acko-config-reference/reference/conditions-and-phases.md
+++ b/skills/acko-config-reference/reference/conditions-and-phases.md
@@ -1,0 +1,108 @@
+# AerospikeCluster Phases & Conditions
+
+This is background reference for `status.phase` and `status.conditions[]` on the `AerospikeCluster` CR. ACKO uses these to communicate reconciliation state. Operations procedures live in `acko-operations`.
+
+---
+
+## status.phase
+
+| Phase | Meaning | Triggers |
+|-------|---------|----------|
+| `""` (empty) | CR just created, reconciler has not yet observed it | Initial admission |
+| `Pending` | Reconciler observed CR, work is in flight | First reconcile loop |
+| `Completed` | Spec is fully realized; cluster is healthy and stable | All pods Ready, generations matched, no in-flight ops |
+| `Error` | A reconcile attempt failed and is being retried | Transient errors (pod not ready, network), exponential backoff |
+| `Paused` | Reconciliation suspended via `spec.paused: true` | User toggled `paused: true` |
+| `ConfigDegraded` | Dynamic config rollback failed; cluster is in inconsistent config state across pods | 2PC apply failed AND LIFO rollback also failed |
+
+### `Phase = Completed`
+
+The expected steady state. All pods Ready, observed generation matches spec generation, no operations in progress.
+
+### `Phase = Error`
+
+Reconciler will retry with exponential backoff. **Note:** for permanent errors (validation, missing secrets), the circuit breaker activates immediately and `status.conditions` will include `ReconcileHealthy=False` with `reason=PermanentError` -- in that case the backoff is bypassed and no further retries happen until you fix the spec or toggle `paused`.
+
+### `Phase = Paused`
+
+Set when `spec.paused: true`. The reconciler stops touching the cluster. Resume by setting `spec.paused: null` (or `false`); on resume, stale `status.failedReconcileCount` and `status.lastReconcileError` are cleared.
+
+### `Phase = ConfigDegraded` (NEW, April 2026)
+
+Dynamic config update used a 2-phase commit (validate-all-then-apply-all). Apply failed mid-flight, and the LIFO rollback also failed -- so different pods now have different runtime configs. The operator will attempt a cold restart on the next reconcile to get back to the spec'd config.
+
+Recovery is automatic on the next reconcile, but you should:
+1. Inspect `status.conditions` for `DynamicConfigDegraded=True` and read its `message`.
+2. Inspect `status.pods[].dynamicConfigChanges` to see which path/oldValue/newValue per pod.
+3. If the cold restart loop continues, fix the underlying spec problem (e.g., a config value that's invalid on some hardware shape).
+
+---
+
+## status.conditions[]
+
+ACKO emits standard K8s-style conditions. Each has `type`, `status` (`True`/`False`/`Unknown`), `reason`, `message`, `lastTransitionTime`.
+
+| Type | Status meaning | Reason examples |
+|------|----------------|-----------------|
+| `ReconcileHealthy` | `True` = recent reconciles succeeded; `False` = circuit broken | `PermanentError`, `Recovered` |
+| `DynamicConfigDegraded` | `True` = pods have inconsistent dynamic config | `RollbackFailed`, `ApplyFailed` |
+| `ReconciliationPaused` | `True` = `spec.paused: true` is in effect | `UserRequested` |
+
+### `ReconcileHealthy = False / reason = PermanentError`
+
+Circuit breaker is active. The operator detected an unrecoverable error (e.g., configgen rejected a value, a required Secret is missing, a webhook validation failure that somehow escaped admission) and stopped retrying. `status.failedReconcileCount` is pinned at the max value -- there is no incremental backoff to wait through.
+
+To recover:
+- Fix the root cause (correct the spec, create the missing Secret, etc.).
+- Either edit the spec to retrigger a reconcile, OR toggle `spec.paused: true` then `spec.paused: null` to clear the stale `failedReconcileCount` and `lastReconcileError`.
+
+### `DynamicConfigDegraded = True`
+
+Set together with `phase=ConfigDegraded`. See above. Read `status.pods[].dynamicConfigChanges` for per-pod detail.
+
+### `ReconciliationPaused = True`
+
+Set together with `phase=Paused`. The condition's `lastTransitionTime` is the canonical "when did pause start" — the `acko_cluster_paused_timestamp_seconds` and `acko_cluster_paused_duration_seconds` metrics are derived from it.
+
+---
+
+## status.pods[].dynamicConfigChanges (NEW)
+
+Each `AerospikePodStatus.dynamicConfigChanges[]` entry tracks one config path mutated in the last dynamic config attempt:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | Dotted config path, e.g. `service.proto-fd-max` |
+| `oldValue` | string | Previous value (TOML-rendered) |
+| `newValue` | string | Attempted new value |
+| `result` | enum | `Applied`, `Failed`, `Pending`, `RolledBack`, `RollbackFailed` |
+
+Use this to debug which specific change failed in a 2PC rollout:
+
+```bash
+kubectl get asc <name> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq
+```
+
+---
+
+## Quick decision tree
+
+```
+status.phase == Completed
+  -> healthy steady state
+
+status.phase == Pending or Error (transient)
+  -> wait one reconcile cycle; check events for hints
+
+status.phase == ConfigDegraded
+  -> 2PC dynamic config rollback failed
+  -> read DynamicConfigDegraded condition + status.pods[].dynamicConfigChanges
+  -> operator will cold-restart on next reconcile
+
+status.conditions[ReconcileHealthy].status == False, reason == PermanentError
+  -> circuit broken on a permanent error
+  -> fix root cause; toggle paused or edit spec to retrigger
+
+status.conditions[ReconciliationPaused].status == True
+  -> spec.paused == true; nothing happens until you resume
+```

--- a/skills/acko-config-reference/reference/crd-mapping.md
+++ b/skills/acko-config-reference/reference/crd-mapping.md
@@ -57,3 +57,34 @@ type: Opaque
 data:
   password: YWRtaW4xMjM=              # base64-encoded password
 ```
+
+---
+
+## Status Fields (NEW: dynamicConfigChanges)
+
+`status.pods[].dynamicConfigChanges []DynamicConfigChangeStatus` (April 2026) tracks each path mutated in the most recent dynamic config attempt. Useful for debugging which specific change failed in a 2-phase commit rollout.
+
+```yaml
+status:
+  pods:
+    cluster-1-0:
+      dynamicConfigChanges:
+        - path: service.proto-fd-max
+          oldValue: "15000"
+          newValue: "20000"
+          result: Applied
+        - path: namespaces.testns.default-ttl
+          oldValue: "0"
+          newValue: "3600"
+          result: RolledBack       # phase 2 apply failed -> LIFO rollback succeeded
+```
+
+Per-change `result` enum: `Applied`, `Failed`, `Pending`, `RolledBack`, `RollbackFailed`.
+
+Inspect with:
+
+```bash
+kubectl get asc <name> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq
+```
+
+For phase/condition meanings (`ConfigDegraded`, `DynamicConfigDegraded`, `ReconcileHealthy`, `ReconciliationPaused`), see `conditions-and-phases.md`.

--- a/skills/acko-config-reference/reference/webhook-validation.md
+++ b/skills/acko-config-reference/reference/webhook-validation.md
@@ -1,5 +1,7 @@
 # Webhook Validation Summary
 
+> Canonical, fully-enumerated rule list (with error codes) lives at `acko-operations/reference/validation-rules.md`. This page is the **shape-and-constraints summary** for use while drafting CR YAML.
+
 ## CE Constraints (Rejection)
 
 The ACKO webhook rejects CRs that violate these constraints:
@@ -10,6 +12,23 @@ The ACKO webhook rejects CRs that violate these constraints:
 - `xdr` or `tls` section present -> rejected
 - `security` present without `aerospikeAccessControl` -> rejected
 - Admin user missing `sys-admin` + `user-admin` -> rejected
+
+## Strengthened map/list validation (April 2026)
+
+The webhook now also rejects CRs that violate these structural rules — preventing permanent configgen failures from reaching the running pod:
+
+| Field | Required shape | Common mistake |
+|-------|----------------|----------------|
+| `aerospikeConfig.service` | YAML map (object) | accidentally passed as string or null |
+| `aerospikeConfig.network` | YAML map (object) | accidentally passed as string or null |
+| `aerospikeConfig.logging` | YAML list (array) | passed as map keyed by sink name |
+| `aerospikeConfig.namespaces[]` | each entry is a map with required `name` key | passed as bare string `"testns"` |
+| `aerospikeConfig.namespaces[]` rack ID transitions | within one update, may add new IDs OR remove old ones, but not both | rename via add+remove in one apply (data loss risk) |
+| `aerospikeConfig...metricLabels[*]` | values must be TOML-quotable: control characters (`\x00`-`\x1F`, `\x7F`) rejected | unescaped newline or tab in label value |
+| `spec.operations[]` | id length 1-20; kind ∈ {`WarmRestart`, `PodRestart`}; cannot modify while one is `InProgress` | reusing an id, or editing operations spec mid-flight |
+| `spec.overrides` | only valid when `spec.templateRef` is set | trying to use overrides on an inline-spec cluster |
+
+These run at admission time, so a bad apply fails fast with a clear webhook error rather than entering CrashLoopBackOff later.
 
 ## Byte Values in CRD YAML
 

--- a/skills/acko-deploy/SKILL.md
+++ b/skills/acko-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acko-deploy
-description: "MUST USE for deploying Aerospike on Kubernetes. Contains CE-specific YAML templates, validated AerospikeCluster CR examples, and critical constraints that prevent enterprise-only config mistakes (feature-key-file, security sections crash CE pods). Without this skill, deployments fail on first attempt due to CE 8.1 breaking changes (data-size not memory-size, no info port 3003). Triggers on: deploy/create/set up Aerospike on K8s, kind, minikube, EKS, GKE; AerospikeCluster CR; ACKO operator; Aerospike cluster YAML; NoSQL database on Kubernetes. This skill has 8 ready-to-use YAML examples from minimal single-node to full-featured multi-rack with monitoring."
+description: "MUST USE for deploying Aerospike on Kubernetes. Contains CE-specific YAML templates, validated AerospikeCluster CR examples, and critical constraints that prevent enterprise-only config mistakes (feature-key-file, security sections crash CE pods). Without this skill, deployments fail on first attempt due to CE 8.1 breaking changes (data-size not memory-size, no info port 3003) or webhook map/list shape rules (service/network must be maps; logging must be a list). Triggers on: deploy/create/set up Aerospike on K8s, kind, minikube, EKS, GKE; AerospikeCluster CR; ACKO operator; spec.operations / WarmRestart / PodRestart YAML; NoSQL database on Kubernetes. 9 ready-to-use YAML examples from minimal single-node to full-featured multi-rack."
 ---
 
 # ACKO Deployment Guide
@@ -95,6 +95,8 @@ These constraints are enforced by the ACKO validating webhook. Violating any of 
 8. **Replication factor**: Must be between 1 and 4, and must not exceed `spec.size`.
 9. **No Enterprise namespace keys**: The following keys are forbidden in namespace config: `compression`, `compression-level`, `durable-delete`, `fast-restart`, `index-type`, `sindex-type`, `rack-id`, `strong-consistency`, `tomb-raider-eligible-age`, `tomb-raider-period`.
 10. **No Enterprise security keys**: Only `enable-security` and `default-password-file` are allowed in `aerospikeConfig.security`. The keys `tls`, `ldap`, `log`, `syslog` are forbidden.
+11. **Strengthened map/list shapes (April 2026)**: `aerospikeConfig.service` and `aerospikeConfig.network` must be YAML maps; `aerospikeConfig.logging` must be a YAML list; each `namespaces[]` entry must be a map with a `name` key. `MetricLabels` values are TOML-escaped — control characters are rejected. Within one update, namespace `rack-id` may be added OR removed but not both (prevents data loss on rename).
+12. **Operations spec invariants**: `spec.operations[].kind` must be `WarmRestart` or `PodRestart`; `spec.operations[].id` length 1–20 chars; the operations list cannot be modified while one operation is `InProgress`. `spec.overrides` only valid when `spec.templateRef` is set.
 
 ---
 
@@ -141,6 +143,13 @@ Choose the scenario that matches your needs. Each links to a ready-to-use YAML e
 - **File**: [./examples/08-full-featured.yaml](./examples/08-full-featured.yaml)
 - **Use when**: Production deployment with all features enabled
 - **Key features**: ACL + monitoring + multi-rack + PV + PDB + dynamic config
+
+### Scenario 9: On-Demand Operations (WarmRestart / PodRestart)
+- **File**: [./examples/09-operations.yaml](./examples/09-operations.yaml)
+- **Use when**: You need to manually restart pods (warm via SIGUSR1, or full pod recreate) without changing spec
+- **Key features**: `spec.operations[]` with `WarmRestart` (SIGUSR1) or `PodRestart` (delete+recreate); optional `podList` to target specific pods; webhook prevents modifying the operations list while one is `InProgress`
+
+> **Monitoring sample note (`04-monitoring.yaml`)**: Recent fix — `metricLabels` values are TOML-escaped (double-quote-wrapped, backslash-escaped, control chars rejected) and the demo `emptyDir` mount points to `/opt/aerospike/work` instead of accidentally overlaying `/opt/aerospike`. If you cloned this example before April 2026, verify both.
 
 ---
 
@@ -203,3 +212,9 @@ Byte values: See acko-config-reference skill's `reference/byte-values.md`
 ## 8. CE 8.1 Configuration Notes
 
 CE 8.1 notes: See acko-config-reference skill
+
+---
+
+## 9. Template Fix Notice (April 2026)
+
+A recent operator fix re-applies the resolved template to the in-memory cluster spec **after** every `Status().Update`/`Patch`, so template-derived fields (`PodSpec.PodAntiAffinity`, `Resources`, `Storage`) now reach the StatefulSet and persist across reconciles. If you previously worked around this by inlining template values into `spec.overrides`, you can drop those workarounds. `VolumeClaimTemplate` updates remain immutable — VCTs are only set at StatefulSet creation time inside `buildStatefulSet`.

--- a/skills/acko-deploy/examples/04-monitoring.yaml
+++ b/skills/acko-deploy/examples/04-monitoring.yaml
@@ -43,7 +43,9 @@ spec:
     env:                            # Environment variables for the exporter
       - name: AS_STAT_NAMESPACES    # Restrict stats collection to specific namespaces
         value: "test"
-    metricLabels:                   # Custom labels added to all exported metrics
+    metricLabels:                   # Custom labels added to all exported metrics.
+      # Values are TOML-rendered into METRIC_LABELS (double-quote-wrapped, backslashes escaped).
+      # Control chars (\x00-\x1F, \x7F) are rejected by the webhook -- keep values as plain ASCII.
       environment: production
       team: platform
     serviceMonitor:
@@ -72,4 +74,8 @@ spec:
             storageClass: standard
             size: 10Gi
         aerospike:
-          path: /opt/aerospike
+          # Mount under /opt/aerospike/work, NOT /opt/aerospike itself.
+          # Mounting at /opt/aerospike overlays the image's binaries/scripts and
+          # was the source of the April 2026 emptyDir mount bug. Always mount
+          # under a subdirectory.
+          path: /opt/aerospike/work

--- a/skills/acko-deploy/examples/09-operations.yaml
+++ b/skills/acko-deploy/examples/09-operations.yaml
@@ -1,0 +1,59 @@
+# Scenario 9: On-Demand Operations (WarmRestart / PodRestart)
+#
+# Description:
+#   Trigger a manual restart on an existing AerospikeCluster without changing
+#   the rest of the spec. Two kinds:
+#     - WarmRestart: sends SIGUSR1 to the aerospike server process.
+#                    Reloads dynamic config; pod is NOT recreated.
+#     - PodRestart:  deletes pods so the StatefulSet recreates them.
+#                    Use when warm restart isn't enough (e.g., changing PodSpec).
+#
+#   The webhook prevents modifying spec.operations[] while the current
+#   operation has status=InProgress. Wait for completion before queueing
+#   another, or change `id` for a fresh operation.
+#
+# Prerequisites:
+#   An AerospikeCluster named "aerospike-basic" already exists and is
+#   in phase=Completed. (Apply 01-minimal.yaml or 02-3node-pv.yaml first.)
+#
+# Apply (patch operations onto an existing cluster):
+#   kubectl patch asc aerospike-basic -n aerospike --type=merge --patch-file=09-operations.yaml
+#
+# Watch progress:
+#   kubectl get asc aerospike-basic -n aerospike -o jsonpath='{.status.operation}' | jq
+#
+# Verify warm restart (uptime resets but pod did NOT restart):
+#   kubectl exec -n aerospike aerospike-basic-0-0 -c aerospike-server -- asinfo -v uptime
+#
+apiVersion: acko.io/v1alpha1
+kind: AerospikeCluster
+metadata:
+  name: aerospike-basic
+  namespace: aerospike
+spec:
+  operations:
+    # Warm restart all pods. SIGUSR1 reloads dynamic config without pod recreate.
+    - kind: WarmRestart
+      id: warm-001                # length 1-20; must be unique-per-cluster
+
+  # ---- Variants (uncomment one at a time, only after the previous completes) ----
+
+  # Warm restart only specific pods:
+  # operations:
+  #   - kind: WarmRestart
+  #     id: warm-rack1-only
+  #     podList:
+  #       - aerospike-basic-1-0
+  #       - aerospike-basic-1-1
+
+  # Full pod restart (delete + recreate via StatefulSet):
+  # operations:
+  #   - kind: PodRestart
+  #     id: pod-restart-001
+
+  # Pod restart targeted at a single pod (e.g., suspected memory leak):
+  # operations:
+  #   - kind: PodRestart
+  #     id: pod-restart-leaky
+  #     podList:
+  #       - aerospike-basic-0-2

--- a/skills/acko-deploy/examples/09-operations.yaml
+++ b/skills/acko-deploy/examples/09-operations.yaml
@@ -36,7 +36,14 @@ spec:
     - kind: WarmRestart
       id: warm-001                # length 1-20; must be unique-per-cluster
 
-  # ---- Variants (uncomment one at a time, only after the previous completes) ----
+  # ============================================================================
+  # WARNING: spec.operations[] accepts AT MOST ONE entry. The webhook rejects
+  # the apply with "only one operation can be specified at a time" if you
+  # uncomment a variant below without deleting the active block above.
+  # Also: you cannot modify spec.operations[] while the current op has
+  # status.operation.phase = InProgress. Wait for it to complete or fail.
+  # ============================================================================
+  # ---- Variants (uncomment ONE, after deleting the active block above) ----
 
   # Warm restart only specific pods:
   # operations:

--- a/skills/acko-deploy/reference/cr-spec-fields.md
+++ b/skills/acko-deploy/reference/cr-spec-fields.md
@@ -69,3 +69,24 @@ Complete field reference for the AerospikeCluster Custom Resource.
 | `monitoring.prometheusRule` | object | Custom PrometheusRule alert definitions |
 | `aerospikeAccessControl` | object | Roles and users for ACL |
 | `aerospikeNetworkPolicy` | object | Access type configuration (pod/hostInternal/hostExternal) |
+
+## On-Demand Operations (`spec.operations[]`)
+
+Trigger manual restarts without otherwise changing the spec. The webhook prevents modifying the operations list while one operation is `InProgress`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `spec.operations[].kind` | enum | `WarmRestart` (sends SIGUSR1 to the aerospike process, no pod recreate) or `PodRestart` (delete + recreate pods) |
+| `spec.operations[].id` | string | Unique-per-cluster id, length 1–20 chars. Identifies one operation across reconciles. |
+| `spec.operations[].podList` | list[string] | Optional. Subset of pod names to target. Omit to apply to all pods. |
+| `status.operation.phase` | enum | `InProgress` / `Completed` / `Error` |
+| `status.operation.completedPods` | list[string] | Pods that finished successfully |
+| `status.operation.failedPods` | list[string] | Pods that errored |
+
+## Status Fields (selected)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status.phase` | enum | `""`, `Pending`, `Completed`, `Error`, `Paused`, `ConfigDegraded` (April 2026) |
+| `status.conditions[]` | list | Includes `ReconcileHealthy`, `DynamicConfigDegraded`, `ReconciliationPaused` (full reference in `acko-config-reference/reference/conditions-and-phases.md`) |
+| `status.pods[].dynamicConfigChanges[]` | list | Per-path tracking from last 2PC dynamic config attempt: `path`, `oldValue`, `newValue`, `result` ∈ {`Applied`,`Failed`,`Pending`,`RolledBack`,`RollbackFailed`} |

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: acko-operations
-description: "MUST USE for any modification, debugging, or management of existing Aerospike Kubernetes clusters. Contains ACKO-specific procedures, kubectl commands, and troubleshooting decision trees that prevent data loss during operations. Without this skill, common operations like scaling and upgrades risk incorrect spec patches, webhook rejections, or missed warm restart procedures. Triggers on: scale up/down Aerospike cluster, rolling upgrade, dynamic config change (proto-fd-max, transaction-threads), warm/cold restart, ACL user management, pause/resume, clone cluster, clear operations, migration status, CrashLoopBackOff debugging, phase=Error troubleshooting, asinfo commands, cluster status checks. Covers all ACKO Day-2 operations with verified step-by-step procedures."
+description: "MUST USE for any modification, debugging, or management of existing Aerospike Kubernetes clusters. Contains ACKO-specific procedures, kubectl commands, and troubleshooting decision trees that prevent data loss during operations. Without this skill, common operations like scaling and upgrades risk incorrect spec patches, webhook rejections, or missed warm restart procedures. Triggers on: scale up/down Aerospike cluster, rolling upgrade, dynamic config change (proto-fd-max, transaction-threads, 2PC rollout), ConfigDegraded phase, circuit breaker / permanent error, warm/cold restart, ACL user management, pause/resume, clone cluster, clear operations, migration status, CrashLoopBackOff debugging, phase=Error troubleshooting, asinfo commands, cluster status checks."
 ---
 
 # ACKO Day-2 Operations & Troubleshooting
@@ -89,9 +89,18 @@ kubectl get pods -n <ns> -l aerospike.io/cr-name=<name> -o jsonpath='{range .ite
 
 ---
 
-## 3. Dynamic Config Update (No Restart)
+## 3. Dynamic Config Update (No Restart, 2-Phase Commit)
 
 Apply configuration changes without restarting pods. Only works for dynamically changeable parameters.
+
+### How the operator applies changes (2PC — April 2026)
+
+1. **Phase 1 — validate-all**: operator probes every pod with the proposed change. If ANY pod rejects validation (syntax, node unresponsive), the entire update is aborted and no pod is mutated.
+2. **Phase 2 — apply sequentially**: each pod is updated with a per-pod 30 s timeout (independent of the reconciliation timeout).
+3. **On apply failure**: a LIFO rollback runs across pods that were already updated. Each rollback also has the per-pod 30 s budget.
+4. **On rollback failure**: cluster transitions to `phase = ConfigDegraded`, `ConditionDynamicConfigDegraded=True` is set, and the operator attempts a cold restart on the next reconcile.
+
+This makes dynamic config rollouts atomic from the user's perspective: either every pod ends up on the new value, every pod ends up back on the old value, or you observe `ConfigDegraded` and the operator self-heals via cold restart.
 
 ### Step 1: Enable Dynamic Config
 
@@ -120,12 +129,23 @@ kubectl patch asc <name> -n <ns> --type=merge \
 ### Step 3: Verify
 
 ```bash
+# Per-pod, per-path tracking (April 2026)
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq
+
+# Aggregate per-pod status (legacy field, still populated)
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq '.[].dynamicConfigStatus'
 ```
 
+Per-change `result` enum (in `dynamicConfigChanges`): `Applied`, `Failed`, `Pending`, `RolledBack`, `RollbackFailed`.
+
+Top-level statuses:
 - `Applied`: Change applied successfully (no restart needed).
-- `Failed`: Parameter is not dynamically changeable. Set `enableDynamicConfigUpdate: false` to force a rolling restart.
+- `Failed`: Phase 1 validation rejected the change on at least one pod, OR phase 2 apply failed and rollback succeeded. Set `enableDynamicConfigUpdate: false` to force a rolling restart.
 - `Pending`: Change is being applied.
+
+### When apply AND rollback both fail
+
+You will see `phase = ConfigDegraded`. Do NOT try to "fix" it by toggling `enableDynamicConfigUpdate` — the operator will cold-restart the pods on the next reconcile to reach a consistent state. See §14 troubleshooting for recovery.
 
 ### Static Config Change (Requires Restart)
 
@@ -143,6 +163,11 @@ kubectl patch asc <name> -n <ns> --type=merge \
 ## 4. Warm Restart / Cold Restart
 
 On-demand restart of pods. Only one operation at a time. Remove the operation from spec after completion.
+
+**Constraints (webhook-enforced):**
+- `kind` must be one of `WarmRestart` (SIGUSR1) or `PodRestart` (delete + recreate). No other values are accepted.
+- `id` must be 1–20 characters, unique-per-cluster.
+- The operations list cannot be modified while an operation has `status.operation.phase = InProgress` — wait for it to complete (or fail) before queueing another.
 
 ### Warm Restart (SIGUSR1)
 
@@ -252,6 +277,18 @@ kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":null}}'
 ```
 
 **Phase**: `Paused` -> `InProgress` -> `Completed`
+
+On resume, the operator clears stale `status.failedReconcileCount` and `status.lastReconcileError`. This is the recommended way to clear a stuck circuit breaker after fixing a permanent error (see §14).
+
+### Pause/Resume Metrics
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `acko_cluster_paused_timestamp_seconds` | gauge | Unix timestamp when pause began (`0` if not paused) |
+| `acko_cluster_paused_duration_seconds` | histogram | Distribution of pause-cycle durations (observed on resume) |
+| `acko_circuit_breaker_active` | gauge | `1` while the breaker is tripped, `0` otherwise |
+
+Pause duration is computed from the `ReconciliationPaused` condition's `lastTransitionTime`. Full metric catalog: `./reference/metrics.md`.
 
 ---
 
@@ -407,16 +444,65 @@ Use this decision tree to diagnose cluster issues systematically.
 ### CircuitBreakerActive Event
 
 ```
-1. Check failure count (threshold: 10 consecutive failures):
+1. Check failure count and breaker metric:
    kubectl get asc <name> -n <ns> -o jsonpath='{.status.failedReconcileCount}'
+   # Promql: acko_circuit_breaker_active{cluster="<name>"} == 1
 
 2. Check the last error:
    kubectl get asc <name> -n <ns> -o jsonpath='{.status.lastReconcileError}'
 
-3. Fix the root cause. The operator auto-retries with exponential backoff:
-   delay = min(2^n, 300) seconds
+3. Determine if the error is permanent or transient:
+   kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=="ReconcileHealthy")]}' | jq
 
-4. After a successful reconciliation, CircuitBreakerReset event is emitted.
+   - status=False, reason=PermanentError -> validation/configgen/secret error.
+     The operator does NOT auto-retry. failedReconcileCount is pinned at max
+     (no exponential backoff to wait through). You MUST take action:
+       a) Fix the root cause (correct the spec, create the missing Secret, etc.)
+       b) Then either edit the spec to retrigger reconcile, OR toggle pause
+          to clear stale failedReconcileCount and lastReconcileError:
+            kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":true}}'
+            kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":null}}'
+
+   - status=True (transient) -> operator will retry with backoff.
+     Just fix the underlying transient cause (image pull, capacity, etc.).
+
+4. After a successful reconciliation, CircuitBreakerReset event is emitted and
+   acko_circuit_breaker_active drops to 0.
+```
+
+### Phase = ConfigDegraded (NEW, April 2026)
+
+```
+1. Confirm the condition:
+   kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=="DynamicConfigDegraded")]}' | jq
+
+2. Inspect per-pod, per-path detail:
+   kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq
+
+3. Meaning: a 2PC dynamic config update failed AND the LIFO rollback also failed.
+   Different pods now have different runtime configs. The operator will attempt
+   a cold restart on the next reconcile to converge to spec.
+
+4. Action: do NOT manually flip enableDynamicConfigUpdate or re-apply the change.
+   Let the cold restart run. If the cold restart loop continues, the underlying
+   config value is invalid for some hardware shape -- revert the spec to the
+   previous known-good value and re-apply.
+
+5. Recovery is complete when phase=Completed and DynamicConfigDegraded is no
+   longer present in conditions.
+```
+
+### ReconciliationPaused = True (Operator Inaction)
+
+```
+1. The operator is intentionally not reconciling because spec.paused=true.
+   This is a normal state, not an error.
+
+2. Resume:
+   kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":null}}'
+
+3. Resume also clears stale failedReconcileCount and lastReconcileError --
+   useful for unsticking a circuit breaker after fixing a permanent error.
 ```
 
 ### Webhook Rejects CR (Apply Error)
@@ -432,7 +518,7 @@ Use this decision tree to diagnose cluster issues systematically.
    - heartbeat.mode != mesh
    - Missing admin user with sys-admin + user-admin roles
 
-3. See reference/validation-rules.md for the complete list of 53 errors and 15 warnings.
+3. See reference/validation-rules.md for the complete list of validation errors and warnings (count grows over releases — see file header).
 ```
 
 ### dynamicConfigStatus = Failed
@@ -471,6 +557,8 @@ Detail: `./reference/diagnostic-commands.md`
 ## Reference Documents
 
 - [Operations Reference](./reference/operations.md) -- Detailed Day-2 operations with all kubectl commands
-- [Events Reference](./reference/events.md) -- All 37 Kubernetes events emitted by ACKO
+- [Events Reference](./reference/events.md) -- Kubernetes events emitted by ACKO (including 2PC dynamic-config events)
 - [Troubleshooting Reference](./reference/troubleshooting.md) -- Symptom-based diagnostic table with commands
-- [Validation Rules Reference](./reference/validation-rules.md) -- 53 webhook errors + 15 warnings
+- [Validation Rules Reference](./reference/validation-rules.md) -- Webhook error/warning catalog (canonical source)
+- [Diagnostic Commands](./reference/diagnostic-commands.md) -- kubectl one-liners for common diagnostics
+- [Operator Metrics](./reference/metrics.md) -- Prometheus metrics emitted by the operator

--- a/skills/acko-operations/reference/diagnostic-commands.md
+++ b/skills/acko-operations/reference/diagnostic-commands.md
@@ -32,6 +32,12 @@ kubectl exec -n <ns> <pod> -c aerospike-server -- asinfo -v 'namespace/<ns-name>
 
 # ===== Dynamic Config Status =====
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq '.[].dynamicConfigStatus'
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq    # per-path detail (April 2026+)
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=="DynamicConfigDegraded")]}' | jq
+
+# ===== Reconcile Health (circuit breaker / permanent error) =====
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=="ReconcileHealthy")]}' | jq
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=="ReconciliationPaused")]}' | jq
 
 # ===== Template Status =====
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.templateSnapshot.synced}'
@@ -41,5 +47,5 @@ kubectl get events -n <ns> --field-selector reason=TemplateDrifted
 kubectl get pvc -n <ns> -l aerospike.io/cr-name=<name>
 
 # ===== Operation Status =====
-kubectl get asc <name> -n <ns> -o jsonpath='{.status.operationStatus}' | jq .
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.operation}' | jq .   # phase, completedPods, failedPods
 ```

--- a/skills/acko-operations/reference/events.md
+++ b/skills/acko-operations/reference/events.md
@@ -1,6 +1,6 @@
 # Kubernetes Events Reference
 
-Complete list of all 37 Kubernetes events emitted by the ACKO operator.
+Catalog of Kubernetes events emitted by the ACKO operator. Count grows over releases — see sections below.
 
 ---
 
@@ -34,6 +34,16 @@ Complete list of all 37 Kubernetes events emitted by the ACKO operator.
 | `ConfigMapUpdated` | Normal | ConfigMap contents updated |
 | `DynamicConfigApplied` | Normal | Dynamic config change (set-config) succeeded |
 | `DynamicConfigStatusFailed` | Warning | Dynamic config change failed |
+
+### Dynamic Config 2-Phase Commit (April 2026)
+
+| Event Reason | Type | When Emitted |
+|---|---|---|
+| `DynamicConfigValidationFailed` | Warning | Phase 1 (validate-all) rejected the change on at least one pod; whole update aborted before any pod is mutated |
+| `DynamicConfigRollbackTriggered` | Warning | Phase 2 apply failed on a pod; LIFO rollback started across already-updated pods |
+| `DynamicConfigRollbackFailed` | Warning | Rollback itself failed; cluster transitioning to `phase=ConfigDegraded` |
+| `DynamicConfigDegraded` | Warning | `ConditionDynamicConfigDegraded=True` set; cold restart will be attempted on next reconcile |
+| `DynamicConfigRecovered` | Normal | `ConfigDegraded` resolved (cold restart converged to spec) |
 
 ---
 
@@ -99,12 +109,20 @@ Complete list of all 37 Kubernetes events emitted by the ACKO operator.
 
 ---
 
-## Circuit Breaker Events
+## Circuit Breaker / Permanent Error Events
 
 | Event Reason | Type | When Emitted |
 |---|---|---|
-| `CircuitBreakerActive` | Warning | 10+ consecutive reconciliation failures; exponential backoff applied |
+| `CircuitBreakerActive` | Warning | Reconcile failure threshold reached (transient errors → exponential backoff) |
 | `CircuitBreakerReset` | Normal | Successful reconciliation; circuit breaker reset |
+| `PermanentError` | Warning | Validation/configgen/secret error detected; `ConditionReconcileHealthy=False` (`Reason=PermanentError`); `failedReconcileCount` pinned at max with NO retry |
+
+## Pause / Resume Events
+
+| Event Reason | Type | When Emitted |
+|---|---|---|
+| `ClusterPaused` | Normal | `spec.paused=true` observed; reconciliation suspended; `ConditionReconciliationPaused=True` |
+| `ClusterResumed` | Normal | `spec.paused` cleared; `failedReconcileCount`/`lastReconcileError` cleared; `ConditionReconciliationPaused=False` |
 
 ---
 

--- a/skills/acko-operations/reference/metrics.md
+++ b/skills/acko-operations/reference/metrics.md
@@ -2,7 +2,20 @@
 
 Prometheus metrics emitted by the ACKO controller process (not the Aerospike server pods themselves — those are exposed via the optional exporter sidecar configured in `monitoring`).
 
-The operator exposes metrics on the standard `controller-runtime` `/metrics` endpoint (default `:8080/metrics` inside the `aerospike-operator` namespace).
+The operator exposes metrics on the standard `controller-runtime` `/metrics` endpoint (default `:8080/metrics` in the `aerospike-operator` namespace).
+
+> Catalog verified against `aerospike-ce-kubernetes-operator/internal/metrics/metrics.go`. Every metric below is registered with the listed labels.
+
+---
+
+## Cluster state
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `acko_cluster_phase` | gauge | `cluster`, `namespace` | Numeric encoding of `status.phase` (0=Unknown, 1=InProgress, 2=Completed, 3=Error) |
+| `acko_cluster_ready_pods` | gauge | `cluster`, `namespace` | Number of pods currently Ready in the cluster |
+| `acko_cluster_as_size` | gauge | `cluster`, `namespace` | Cluster size reported by `asinfo` (may differ from K8s pod count during transitions) |
+| `acko_cluster_migrating_partitions` | gauge | `cluster`, `namespace` | Total partitions remaining to be migrated across all nodes |
 
 ---
 
@@ -10,10 +23,13 @@ The operator exposes metrics on the standard `controller-runtime` `/metrics` end
 
 | Metric | Type | Labels | Meaning |
 |--------|------|--------|---------|
-| `acko_reconcile_total` | counter | `cluster`, `namespace`, `result` | Reconcile attempts. `result` ∈ {`success`, `error`, `permanent_error`} |
 | `acko_reconcile_duration_seconds` | histogram | `cluster`, `namespace` | Per-reconcile wall time |
-| `acko_failed_reconcile_count` | gauge | `cluster`, `namespace` | Mirrors `status.failedReconcileCount` |
-| `acko_circuit_breaker_active` | gauge | `cluster`, `namespace` | `1` while breaker tripped, `0` otherwise. Stays `1` indefinitely on `PermanentError`. |
+| `acko_last_reconcile_timestamp_seconds` | gauge | `cluster`, `namespace` | Unix timestamp of the last *successful* reconciliation (use age = `time() - acko_last_reconcile_timestamp_seconds`) |
+| `acko_reconcile_errors_total` | counter | `cluster`, `namespace`, `reason` | Reconciliation errors by reason (covers both transient and permanent) |
+| `acko_circuit_breaker_active` | gauge | `cluster`, `namespace` | `1` while the reconcile breaker is tripped, `0` otherwise. Stays `1` indefinitely on `PermanentError` (no auto-retry). |
+
+> There is no `acko_reconcile_total{result="success"}` counter; success is observed via `acko_last_reconcile_timestamp_seconds` advancing.
+> There is no `acko_failed_reconcile_count` Prometheus metric; the field exists only on `status.failedReconcileCount` (CR status).
 
 ### Useful PromQL
 
@@ -21,8 +37,11 @@ The operator exposes metrics on the standard `controller-runtime` `/metrics` end
 # Clusters with the breaker tripped right now
 sum by (cluster, namespace) (acko_circuit_breaker_active == 1)
 
-# Permanent-error rate (tells you what a human will need to look at)
-rate(acko_reconcile_total{result="permanent_error"}[15m])
+# Reconcile-error rate by reason (catches both transient and permanent)
+sum by (cluster, reason) (rate(acko_reconcile_errors_total[15m]))
+
+# How stale is the last successful reconcile? (alert when > 10m)
+time() - max by (cluster, namespace) (acko_last_reconcile_timestamp_seconds)
 
 # P95 reconcile latency
 histogram_quantile(0.95, sum by (le, cluster) (rate(acko_reconcile_duration_seconds_bucket[5m])))
@@ -49,19 +68,17 @@ histogram_quantile(0.95, sum by (le, cluster) (rate(acko_cluster_paused_duration
 
 ---
 
-## Dynamic config / 2PC
+## Operations & ACL
 
 | Metric | Type | Labels | Meaning |
 |--------|------|--------|---------|
-| `acko_dynamic_config_apply_total` | counter | `cluster`, `namespace`, `result` | One increment per pod applied. `result` ∈ {`applied`, `failed`, `rolled_back`, `rollback_failed`} |
-| `acko_dynamic_config_validation_failed_total` | counter | `cluster`, `namespace` | Phase 1 abort count (any pod rejected the change) |
+| `acko_warm_restarts_total` | counter | `cluster`, `namespace` | Warm restarts (SIGUSR1) performed via `spec.operations[]` or password rotation |
+| `acko_cold_restarts_total` | counter | `cluster`, `namespace` | Cold restarts (pod delete + recreate) performed |
+| `acko_dynamic_config_updates_total` | counter | `cluster`, `namespace` | Successful dynamic config updates via `set-config` (does NOT count failures or rollbacks) |
+| `acko_acl_sync_total` | counter | `cluster`, `namespace` | ACL synchronization operations performed |
+| `acko_scaledown_deferrals_total` | counter | `cluster`, `namespace` | Scale-down operations deferred because data migration was in progress |
 
-### Useful PromQL
-
-```promql
-# Per-cluster ConfigDegraded entries (rollback_failed implies degraded)
-sum by (cluster) (rate(acko_dynamic_config_apply_total{result="rollback_failed"}[1h]))
-```
+> The current operator does not expose per-result counters for the 2PC dynamic config rollout (e.g., no `result=rolled_back` label on `acko_dynamic_config_updates_total`). To detect `ConfigDegraded`, monitor `acko_cluster_phase` for the corresponding numeric encoding (or, more reliably, query the CR status condition `DynamicConfigDegraded` directly via the `kube-state-metrics` `kube_customresource_*` series if exposed).
 
 ---
 
@@ -71,21 +88,33 @@ sum by (cluster) (rate(acko_dynamic_config_apply_total{result="rollback_failed"}
 groups:
 - name: acko-operator
   rules:
-    - alert: ACKOPermanentReconcileError
-      expr: max by (cluster, namespace) (rate(acko_reconcile_total{result="permanent_error"}[15m])) > 0
+    - alert: ACKOCircuitBreakerActive
+      expr: max by (cluster, namespace) (acko_circuit_breaker_active) == 1
       for: 5m
       annotations:
-        summary: "ACKO has stopped retrying {{ $labels.cluster }} due to a permanent error"
-        runbook: "Check status.conditions[ReconcileHealthy] and status.lastReconcileError; toggle paused after fixing root cause."
+        summary: "ACKO circuit breaker tripped for {{ $labels.cluster }}"
+        runbook: "Check status.conditions[ReconcileHealthy]; if reason=PermanentError, fix root cause and toggle paused to clear stale state."
 
-    - alert: ACKOConfigDegraded
-      expr: max by (cluster, namespace) (rate(acko_dynamic_config_apply_total{result="rollback_failed"}[1h])) > 0
+    - alert: ACKOReconcileStale
+      expr: (time() - max by (cluster, namespace) (acko_last_reconcile_timestamp_seconds)) > 600
+      for: 5m
       annotations:
-        summary: "Dynamic config rollback failed on {{ $labels.cluster }}"
-        runbook: "Operator will cold-restart on next reconcile. Inspect status.pods[*].dynamicConfigChanges."
+        summary: "{{ $labels.cluster }} has not reconciled successfully in over 10 minutes"
+
+    - alert: ACKOReconcileErrorRate
+      expr: sum by (cluster, reason) (rate(acko_reconcile_errors_total[10m])) > 0.1
+      for: 10m
+      annotations:
+        summary: "{{ $labels.cluster }} reconcile errors ({{ $labels.reason }}) at high rate"
 
     - alert: ACKOClusterPausedTooLong
       expr: (time() - acko_cluster_paused_timestamp_seconds > 86400) and (acko_cluster_paused_timestamp_seconds > 0)
       annotations:
         summary: "{{ $labels.cluster }} has been paused for over 24h"
+
+    - alert: ACKOMigrationStuck
+      expr: acko_cluster_migrating_partitions > 0
+      for: 1h
+      annotations:
+        summary: "{{ $labels.cluster }} has been migrating partitions for over 1h"
 ```

--- a/skills/acko-operations/reference/metrics.md
+++ b/skills/acko-operations/reference/metrics.md
@@ -1,0 +1,91 @@
+# Operator Metrics Catalog
+
+Prometheus metrics emitted by the ACKO controller process (not the Aerospike server pods themselves — those are exposed via the optional exporter sidecar configured in `monitoring`).
+
+The operator exposes metrics on the standard `controller-runtime` `/metrics` endpoint (default `:8080/metrics` inside the `aerospike-operator` namespace).
+
+---
+
+## Reconciliation health
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `acko_reconcile_total` | counter | `cluster`, `namespace`, `result` | Reconcile attempts. `result` ∈ {`success`, `error`, `permanent_error`} |
+| `acko_reconcile_duration_seconds` | histogram | `cluster`, `namespace` | Per-reconcile wall time |
+| `acko_failed_reconcile_count` | gauge | `cluster`, `namespace` | Mirrors `status.failedReconcileCount` |
+| `acko_circuit_breaker_active` | gauge | `cluster`, `namespace` | `1` while breaker tripped, `0` otherwise. Stays `1` indefinitely on `PermanentError`. |
+
+### Useful PromQL
+
+```promql
+# Clusters with the breaker tripped right now
+sum by (cluster, namespace) (acko_circuit_breaker_active == 1)
+
+# Permanent-error rate (tells you what a human will need to look at)
+rate(acko_reconcile_total{result="permanent_error"}[15m])
+
+# P95 reconcile latency
+histogram_quantile(0.95, sum by (le, cluster) (rate(acko_reconcile_duration_seconds_bucket[5m])))
+```
+
+---
+
+## Pause / Resume
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `acko_cluster_paused_timestamp_seconds` | gauge | `cluster`, `namespace` | Unix timestamp of pause start; `0` when not paused. Derived from `ReconciliationPaused` condition's `lastTransitionTime`. |
+| `acko_cluster_paused_duration_seconds` | histogram | `cluster`, `namespace` | Pause-cycle duration, observed when the cluster is resumed (i.e. on the `Paused → InProgress` transition). |
+
+### Useful PromQL
+
+```promql
+# Currently paused clusters and how long they've been paused
+(time() - acko_cluster_paused_timestamp_seconds) and (acko_cluster_paused_timestamp_seconds > 0)
+
+# P95 pause duration over the last day
+histogram_quantile(0.95, sum by (le, cluster) (rate(acko_cluster_paused_duration_seconds_bucket[1d])))
+```
+
+---
+
+## Dynamic config / 2PC
+
+| Metric | Type | Labels | Meaning |
+|--------|------|--------|---------|
+| `acko_dynamic_config_apply_total` | counter | `cluster`, `namespace`, `result` | One increment per pod applied. `result` ∈ {`applied`, `failed`, `rolled_back`, `rollback_failed`} |
+| `acko_dynamic_config_validation_failed_total` | counter | `cluster`, `namespace` | Phase 1 abort count (any pod rejected the change) |
+
+### Useful PromQL
+
+```promql
+# Per-cluster ConfigDegraded entries (rollback_failed implies degraded)
+sum by (cluster) (rate(acko_dynamic_config_apply_total{result="rollback_failed"}[1h]))
+```
+
+---
+
+## Suggested alerts
+
+```yaml
+groups:
+- name: acko-operator
+  rules:
+    - alert: ACKOPermanentReconcileError
+      expr: max by (cluster, namespace) (rate(acko_reconcile_total{result="permanent_error"}[15m])) > 0
+      for: 5m
+      annotations:
+        summary: "ACKO has stopped retrying {{ $labels.cluster }} due to a permanent error"
+        runbook: "Check status.conditions[ReconcileHealthy] and status.lastReconcileError; toggle paused after fixing root cause."
+
+    - alert: ACKOConfigDegraded
+      expr: max by (cluster, namespace) (rate(acko_dynamic_config_apply_total{result="rollback_failed"}[1h])) > 0
+      annotations:
+        summary: "Dynamic config rollback failed on {{ $labels.cluster }}"
+        runbook: "Operator will cold-restart on next reconcile. Inspect status.pods[*].dynamicConfigChanges."
+
+    - alert: ACKOClusterPausedTooLong
+      expr: (time() - acko_cluster_paused_timestamp_seconds > 86400) and (acko_cluster_paused_timestamp_seconds > 0)
+      annotations:
+        summary: "{{ $labels.cluster }} has been paused for over 24h"
+```

--- a/skills/acko-operations/reference/operations.md
+++ b/skills/acko-operations/reference/operations.md
@@ -54,7 +54,7 @@ kubectl patch asc <name> -n <ns> --type=merge \
 
 Phase: `RollingRestart` -> `Completed`.
 
-### Dynamic Config Change (No Restart)
+### Dynamic Config Change (No Restart, 2-Phase Commit)
 
 ```yaml
 spec:
@@ -68,15 +68,50 @@ spec:
         stop-writes-pct: 90             # Dynamic parameter (CE 7.x)
 ```
 
+The operator applies dynamic changes via 2-phase commit (April 2026+):
+
+| Phase | Behavior | On failure |
+|-------|----------|------------|
+| 1. Validate-all | Probe every pod with the proposed change (syntax + node responsiveness) | Abort whole update; no pod is mutated |
+| 2. Apply sequentially | Per-pod 30 s timeout (independent of reconciliation timeout) | Run LIFO rollback across already-updated pods |
+| 3. Rollback | Revert each updated pod in reverse order, per-pod 30 s timeout | Set `phase=ConfigDegraded`; cold restart on next reconcile |
+
+This makes a dynamic config rollout effectively atomic from the user's perspective.
+
 Verification:
+
 ```bash
+# Per-pod, per-path detail (April 2026+)
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq
+
+# Aggregate per-pod status (legacy)
 kubectl get asc <name> -o jsonpath='{.status.pods}' | jq '.[].dynamicConfigStatus'
 ```
 
-Status values:
+Per-change `result` enum: `Applied`, `Failed`, `Pending`, `RolledBack`, `RollbackFailed`.
+
+Top-level statuses:
 - `Applied`: Success (no restart needed)
-- `Failed`: Parameter is not dynamically changeable; set `enableDynamicConfigUpdate: false` to force rolling restart
+- `Failed`: Phase 1 validation rejected, OR phase 2 apply failed and rollback succeeded; set `enableDynamicConfigUpdate: false` to force rolling restart
 - `Pending`: Change is being applied
+
+If phase 2 apply AND rollback both fail, the cluster enters `phase=ConfigDegraded` and `ConditionDynamicConfigDegraded=True`. The operator will cold-restart on the next reconcile to converge to spec — do not manually toggle `enableDynamicConfigUpdate` during this window.
+
+Example status snapshot of a partial rollback:
+
+```yaml
+status:
+  pods:
+    cluster-1-0:
+      dynamicConfigChanges:
+        - { path: service.proto-fd-max, oldValue: "15000", newValue: "20000", result: Applied }
+    cluster-1-1:
+      dynamicConfigChanges:
+        - { path: service.proto-fd-max, oldValue: "15000", newValue: "20000", result: RolledBack }
+    cluster-1-2:
+      dynamicConfigChanges:
+        - { path: service.proto-fd-max, oldValue: "15000", newValue: "20000", result: Failed }
+```
 
 ### Batch Size
 
@@ -174,6 +209,15 @@ kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":true}}'    #
 kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":null}}'     # Resume
 ```
 
+Resume clears stale `status.failedReconcileCount` and `status.lastReconcileError` — useful for unsticking a tripped circuit breaker after fixing a permanent error.
+
+Metrics for pause cycles (see `./metrics.md`):
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `acko_cluster_paused_timestamp_seconds` | gauge | Unix timestamp of pause start (`0` if not paused) |
+| `acko_cluster_paused_duration_seconds` | histogram | Distribution of pause-cycle durations, observed on resume |
+
 ---
 
 ## 7. Readiness Gate
@@ -239,11 +283,23 @@ spec:
 ### Circuit Breaker
 
 ```bash
-kubectl get asc <name> -o jsonpath='{.status.failedReconcileCount}'       # Threshold: 10
+kubectl get asc <name> -o jsonpath='{.status.failedReconcileCount}'
 kubectl get asc <name> -o jsonpath='{.status.lastReconcileError}'
+kubectl get asc <name> -o jsonpath='{.status.conditions[?(@.type=="ReconcileHealthy")]}' | jq
 ```
 
-Fix root cause. Operator auto-retries with backoff: `min(2^n, 300)` seconds.
+**Two flavors of "breaker active":**
+
+| ReconcileHealthy condition | Cause | Operator behavior | Recovery |
+|----------------------------|-------|-------------------|----------|
+| `status=True` (transient) | Pod not ready, image pull, capacity | Auto-retries with backoff | Fix transient cause; wait |
+| `status=False, reason=PermanentError` | Validation/configgen error, missing Secret | **No auto-retry**; `failedReconcileCount` pinned at max | Fix root cause; toggle `paused: true → null` to clear stale state, OR edit spec to retrigger |
+
+Watching the breaker:
+
+```promql
+acko_circuit_breaker_active{cluster="<name>"} == 1
+```
 
 ### WaitingForMigration
 

--- a/skills/acko-operations/reference/troubleshooting.md
+++ b/skills/acko-operations/reference/troubleshooting.md
@@ -9,11 +9,15 @@ Symptom-based diagnostic reference for ACKO Aerospike clusters.
 | Symptom | Diagnostic Command | Likely Cause | Resolution |
 |---------|-------------------|--------------|------------|
 | Phase = `Error` | `kubectl get asc <name> -o jsonpath='{.status.lastReconcileError}'` | Invalid config, image pull failure, resource exhaustion | Read the error message, fix the root cause, re-apply the CR |
+| Phase = `ConfigDegraded` | `kubectl get asc <name> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' \| jq` | 2PC dynamic config rollback failed; pods inconsistent | Do NOT toggle `enableDynamicConfigUpdate`; let the operator cold-restart on next reconcile. If the loop continues, revert spec to known-good values |
 | Phase = `WaitingForMigration` | `kubectl exec <pod> -c aerospike-server -- asinfo -v 'statistics' \| tr ';' '\n' \| grep migrate` | Data migration in progress (normal during scale-down) | Wait for completion (operator auto-proceeds) |
 | `InProgress` stuck > 5 min | `kubectl get pvc -n <ns> -l aerospike.io/cr-name=<name>` | PVC Pending, ImagePull failure, scheduling failure | Check StorageClass, image name, resource availability |
-| `CircuitBreakerActive` event | `kubectl get asc <name> -o jsonpath='{.status.failedReconcileCount}'` | 10+ consecutive reconciliation failures | Check `lastReconcileError`, fix root cause (auto-retries with backoff) |
+| `CircuitBreakerActive` (transient) | `kubectl get asc <name> -o jsonpath='{.status.conditions[?(@.type=="ReconcileHealthy")]}'` returns `status=True` | Reconcile failure threshold reached | Fix transient cause; operator auto-retries with backoff |
+| `ReconcileHealthy=False, reason=PermanentError` | Same jsonpath returns `status=False, reason=PermanentError` | Validation/configgen/secret error; no auto-retry | Fix root cause; toggle `paused: true → null` to clear stale `failedReconcileCount`/`lastReconcileError` (or edit spec to retrigger) |
+| Operations stuck `InProgress`, webhook rejects new edit | `kubectl get asc <name> -o jsonpath='{.status.operation.phase}'` | Cannot modify `spec.operations[]` while one is `InProgress` | Wait for the in-flight operation to complete or fail; only then queue the next |
 | Pod `CrashLoopBackOff` | `kubectl logs <pod> -c aerospike-server --previous` | Config parse error, OOM, invalid parameters | Check server logs, fix aerospikeConfig |
-| Webhook rejects CR | Read `kubectl apply` error output | CE constraint violation (size>8, namespaces>2, enterprise image, xdr/tls) | Fix the CR to comply with CE constraints |
+| Webhook rejects CR (`service`/`network` not a map, etc.) | Read `kubectl apply` error output | Strengthened webhook (April 2026) — wrong YAML shape | Make `aerospikeConfig.service`/`network` maps; `logging` a list; namespace entries maps with `name` key |
+| Webhook rejects CR (CE constraint) | Read `kubectl apply` error output | CE constraint violation (size>8, namespaces>2, enterprise image, xdr/tls) | Fix the CR to comply with CE constraints |
 | `dynamicConfigStatus=Failed` | `kubectl get asc <name> -o jsonpath='{.status.pods}' \| jq '.[].dynamicConfigStatus'` | Parameter is not dynamically changeable | Set `enableDynamicConfigUpdate: false` to force rolling restart |
 | `ReadinessGateBlocking` | `kubectl get pod <pod> -o jsonpath='{.status.conditions}' \| jq '.[]'` | Readiness gate not satisfied | Check if Aerospike server is healthy inside the pod |
 

--- a/skills/acko-operations/reference/validation-rules.md
+++ b/skills/acko-operations/reference/validation-rules.md
@@ -1,6 +1,6 @@
 # Validation Rules Reference
 
-Complete list of ACKO webhook validation errors (53) and warnings (15).
+Canonical catalog of ACKO webhook validation errors and non-blocking warnings. The exact count grows over releases — this page is the source of truth; `acko-config-reference/reference/webhook-validation.md` is a shape-and-constraints summary that links here.
 
 ---
 
@@ -23,6 +23,12 @@ Complete list of ACKO webhook validation errors (53) and warnings (15).
 | `tls` section present | `"aerospikeConfig must not contain 'tls' section (TLS is Enterprise-only)"` |
 | namespaces > 2 | `"aerospikeConfig.namespaces count N exceeds CE maximum of 2"` |
 | `heartbeat.mode != "mesh"` | `"aerospikeConfig.network.heartbeat.mode must be 'mesh' for CE"` |
+| `service` not a map | `"aerospikeConfig.service must be a map"` |
+| `network` not a map | `"aerospikeConfig.network must be a map"` |
+| `logging` not a list | `"aerospikeConfig.logging must be a list"` |
+| namespace entry not a map with `name` | `"aerospikeConfig.namespaces[N] must be a map with required key 'name'"` |
+| Rack ID add+remove in single update | `"rackConfig: rack IDs cannot be added and removed in the same update (rename-like change risks data loss)"` |
+| `MetricLabels` value contains control chars | `"monitoring.metricLabels[\"key\"]: control characters are not permitted in TOML output"` |
 
 ### Enterprise-Only Namespace Keys (10)
 
@@ -103,6 +109,7 @@ Privilege format: `"<code>"` / `"<code>.<namespace>"` / `"<code>.<namespace>.<se
 |------|--------------|
 | More than 1 operation | `"only one operation can be specified at a time"` |
 | ID length outside 1-20 chars | `"operation id must be 1-20 characters"` |
+| Invalid `kind` | `"operation kind must be one of: WarmRestart, PodRestart"` |
 | Change during InProgress | `"cannot change operations while operation \"ID\" is InProgress"` |
 
 ### Update-Only Validation

--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aerospike-py-api
-description: "MUST USE when writing any Python code with aerospike-py or aerospike_py. This is a Rust/PyO3 library with UNCONVENTIONAL patterns that differ from typical Python clients — exceptions live on the module (aerospike_py.RecordNotFound, NOT aerospike_py.exception.RecordNotFound), return types are NamedTuples (record.bins, record.meta.gen, NOT tuple unpacking), and policies use module-level constants (aerospike_py.POLICY_EXISTS_CREATE_ONLY). Without this skill, code will use wrong import paths, wrong return type patterns, and miss critical features like expression filters (exp module), batch operations, CDT list/map/bit/hll, operate_ordered, backpressure (max_concurrent_operations), Prometheus get_metrics(), OpenTelemetry tracing, NumPy integration, and admin APIs. Triggers on: aerospike-py, aerospike_py, AsyncClient, Python + Aerospike, put/get/query/batch with Aerospike."
+description: "MUST USE when writing any Python code with aerospike-py or aerospike_py. This is a Rust/PyO3 library with UNCONVENTIONAL patterns that differ from typical Python clients — exceptions live on the module (aerospike_py.RecordNotFound, NOT aerospike_py.exception.RecordNotFound), return types are NamedTuples (record.bins, record.meta.gen, NOT tuple unpacking), batch_read returns dict[UserKey, AerospikeRecord] (NOT BatchRecords), and policies use module-level constants (aerospike_py.POLICY_EXISTS_CREATE_ONLY). Without this skill, code will use wrong import paths, wrong return type patterns, and miss critical features like expression filters (exp module), batch_write with in_doubt retry semantics, CDT list/map/bit/hll, ping() health check, backpressure, Prometheus metrics, OpenTelemetry tracing, NumPy integration, and admin APIs. Triggers on: aerospike-py, aerospike_py, AsyncClient, client.ping(), batch_write, Python + Aerospike, put/get/query/batch with Aerospike."
 ---
 
 ## Installation
@@ -10,6 +10,8 @@ pip install aerospike-py         # core
 pip install aerospike-py[numpy]  # NumPy batch integration
 pip install aerospike-py[otel]   # OpenTelemetry context propagation
 ```
+
+Wheels include Python 3.14 and 3.14t (free-threaded, `gil_used=true`).
 
 **Import note**: Rust/PyO3 extension. All exceptions and constants live on `aerospike_py` module directly (e.g., `aerospike_py.RecordNotFound`). No `aerospike_py.exception` submodule. Return types are NamedTuples — use `record.bins`, `record.meta.gen`. Type stubs: `src/aerospike_py/__init__.pyi`
 
@@ -73,6 +75,8 @@ except aerospike_py.AerospikeError as e: ...  # catch-all
 
 Hierarchy: `AerospikeError` > `ClientError(BackpressureError)`, `ClusterError`, `AerospikeTimeoutError`, `RecordError(RecordNotFound, RecordExistsError, RecordGenerationError, FilteredOut, ...)`, `ServerError(AerospikeIndexError, QueryError, AdminError, UDFError)`
 
+`TimeoutError`/`IndexError` aliases are removed -- use `AerospikeTimeoutError`/`AerospikeIndexError`.
+
 Detail: `./reference/admin.md`
 
 ## 5. Batch Operations
@@ -80,16 +84,13 @@ Detail: `./reference/admin.md`
 ```python
 keys = [("test", "demo", f"user_{i}") for i in range(10)]
 
-# All batch operations return BatchRecords (same container type)
-batch = client.batch_read(keys)  # or batch_read(keys, bins=["name"])
-for br in batch.batch_records:
-    if br.result == 0 and br.record is not None: print(br.record.bins)
+# batch_read -> dict[UserKey, AerospikeRecord]  (UserKey = str | int, AerospikeRecord = dict[str, Any])
+records = client.batch_read(keys)  # or batch_read(keys, bins=["name"])
+for user_key, bins in records.items():
+    print(user_key, bins["name"])
+# Missing keys are absent from dict. 2.6x faster than C client under asyncio.gather.
 
-records = [(k, {"name": f"user_{i}", "score": i * 10}) for i, k in enumerate(keys)]
-results = client.batch_write(records, retry=3)  # per-record bins, auto-retry transient failures
-for br in results.batch_records:
-    if br.result != 0: print(f"Failed: {br.key}, in_doubt={br.in_doubt}")
-
+# batch_operate / batch_remove return BatchWriteResult (NamedTuple wrapper with .batch_records)
 results = client.batch_operate(keys, [{"op": aerospike_py.OPERATOR_INCR, "bin": "views", "val": 1}])
 for br in results.batch_records:
     if br.result == 0 and br.record is not None: print(br.record.bins)
@@ -98,7 +99,28 @@ results = client.batch_remove(keys)
 failed = [br for br in results.batch_records if br.result != 0]
 ```
 
-NumPy: `batch_read(..., _dtype=np.dtype(...))` for zero-copy arrays; `batch_write_numpy(data, ns, set, dtype, retry=3)` for writes with auto-retry. Detail: `./reference/read.md` | `./reference/write.md`
+NumPy: `batch_read(..., _dtype=np.dtype(...))` returns `NumpyBatchRecords` (NOT dict); `batch_write_numpy(data, ns, set, dtype, retry=3)` for writes with auto-retry. Detail: `./reference/read.md` | `./reference/write.md`
+
+## 5b. Batch Write
+
+Per-record bins (and optional per-record TTL/gen via `WriteMeta`). Different from `batch_operate` which applies same ops to all keys.
+
+```python
+records = [
+    (("test", "demo", "u1"), {"name": "Alice", "age": 30}),
+    (("test", "demo", "u2"), {"name": "Bob",   "age": 25}, {"ttl": 3600}),
+    (("test", "demo", "u3"), {"name": "Carol", "age": 40}, {"ttl": 0, "gen": 5}),  # CAS via gen
+]
+result = client.batch_write(records, retry=0)  # BatchWriteResult
+for br in result.batch_records:
+    if br.result != 0:
+        if br.in_doubt:
+            ...  # write may have succeeded -- do NOT blindly retry non-idempotent ops
+        else:
+            ...  # safe to retry
+```
+
+`BatchRecord.in_doubt: bool` is critical for idempotency decisions. Detail: `./reference/write.md`
 
 ## 6. Operate / Operate Ordered
 
@@ -148,6 +170,8 @@ records = query.results()     # or query.foreach(callback)
 
 Predicates: `p.equals(bin, val)`, `p.between(bin, min, max)`, `p.contains(bin, idx_type, val)`
 
+> Scan API removed -- use `Query` (no `where` clause) for full-set scan. `get_many`/`exists_many`/`select_many` removed -- use `batch_read`/`batch_operate`.
+
 ## 9. Expression Filters
 
 Server-side filtering (Aerospike 5.2+). No secondary index required. Policy key: `"filter_expression"`.
@@ -182,13 +206,31 @@ response = client.info_random_node("build")  # str
 
 Detail: `./reference/admin.md`
 
+## 10b. Health Check (`ping`)
+
+```python
+ok: bool = client.ping()              # sync: info("build") round-trip to a random node
+ok: bool = await async_client.ping()  # async equivalent
+```
+
+Never raises -- returns `False` on failure. Use for K8s readiness probes and load-balancer health checks. Detail: `./reference/health.md`
+
 ## 11. Observability
 
 ```python
-aerospike_py.start_metrics_server(port=9464)       # Prometheus /metrics endpoint
-aerospike_py.get_metrics()                          # Prometheus text format string
-aerospike_py.init_tracing(); aerospike_py.shutdown_tracing()  # OpenTelemetry (OTEL_* env vars)
-aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)      # OFF=-1,ERR=0,WARN=1,INFO=2,DBG=3,TRACE=4
+# Metrics (Prometheus text format)
+aerospike_py.start_metrics_server(port=9464)        # built-in HTTP /metrics endpoint
+aerospike_py.stop_metrics_server()
+aerospike_py.get_metrics()                           # current metrics as string
+aerospike_py.set_metrics_enabled(False)              # disable collection (~1ns atomic check overhead)
+aerospike_py.is_metrics_enabled()                    # bool
+
+# Tracing (OpenTelemetry; reads OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME)
+aerospike_py.init_tracing(); aerospike_py.shutdown_tracing()
+
+# Logging (Rust -> Python bridge)
+aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)  # OFF=-1,ERR=0,WARN=1,INFO=2,DBG=3,TRACE=4
+aerospike_py.dropped_log_count()                     # int -- back-pressure counter (drops when sink slow)
 ```
 
 Detail: `./reference/observability.md`

--- a/skills/aerospike-py-api/reference/admin.md
+++ b/skills/aerospike-py-api/reference/admin.md
@@ -205,7 +205,7 @@ nodes = async_client.get_node_names()    # async client — NOT awaitable, alway
 Always catch specific exceptions before broader ones:
 
 ```python
-from aerospike_py.exception import (
+from aerospike_py import (
     RecordNotFound,
     AerospikeTimeoutError,
     ClusterError,
@@ -267,9 +267,19 @@ Batch operations do not raise exceptions for individual record failures. Check p
 import aerospike_py as aerospike
 
 keys = [("test", "demo", f"id-{i}") for i in range(100)]
-batch = client.batch_read(keys)
+records = client.batch_read(keys)
+# batch_read returns dict[UserKey, AerospikeRecord]; missing keys are absent
+present_user_keys = set(records.keys())
+expected_user_keys = {f"id-{i}" for i in range(100)}
+missing = expected_user_keys - present_user_keys
+for user_key, bins in records.items():
+    print(user_key, bins)
+for user_key in missing:
+    print("missing:", user_key)
 
-for br in batch.batch_records:
+# batch_operate / batch_remove still return BatchRecords -- check per-record result
+results = client.batch_operate(keys, [{"op": aerospike.OPERATOR_INCR, "bin": "views", "val": 1}])
+for br in results.batch_records:
     if br.result == aerospike.AEROSPIKE_OK and br.record is not None:
         print(br.record.bins)
     elif br.result == aerospike.AEROSPIKE_ERR_RECORD_NOT_FOUND:
@@ -278,7 +288,7 @@ for br in batch.batch_records:
         print("error:", br.key, br.result)
 ```
 
-For `batch_operate` / `batch_remove`, the same pattern applies -- check `br.result` per record.
+For `batch_write`, also inspect `br.in_doubt` to decide whether a failure is safe to retry.
 
 ### Async Error Handling
 
@@ -298,7 +308,7 @@ async def get_user(client, user_id: str) -> dict | None:
 ### Connection Error Handling
 
 ```python
-from aerospike_py.exception import ClusterError
+from aerospike_py import ClusterError
 
 try:
     client = aerospike.client(config).connect()
@@ -311,7 +321,7 @@ The client automatically reconnects to surviving nodes. For transient failures, 
 
 ```python
 import time
-from aerospike_py.exception import AerospikeTimeoutError, ClusterError
+from aerospike_py import AerospikeTimeoutError, ClusterError
 
 TRANSIENT_ERRORS = (AerospikeTimeoutError, ClusterError)
 
@@ -348,7 +358,7 @@ def resilient_get(client, key, max_retries: int = 3):
 
 ## Exception Hierarchy
 
-All exceptions are importable from `aerospike_py` or `aerospike_py.exception`.
+All exceptions are importable from `aerospike_py` directly. There is **no** `aerospike_py.exception` submodule (the previous alias was removed).
 
 ```
 AerospikeError

--- a/skills/aerospike-py-api/reference/admin.md
+++ b/skills/aerospike-py-api/reference/admin.md
@@ -277,7 +277,7 @@ for user_key, bins in records.items():
 for user_key in missing:
     print("missing:", user_key)
 
-# batch_operate / batch_remove still return BatchRecords -- check per-record result
+# batch_operate / batch_remove return BatchWriteResult (NamedTuple) -- check per-record result
 results = client.batch_operate(keys, [{"op": aerospike.OPERATOR_INCR, "bin": "views", "val": 1}])
 for br in results.batch_records:
     if br.result == aerospike.AEROSPIKE_OK and br.record is not None:

--- a/skills/aerospike-py-api/reference/health.md
+++ b/skills/aerospike-py-api/reference/health.md
@@ -1,0 +1,94 @@
+# Health Check Reference
+
+## Table of Contents
+- [`ping()` — round-trip health probe](#ping--round-trip-health-probe)
+- [Liveness vs Readiness in Kubernetes](#liveness-vs-readiness-in-kubernetes)
+- [Comparison with `get_node_names()`](#comparison-with-get_node_names)
+
+---
+
+## `ping()` — round-trip health probe
+
+```python
+ok: bool = client.ping()                  # sync
+ok: bool = await async_client.ping()      # async
+```
+
+Sends `info("build")` to a randomly selected cluster node. Returns `True` on success, `False` on any failure (timeout, connection refused, parse error, etc.). **Never raises** — safe to call from a health-check handler without try/except.
+
+Both sync and async clients implement `ping()`. The async variant is awaitable; the sync variant blocks.
+
+### What it actually validates
+
+- TCP connection to a cluster node is established (or can be re-established).
+- Cluster tend has discovered at least one node.
+- The selected node responds to a basic info request within client policy timeouts.
+
+It does NOT validate per-namespace state (e.g., a namespace stuck in `dead-partitions`). For deeper checks, use `client.info_random_node("namespace/<ns>")` or `client.info_all("namespace/<ns>")` and parse the response.
+
+---
+
+## Liveness vs Readiness in Kubernetes
+
+Use `ping()` for **readiness**, not liveness:
+
+| Probe | Recommended | Why |
+|-------|-------------|-----|
+| **Readiness** | `await client.ping()` | If the cluster is unreachable, take this pod out of the Service so traffic shifts to healthy peers. |
+| **Liveness**  | A trivial `200 OK` from the HTTP server | A failed liveness probe restarts the pod. You typically don't want to restart your app process just because Aerospike blipped — that won't fix the database. |
+
+### FastAPI readiness example
+
+```python
+from fastapi import FastAPI, Depends, Request
+from fastapi.responses import JSONResponse
+from aerospike_py import AsyncClient
+
+app = FastAPI()
+
+def get_client(request: Request) -> AsyncClient:
+    return request.app.state.aerospike
+
+@app.get("/health/ready")
+async def ready(client: AsyncClient = Depends(get_client)):
+    return {"status": "ok"} if await client.ping() else JSONResponse(503, {"status": "unhealthy"})
+
+@app.get("/health/live")
+async def live():
+    return {"status": "ok"}
+```
+
+K8s manifest snippet:
+
+```yaml
+readinessProbe:
+  httpGet: { path: /health/ready, port: 8080 }
+  periodSeconds: 5
+  failureThreshold: 3
+livenessProbe:
+  httpGet: { path: /health/live, port: 8080 }
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+---
+
+## Comparison with `get_node_names()`
+
+`get_node_names()` returns the locally cached list of cluster nodes from the most recent tend cycle. It does not perform any network I/O at call time and always returns synchronously, even on `AsyncClient`.
+
+| | `ping()` | `get_node_names()` |
+|---|---|---|
+| Network I/O at call time | yes (info round-trip) | no (cache lookup) |
+| Returns | `bool` | `list[str]` |
+| Sync or async | matches client | always sync |
+| Raises on failure | no (returns `False`) | no (returns possibly stale list) |
+| Good for | readiness probe | introspection, metrics labels |
+
+If the cluster has gone fully unreachable but the tend interval has not yet elapsed, `get_node_names()` may still return a non-empty list — making it unsuitable as a health check on its own.
+
+---
+
+## Tuning timeouts
+
+`ping()` honors the client's default operation timeouts. To bound probe latency tightly, configure the client with a short `operation_queue_timeout_ms` and a short `total_timeout` policy. A failed `ping()` typically returns within a few hundred milliseconds; readiness probes with `periodSeconds: 5` give the client time to recover from a transient blip without flapping out of the Service.

--- a/skills/aerospike-py-api/reference/observability.md
+++ b/skills/aerospike-py-api/reference/observability.md
@@ -27,6 +27,7 @@ Built-in Rust-to-Python logging bridge that forwards all internal Rust logs to P
 | Function | Description |
 |----------|-------------|
 | set_log_level(level: int) | Set Rust logger level |
+| dropped_log_count() -> int | Total logs dropped due to bridge back-pressure (slow Python sink) |
 
 ```python
 import logging
@@ -34,6 +35,10 @@ import aerospike_py
 
 logging.basicConfig(level=logging.DEBUG)
 aerospike_py.set_log_level(aerospike_py.LOG_LEVEL_DEBUG)
+
+# Periodically check for dropped logs to detect a slow logging sink
+if aerospike_py.dropped_log_count() > 0:
+    logging.warning("aerospike-py dropped %d log records", aerospike_py.dropped_log_count())
 ```
 
 ### Logger Names
@@ -157,10 +162,11 @@ sum by (db_namespace, db_operation_name) (rate(db_client_operation_duration_seco
 | Scenario | Overhead |
 |----------|----------|
 | Per-operation recording | ~30-80 ns (atomic increment) |
+| `set_metrics_enabled(False)` | ~1 ns (atomic check, useful for benchmarks) |
 | Relative to network round-trip | 0.001-0.01% |
 | `get_metrics()` encoding | ~50-200 us |
 
-Metrics collection is always enabled with negligible overhead.
+Metrics collection is enabled by default. Toggle off via `set_metrics_enabled(False)` for benchmark runs.
 
 ---
 

--- a/skills/aerospike-py-api/reference/read.md
+++ b/skills/aerospike-py-api/reference/read.md
@@ -102,7 +102,7 @@ for user_key, bins in records.items():
     print(bins)
 ```
 
-Note: `batch_operate`, `batch_remove`, and `batch_write_numpy` still return `BatchRecords` -- only `batch_read` (non-NumPy) changed.
+Note: `batch_operate`, `batch_remove`, `batch_write`, and `batch_write_numpy` return `BatchWriteResult` (a NamedTuple wrapping `list[BatchRecord]`) -- only `batch_read` returns the new dict shape (`BatchRecords`, redefined as a TypeAlias for `dict[UserKey, AerospikeRecord]`).
 
 ### ReadPolicy
 

--- a/skills/aerospike-py-api/reference/read.md
+++ b/skills/aerospike-py-api/reference/read.md
@@ -60,28 +60,49 @@ if result.meta is not None:
     print(f"gen={result.meta.gen}")
 ```
 
-### batch_read(keys, bins=None, policy=None, _dtype=None) -> BatchRecords | NumpyBatchRecords
+### batch_read(keys, bins=None, policy=None, _dtype=None) -> dict[UserKey, AerospikeRecord] | NumpyBatchRecords
 
-Read multiple records in a single network call.
+Read multiple records in a single network call. **Returns dict** keyed by user key (str | int) to bins dict. Missing keys are absent from the dict. Roughly 2.6x faster than the official C client under `asyncio.gather` workloads.
 
 ```python
 keys = [("test", "demo", f"user_{i}") for i in range(10)]
 
 # All bins
+records: dict[str | int, dict[str, Any]] = client.batch_read(keys)
+for user_key, bins in records.items():
+    print(user_key, bins["name"])
+
+# Specific bins
+records = client.batch_read(keys, bins=["name", "age"])
+
+# Existence check (empty bins) -- still returns dict; missing keys absent
+records = client.batch_read(keys, bins=[])
+
+# Async
+records = await async_client.batch_read(keys, bins=["name", "age"])
+
+# NumPy zero-copy variant returns NumpyBatchRecords (NOT dict)
+import numpy as np
+np_batch = client.batch_read(keys, _dtype=np.dtype([("score", "i4")]))
+np_batch.batch_records["score"].mean()
+```
+
+**Migration from `BatchRecords`:**
+
+```python
+# Before (pre-April 2026)
 batch = client.batch_read(keys)
 for br in batch.batch_records:
     if br.result == 0 and br.record is not None:
         print(br.record.bins)
 
-# Specific bins
-batch = client.batch_read(keys, bins=["name", "age"])
-
-# Existence check only
-batch = client.batch_read(keys, bins=[])
-
-# Async
-batch = await async_client.batch_read(keys, bins=["name", "age"])
+# After
+records = client.batch_read(keys)
+for user_key, bins in records.items():
+    print(bins)
 ```
+
+Note: `batch_operate`, `batch_remove`, and `batch_write_numpy` still return `BatchRecords` -- only `batch_read` (non-NumPy) changed.
 
 ### ReadPolicy
 

--- a/skills/aerospike-py-api/reference/types.md
+++ b/skills/aerospike-py-api/reference/types.md
@@ -1,9 +1,25 @@
 # Types Reference
 
 ## Table of Contents
+- [Common Type Aliases](#common-type-aliases)
 - [Return Types (NamedTuple)](#return-types)
 - [Policy Types (TypedDict)](#policy-types)
 - [Internal Types](#internal-types)
+
+---
+
+## Common Type Aliases
+
+```python
+UserKey         = str | int                          # primary key value
+AerospikeRecord = dict[str, Any]                     # bins dict
+BatchRecords    = dict[UserKey, AerospikeRecord]     # batch_read return (TypeAlias)
+```
+
+`batch_read()` returns `BatchRecords` (a plain dict — the alias was redefined; it is **not** a NamedTuple).
+Missing keys are simply absent from the dict. NumPy variant `batch_read(_dtype=...)` returns `NumpyBatchRecords` instead.
+
+Write-style batch methods (`batch_write`, `batch_operate`, `batch_remove`, `batch_write_numpy`) return `BatchWriteResult`, a NamedTuple with `.batch_records: list[BatchRecord]` (see below).
 
 ---
 
@@ -48,27 +64,38 @@ _, meta, bins = record     # tuple unpacking
 | ttl | int | Seconds until expiration |
 
 ### BatchRecord
-`(key: AerospikeKey | None, result: int, record: Record | None, in_doubt: bool)`
+`(key: AerospikeKey | None, result: int, record: Record | None, in_doubt: bool = False)`
 
-Per-record result from batch operations. `result` is 0 on success.
+Per-record result from write-style batch operations (`batch_write`, `batch_operate`, `batch_remove`, `batch_write_numpy`). `result` is 0 on success.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | key | AerospikeKey \| None | Record key |
 | result | int | Per-record result code (0 = success) |
 | record | Record \| None | Record data (`None` if failed) |
-| in_doubt | bool | `True` if the write may have completed despite the error (e.g., timeout after send). Check before retrying to avoid duplicates. |
+| in_doubt | bool | `True` if the write may have completed despite the error (e.g., timeout after send). Check before retrying to avoid duplicates with non-idempotent ops. |
 
 ### BatchRecords
-`(batch_records: list[BatchRecord])`
+`TypeAlias = dict[UserKey, AerospikeRecord]`
 
-Container returned by all batch operations: `batch_read`, `batch_write`, `batch_operate`, `batch_remove`, `batch_write_numpy`.
+The return type of `batch_read()`. **Not** a NamedTuple anymore — it's a plain dict mapping each user key (str | int) to its bins dict. Missing keys are simply absent.
 
 ```python
-results = client.batch_operate(keys, ops)
-for br in results.batch_records:
-    if br.result == 0 and br.record is not None:
-        print(br.record.bins)
+records = client.batch_read(keys)            # BatchRecords
+for user_key, bins in records.items():
+    print(user_key, bins["name"])
+```
+
+### BatchWriteResult
+`(batch_records: list[BatchRecord])`
+
+NamedTuple returned by all write-style batch methods: `batch_write`, `batch_operate`, `batch_remove`, `batch_write_numpy`. Iterate `result.batch_records` and check each `BatchRecord.result` (and `.in_doubt` for write retry decisions).
+
+```python
+result = client.batch_write([(key, bins), (key2, bins2, {"ttl": 60})])
+for br in result.batch_records:
+    if br.result != 0 and not br.in_doubt:
+        ...  # safe to retry
 ```
 
 ### ExistsResult
@@ -122,9 +149,9 @@ Returned by `info_all`. One result per cluster node.
 | `operate()` | `Record` |
 | `operate_ordered()` | `OperateOrderedResult` |
 | `info_all()` | `list[InfoNodeResult]` |
-| `batch_read()` | `BatchRecords` \| `NumpyBatchRecords` |
-| `batch_write()`, `batch_operate()`, `batch_remove()` | `BatchRecords` |
-| `batch_write_numpy()` | `BatchRecords` |
+| `batch_read()` | `BatchRecords` (= `dict[UserKey, AerospikeRecord]`) or `NumpyBatchRecords` with `_dtype=` |
+| `batch_write()`, `batch_operate()`, `batch_remove()`, `batch_write_numpy()` | `BatchWriteResult` (NamedTuple, `.batch_records: list[BatchRecord]`) |
+| `ping()` | `bool` |
 | `Query.results()` | `list[Record]` |
 
 ---
@@ -166,7 +193,7 @@ Used by: `put()`, `remove()`, `touch()`, `append()`, `prepend()`, `increment()`,
 
 ### WriteMeta
 
-Used by: `put()`, `remove()`, `touch()`, `operate()` etc. as `meta` parameter
+Used by: `put()`, `remove()`, `touch()`, `operate()` etc. as `meta` parameter, and by `batch_write()` as the optional 3rd tuple element per record. `gen` is honored by `batch_write` for per-record CAS.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/skills/aerospike-py-api/reference/write.md
+++ b/skills/aerospike-py-api/reference/write.md
@@ -594,7 +594,7 @@ Requires `numpy >= 2.0`. Install with: `pip install aerospike-py[numpy]`
 | `policy` | `dict \| None` | `None` | Optional BatchPolicy overrides |
 | `retry` | `int` | `0` | Max retries for transient failures (timeout, device overload, key busy). Exponential backoff 10ms-500ms. |
 
-Returns `BatchRecords` -- contains `batch_records: list[BatchRecord]` where each `BatchRecord` has `key`, `result` (0=success), and `record`.
+Returns `BatchWriteResult` -- a NamedTuple with `batch_records: list[BatchRecord]` where each `BatchRecord` has `key`, `result` (0=success), `record`, and `in_doubt`.
 
 ### How It Works
 

--- a/skills/aerospike-py-api/reference/write.md
+++ b/skills/aerospike-py-api/reference/write.md
@@ -96,7 +96,7 @@ Remove specific bins from a record.
 client.remove_bin(key, ["temp_bin", "debug_bin"])
 ```
 
-### batch_operate(keys, ops, policy=None) -> BatchRecords
+### batch_operate(keys, ops, policy=None) -> BatchWriteResult
 
 Execute operations on multiple records in a single network call.
 
@@ -108,44 +108,7 @@ for br in results.batch_records:
         print(br.record.bins)
 ```
 
-### batch_write(records, policy=None, retry=0) -> BatchRecords
-
-Write multiple records with per-record bins in a single batch call. Each record is a `(key, bins)` tuple. Unlike `batch_operate()` (same ops for all keys), each record can have different bins.
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `records` | `list[tuple[Key, dict]]` | required | List of `(key, bins)` tuples |
-| `policy` | `dict` | `None` | Optional BatchPolicy |
-| `retry` | `int` | `0` | Max retries for transient failures (Full Jitter backoff) |
-
-**Returns:** `BatchRecords` — each `BatchRecord` has `.result` (0=OK), `.in_doubt` (bool), `.record`.
-
-**Retryable errors:** Timeout, DeviceOverload, KeyBusy, ServerMemError, PartitionUnavailable.
-
-```python
-# Basic usage
-records = [
-    (("test", "demo", "user1"), {"name": "Alice", "age": 30}),
-    (("test", "demo", "user2"), {"name": "Bob", "age": 25}),
-]
-results = client.batch_write(records)
-
-# With retry
-results = client.batch_write(records, retry=3)
-
-# Async
-results = await async_client.batch_write(records, retry=3)
-
-# Error handling with in_doubt
-for br in results.batch_records:
-    if br.result != 0:
-        if br.in_doubt:
-            print(f"Write may have completed: {br.key}")  # don't blindly retry
-        else:
-            print(f"Write definitely failed: {br.key}, code={br.result}")
-```
-
-### batch_remove(keys, policy=None) -> BatchRecords
+### batch_remove(keys, policy=None) -> BatchWriteResult
 
 Delete multiple records in a single network call.
 
@@ -154,10 +117,53 @@ results = client.batch_remove(keys)
 failed = [br for br in results.batch_records if br.result != 0]
 ```
 
+### batch_write(records, policy=None, retry=0) -> BatchWriteResult
+
+Write multiple records with per-record bins (and optional per-record TTL/gen via `WriteMeta`). Each record is a `(key, bins)` tuple, or `(key, bins, meta)` for TTL/gen control. Different from `batch_operate` (which applies the same ops to all keys) — each record can have a completely different bin set.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `records` | `list[tuple[Key, dict]]` or `list[tuple[Key, dict, WriteMeta]]` | required | Per-record key + bins (+ optional WriteMeta) |
+| `policy` | `dict` | `None` | Optional BatchPolicy |
+| `retry` | `int` | `0` | SDK-level max retries for transient failures (Full Jitter backoff) |
+
+**Returns:** `BatchWriteResult` (NamedTuple) — iterate `result.batch_records`; each `BatchRecord` has `.result` (0=OK), `.in_doubt` (bool), `.record`, `.key`.
+
+**Retryable errors (when `retry > 0`):** Timeout, DeviceOverload, KeyBusy, ServerMemError, PartitionUnavailable.
+
+```python
+records = [
+    (("test", "demo", "u1"), {"name": "Alice", "age": 30}),
+    (("test", "demo", "u2"), {"name": "Bob",   "age": 25}, {"ttl": 3600}),
+    (("test", "demo", "u3"), {"name": "Carol", "age": 40}, {"ttl": 0, "gen": 5}),  # CAS via gen
+]
+
+result = client.batch_write(records, retry=3)             # BatchWriteResult
+result = await async_client.batch_write(records, retry=3)  # async equivalent
+
+# Error handling with in_doubt
+for br in result.batch_records:
+    if br.result == 0:
+        continue
+    if br.in_doubt:
+        # write may have completed despite transient error
+        # do NOT blindly retry non-idempotent ops; reconcile via batch_read first
+        ...
+    else:
+        # definitely failed -- safe to retry
+        ...
+```
+
+**Per-record meta tuple:** the optional 3rd element is `WriteMeta` (`{"gen": int, "ttl": int}`). `gen` is honored for per-record optimistic concurrency control.
+
+**`retry` parameter:** SDK-level retry count for the whole batch (defaults to 0). Distinct from `BatchRecord.in_doubt` per-record signal.
+
+**`BatchRecord.in_doubt`** is critical for idempotency decisions: it indicates that a write may have completed before a transient failure was observed. Treat in-doubt records as potentially applied — reconcile state with a follow-up `batch_read` rather than blind retry for non-idempotent operations.
+
 ### Optimistic Locking
 
 ```python
-from aerospike_py.exception import RecordGenerationError
+from aerospike_py import RecordGenerationError
 
 record = client.get(key)
 try:
@@ -576,7 +582,7 @@ Write records from a numpy structured array. One designated field serves as the 
 
 Requires `numpy >= 2.0`. Install with: `pip install aerospike-py[numpy]`
 
-### batch_write_numpy(data, namespace, set_name, _dtype, key_field="_key", policy=None, retry=0) -> BatchRecords
+### batch_write_numpy(data, namespace, set_name, _dtype, key_field="_key", policy=None, retry=0) -> BatchWriteResult
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/skills/aerospike-py-fastapi/SKILL.md
+++ b/skills/aerospike-py-fastapi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aerospike-py-fastapi
-description: "MUST USE for building FastAPI/REST API applications with Aerospike database. Contains production-ready patterns for aerospike-py (Rust/PyO3 async client) that CANNOT be inferred from general knowledge: correct AsyncClient lifespan management, FastAPI Depends injection for client, aerospike_py exception-to-HTTP-status mapping (RecordNotFound→404, RecordExistsError→409, BackpressureError→503), POLICY_EXISTS_CREATE_ONLY/UPDATE_ONLY for CRUD semantics, NamedTuple attribute access (record.bins not tuple unpacking), and global AerospikeError handler. Without this skill, generated code uses wrong import paths, missing DI patterns, and lacks backpressure/metrics/health checks. Triggers on: FastAPI + Aerospike, REST API + aerospike-py, CRUD API with Aerospike, web server/HTTP service backed by Aerospike NoSQL, uvicorn + Aerospike."
+description: "MUST USE for building FastAPI/REST API applications with Aerospike database. Contains production-ready patterns for aerospike-py (Rust/PyO3 async client) that CANNOT be inferred from general knowledge: correct AsyncClient lifespan management, FastAPI Depends injection for client, aerospike_py exception-to-HTTP-status mapping (RecordNotFound→404, RecordExistsError→409, BackpressureError→503, AerospikeTimeoutError→504), POLICY_EXISTS_CREATE_ONLY/UPDATE_ONLY for CRUD semantics, NamedTuple attribute access (record.bins not tuple unpacking), client.ping() readiness probe, batch_read returning dict, batch_write with in_doubt retry signal, and global AerospikeError handler. Without this skill, generated code uses wrong import paths, missing DI patterns, and lacks backpressure/metrics/health checks. Triggers on: FastAPI + Aerospike, REST API + aerospike-py, CRUD API with Aerospike, client.ping() health probe, batch_read/batch_write endpoint, web server/HTTP service backed by Aerospike NoSQL, uvicorn + Aerospike."
 ---
 
 ## 1. App Structure (Lifespan + DI)
@@ -19,10 +19,12 @@ async def lifespan(app: FastAPI):
         "operation_queue_timeout_ms": 5000,
     })
     aerospike_py.init_tracing()                # OpenTelemetry (optional)
+    # aerospike_py.start_metrics_server(port=9464)  # built-in /metrics; pick this OR §6 endpoint, not both
     await client.connect()
     app.state.aerospike = client
     yield
     await client.close()
+    # aerospike_py.stop_metrics_server()
     aerospike_py.shutdown_tracing()
 
 app = FastAPI(lifespan=lifespan)
@@ -72,6 +74,43 @@ async def delete(pk: str, client: AsyncClient = Depends(get_client)):
         return JSONResponse(status_code=404, content={"error": "not found"})
 ```
 
+## 2b. Batch Endpoints
+
+`batch_read` returns `dict[UserKey, AerospikeRecord]` -- iterate with `.items()`. Missing keys are absent from the dict.
+
+```python
+from pydantic import BaseModel
+
+class BatchReadReq(BaseModel):
+    keys: list[str]
+
+@app.post("/records:batchRead")
+async def batch_read(req: BatchReadReq, client: AsyncClient = Depends(get_client)):
+    keys = [(NS, SET, k) for k in req.keys]
+    records = await client.batch_read(keys)            # dict[str, dict[str, Any]]
+    return {"found": records, "missing": [k for k in req.keys if k not in records]}
+
+class BatchWriteItem(BaseModel):
+    key: str
+    bins: dict
+    ttl: int | None = None
+
+@app.post("/records:batchWrite")
+async def batch_write(items: list[BatchWriteItem], client: AsyncClient = Depends(get_client)):
+    records = [
+        ((NS, SET, item.key), item.bins) if item.ttl is None
+        else ((NS, SET, item.key), item.bins, {"ttl": item.ttl})
+        for item in items
+    ]
+    result = await client.batch_write(records)         # BatchWriteResult
+    in_doubt = [str(br.key.user_key) for br in result.batch_records if br.result != 0 and br.in_doubt]
+    failed   = [str(br.key.user_key) for br in result.batch_records if br.result != 0 and not br.in_doubt]
+    if in_doubt:
+        # Some writes may have applied -- caller should reconcile via batch_read, not blind retry
+        return JSONResponse(status_code=503, content={"in_doubt": in_doubt, "failed": failed})
+    return {"failed": failed}
+```
+
 ## 3. Global Error Handler
 
 ```python
@@ -92,19 +131,21 @@ async def aerospike_error_handler(request, exc):
 | `RecordExistsError` | 409 | Record already exists (CREATE_ONLY) |
 | `RecordGenerationError` | 409 | Optimistic lock conflict |
 | `BackpressureError` | 503 | Too many concurrent operations |
-| `AerospikeTimeoutError` | 504 | Operation timed out |
+| `AerospikeTimeoutError` | 504 | Operation timed out (canonical name; `TimeoutError` alias removed) |
+| `AerospikeIndexError` | 400/500 | Secondary index error (400 if user supplied bad query, else 500) |
 | `AerospikeError` | 500 | Catch-all server error |
 
 ## 5. Health Check
 
 ```python
-@app.get("/health")
-async def health(client: AsyncClient = Depends(get_client)):
-    try:
-        nodes = client.get_node_names()   # sync call, NOT awaitable
-        return {"status": "ok", "nodes": len(nodes)}
-    except Exception:
-        return JSONResponse(status_code=503, content={"status": "unhealthy"})
+@app.get("/health/ready")
+async def ready(client: AsyncClient = Depends(get_client)):
+    # ping() does an info("build") round-trip; never raises -- returns False on failure.
+    return {"status": "ok"} if await client.ping() else JSONResponse(503, {"status": "unhealthy"})
+
+@app.get("/health/live")
+async def live():
+    return {"status": "ok"}  # liveness should NOT depend on Aerospike (avoids restart loops on transient blip)
 ```
 
 ## 6. Metrics Endpoint
@@ -128,7 +169,10 @@ Or use the built-in server: `aerospike_py.start_metrics_server(port=9464)` in li
 - **DI**: Use `Depends(get_client)` for every endpoint — never create client per-request
 - **Exceptions on module**: `aerospike_py.RecordNotFound` (NOT `aerospike_py.exception.RecordNotFound`)
 - **NamedTuple returns**: `record.bins`, `record.meta.gen` (NOT tuple unpacking)
-- **get_node_names()**: Always sync, even on AsyncClient
+- **batch_read**: returns `dict[UserKey, AerospikeRecord]` — iterate with `.items()`, missing keys are absent
+- **batch_write**: inspect `BatchRecord.in_doubt` before retrying non-idempotent writes
+- **Health probe**: `await client.ping()` for readiness; trivial 200 OK for liveness
 - **Backpressure**: Set `max_concurrent_operations` to prevent connection pool exhaustion
+- **Exception name**: `AerospikeTimeoutError` (legacy `TimeoutError` alias removed)
 
-Detail: `../aerospike-py-api/reference/client-config.md` | `../aerospike-py-api/reference/admin.md`
+Detail: `../aerospike-py-api/reference/client-config.md` | `../aerospike-py-api/reference/admin.md` | `../aerospike-py-api/reference/health.md` | `../aerospike-py-api/reference/write.md`

--- a/skills/aerospike-py-fastapi/SKILL.md
+++ b/skills/aerospike-py-fastapi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aerospike-py-fastapi
-description: "MUST USE for building FastAPI/REST API applications with Aerospike database. Contains production-ready patterns for aerospike-py (Rust/PyO3 async client) that CANNOT be inferred from general knowledge: correct AsyncClient lifespan management, FastAPI Depends injection for client, aerospike_py exception-to-HTTP-status mapping (RecordNotFound→404, RecordExistsError→409, BackpressureError→503, AerospikeTimeoutError→504), POLICY_EXISTS_CREATE_ONLY/UPDATE_ONLY for CRUD semantics, NamedTuple attribute access (record.bins not tuple unpacking), client.ping() readiness probe, batch_read returning dict, batch_write with in_doubt retry signal, and global AerospikeError handler. Without this skill, generated code uses wrong import paths, missing DI patterns, and lacks backpressure/metrics/health checks. Triggers on: FastAPI + Aerospike, REST API + aerospike-py, CRUD API with Aerospike, client.ping() health probe, batch_read/batch_write endpoint, web server/HTTP service backed by Aerospike NoSQL, uvicorn + Aerospike."
+description: "MUST USE for building FastAPI/REST API applications with Aerospike database (aerospike-py Rust/PyO3 async client). Covers AsyncClient lifespan management, FastAPI Depends injection, aerospike_py exception-to-HTTP-status mapping (RecordNotFound→404, RecordExistsError→409, BackpressureError→503, AerospikeTimeoutError→504), POLICY_EXISTS_CREATE_ONLY/UPDATE_ONLY for CRUD semantics, NamedTuple attribute access (record.bins not tuple unpacking), client.ping() readiness probe, batch_read returning dict, batch_write with in_doubt retry signal, and global AerospikeError handler. Triggers on: FastAPI + Aerospike, REST API + aerospike-py, CRUD API with Aerospike, client.ping() health probe, batch_read/batch_write endpoint, web server/HTTP service backed by Aerospike NoSQL, uvicorn + Aerospike."
 ---
 
 ## 1. App Structure (Lifespan + DI)
@@ -103,8 +103,11 @@ async def batch_write(items: list[BatchWriteItem], client: AsyncClient = Depends
         for item in items
     ]
     result = await client.batch_write(records)         # BatchWriteResult
-    in_doubt = [str(br.key.user_key) for br in result.batch_records if br.result != 0 and br.in_doubt]
-    failed   = [str(br.key.user_key) for br in result.batch_records if br.result != 0 and not br.in_doubt]
+    # br.key may be None for some failure paths -- guard before dereferencing
+    def _user_key(br):
+        return str(br.key.user_key) if br.key is not None else None
+    in_doubt = [_user_key(br) for br in result.batch_records if br.result != 0 and br.in_doubt]
+    failed   = [_user_key(br) for br in result.batch_records if br.result != 0 and not br.in_doubt]
     if in_doubt:
         # Some writes may have applied -- caller should reconcile via batch_read, not blind retry
         return JSONResponse(status_code=503, content={"in_doubt": in_doubt, "failed": failed})


### PR DESCRIPTION
## Summary
- Sync 5 skills with `aerospike-py` and `aerospike-ce-kubernetes-operator` changes since the March 2026 sync.
- Fix two **BREAKING incorrectness bugs** that would cause Claude to generate non-working code:
  - `aerospike-py-api` §5: `batch_read()` returns `dict[UserKey, AerospikeRecord]` (was `BatchRecords`).
  - `acko-operations` §14: circuit breaker for `PermanentError` no longer uses exponential backoff — requires manual intervention.
- Add new APIs: `batch_write` (with `in_doubt`), `client.ping()`, expanded observability surface, NumPy/Python 3.14t notes.
- Add new ACKO surfaces: 2PC dynamic config, `ConfigDegraded` phase, `ReconcileHealthy` condition, pause metrics, `spec.operations[]` constraints, strengthened webhook map/list validation.
- 4 new reference files (`aerospike-py-api/reference/health.md`, `acko-config-reference/reference/conditions-and-phases.md`, `acko-operations/reference/metrics.md`, `acko-deploy/examples/09-operations.yaml`).
- Trim all 5 skill descriptions per review feedback (keep discriminative new keywords; drop filler).
- 2 new evals (id 7 ConfigDegraded recovery, id 8 FastAPI ping/batch_write).

20 modified files, 4 new files, +551/-73 lines.

## Source commits referenced
- aerospike-py: `795455e` (batch_read), `a750707` (batch_write), `7bd78b7` (ping), `dbe4258` (batch_write gen), `8561b40` (3.14t).
- ACKO: `7712e075` (2PC), `5c3f6785` (circuit breaker), `7f211613` (pause/resume + metrics), `53894959` (template re-apply), `30b52212` (METRIC_LABELS).

## Test plan
- [ ] Frontmatter parses on all 5 SKILL.md files
- [ ] No stale `from aerospike_py.exception import ...` references remain
- [ ] No stale `batch_read(...).batch_records` outside Migration / NumPy contexts
- [ ] All YAML examples parse via `yq`
- [ ] `evals/evals.json` parses and has 8 cases
- [ ] Skill triggering smoke tests in a fresh session:
  - "FastAPI에서 client.ping() readiness probe 만들어줘" → triggers `aerospike-py-fastapi`
  - "batch_write로 100개 레코드 한 번에 쓰기" → triggers `aerospike-py-api`
  - "Aerospike 클러스터가 ConfigDegraded 상태야" → triggers `acko-operations`
  - "WarmRestart operation YAML 만들어줘" → triggers `acko-deploy`