### PR TITLE
feat(acko-e2e-test): split execution into scripts/, slim SKILL.md to eval contracts

### DIFF
--- a/skills/acko-e2e-test/SKILL.md
+++ b/skills/acko-e2e-test/SKILL.md
@@ -1,332 +1,228 @@
 ---
 name: acko-e2e-test
-description: "MUST USE for ACKO end-to-end testing on Kind/local clusters. Contains the canonical scenario list (deploy, scale, rolling update, multi-rack, ACL, PVC, Helm chart split-mode, OTel observability), Ginkgo label conventions (`heavy` vs default), the project's mandatory `helm install`-based operator setup (NOT `make run-local`/`make deploy` — those bypass the real user install path), and performance-check procedures the project expects every release to verify. Without this skill, e2e runs miss scenarios that have caught regressions historically (CE 8.1 data-size rename, webhook duplicate ServiceMonitor, helm test pod in web-only mode, circuit-breaker BackoffActive) and they may install the operator via paths real users never take. Triggers on: ACKO e2e test, kind cluster test, make test-e2e, release verification, performance test for Aerospike operator, helm chart test, post-merge smoke test, regression checklist."
+description: "MUST USE for ACKO end-to-end testing on Kind/local clusters. Contains the canonical scenario list (deploy, scale, rolling update, multi-rack, ACL, PVC, Helm chart split-mode, OTel observability, UI api CRUD), Ginkgo label conventions (`heavy` vs default), the project's mandatory `helm install`-based operator setup (NOT `make run-local`/`make deploy` — those bypass the real user install path), and performance-check procedures the project expects every release to verify. Each section ships an executable script under `scripts/` that the orchestrator (`scripts/run-all.sh`) sequences. Without this skill, e2e runs miss scenarios that have caught regressions historically (CE 8.1 data-size rename, webhook duplicate ServiceMonitor, helm test pod in web-only mode, circuit-breaker BackoffActive, missing FastAPIInstrumentor in OTel pipeline #265) and they may install the operator via paths real users never take. Triggers on: ACKO e2e test, kind cluster test, make test-e2e, release verification, performance test for Aerospike operator, helm chart test, post-merge smoke test, regression checklist."
 ---
 
 # ACKO End-to-End Test Playbook
 
-Canonical scenarios + performance checks the ACKO project expects to pass before each release. Run from the operator repo root (`aerospike-ce-kubernetes-operator/`). Most scenarios run inside a Kind cluster spawned by `make setup-test-e2e`.
+This skill encodes **what counts as PASS** for each ACKO release-verification concern in natural language, plus a `scripts/` directory that **performs and asserts** each contract. Use it when validating an ACKO PR, a chart change, or a cluster-manager image bump.
+
+The skill is opinionated about two things:
+
+1. **Real users install via Helm.** e2e MUST exercise `helm install ./charts/...`. `make run-local` and `make deploy` are forbidden — they bypass the chart and miss regressions in RBAC, CRD bundling, value defaults, helper templates.
+2. **Eval criteria live here, mechanics live in scripts.** This file does NOT contain bash blobs. If you find yourself typing `kubectl ...` while reading this, stop — the script in `scripts/` is the source of truth.
 
 ---
 
-## 0. Prerequisites
+## How to run
 
 ```bash
-# Required tools
-command -v kind go podman kubectl helm    # all must resolve
-go version                                # >= 1.25
-kind --version                            # >= 0.31
-podman machine list                       # machine must be Running
+# from the skill directory:
+./scripts/run-all.sh --mode chart       # PR-time fast gate (~1 min, no cluster)
+./scripts/run-all.sh --mode smoke       # smoke incl. cluster + api + OTel (~10 min)
+./scripts/run-all.sh --mode full        # smoke + full Ginkgo suite (~30–45 min)
+./scripts/run-all.sh --mode ginkgo --ginkgo-mode heavy   # heavy-only Ginkgo
 ```
 
-CLAUDE.md (repo root) note — Podman is the project's container runtime. Set `CONTAINER_TOOL=podman KIND_PROVIDER=podman` for every e2e invocation. Do NOT swap to Docker without a recorded ADR.
+The orchestrator parses every script's last line (the `e2e:pass[scope=...]` / `e2e:fail[scope=...]` contract) and emits the standard report described in [§ Reporting](#reporting). Each step's full output is at `/tmp/run-all-<step>.out`. On failure, a diagnostic bundle lands at `/tmp/e2e-diag-<timestamp>/`.
+
+Override env vars to customize: `KIND_CLUSTER`, `IMG`, `API_IMG`, `NS_OPERATOR`, `NS_AEROSPIKE`, `HELM_RELEASE`. See `scripts/lib.sh` for the full list.
 
 ---
 
-## 1. Operator Install — use `helm install`, NOT `make run-local` / `make deploy`
+## Run modes
 
-**This is the project's most important e2e rule.** Real users install the operator via the Helm chart at `charts/aerospike-ce-kubernetes-operator/`. e2e runs MUST exercise that same path so chart-level regressions (RBAC scope, CRD bundling, value defaults, namespace handling, helper templates) get caught before release.
+| Mode | When to use | Time | Steps |
+|------|-------------|------|-------|
+| `chart` | Chart-only PR; no controller change | ~1 min | 40 |
+| `smoke` | Most PRs (functional + api + OTel, no Ginkgo) | ~10 min | 40 → 41 → 10 → 11 → 12 → 21 → 30 → 33 → 31 → 32 → 99 |
+| `full` | Pre-release / post-rebase / weekly main | ~30–45 min | smoke + 20 (Ginkgo full) |
+| `ginkgo` | Iterating on a specific scenario | varies | 10 → 20 (focus or label-filter) |
 
-Forbidden during e2e (these bypass the chart entirely):
-- `make run-local` — runs the controller as a host process against the cluster's API. Skips RBAC, the chart, and image loading.
-- `make deploy` — applies in-tree `config/` manifests directly with kustomize. Skips the chart, helper templates, and `values.yaml` defaults.
-
-Required setup (run after `make setup-test-e2e` brings up the Kind cluster):
-
-```bash
-# 1. Build and load the operator image into Kind.
-#    Kind+podman provider does not pick up `kind load docker-image` reliably,
-#    so use the tarball path which works on every Kind+podman combination.
-make docker-build IMG=acko-controller:e2e CONTAINER_TOOL=podman
-podman save -o /tmp/acko-controller-e2e.tar localhost/acko-controller:e2e
-KIND_EXPERIMENTAL_PROVIDER=podman \
-  kind load image-archive /tmp/acko-controller-e2e.tar \
-  --name aerospike-ce-kubernetes-operator-test-e2e
-# Verify image is on every node (control-plane + 3 workers in the default kind-config):
-for n in $(kubectl get nodes -o name | sed 's|node/||'); do
-  podman exec "$n" crictl images | grep acko-controller
-done
-
-# 2. Install cert-manager — required by the chart's webhook Certificate / Issuer
-#    resources. Pinned to the same version test/utils/utils.go uses.
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.3/cert-manager.yaml
-kubectl wait deployment/cert-manager-webhook --for=condition=Available -n cert-manager --timeout=5m
-sleep 10  # webhook CA still propagating after Available=true
-
-# 3. Helm install — the chart's aerospike-ce-kubernetes-operator-crds subchart
-#    bundles CRDs, so DO NOT run `make install` first (it would create
-#    CRDs without helm ownership labels and the helm install would refuse to
-#    take them over).
-helm install acko ./charts/aerospike-ce-kubernetes-operator \
-  --namespace aerospike-operator --create-namespace \
-  --set image.repository=localhost/acko-controller \
-  --set image.tag=e2e \
-  --set image.pullPolicy=Never \
-  --wait --timeout 5m
-
-# 4. Verify it came up via the chart, not via leftover state
-helm list -n aerospike-operator                                # STATUS=deployed
-kubectl get pods -n aerospike-operator                         # all Running
-kubectl get crd | grep acko                                    # both CRDs present
-```
-
-If `helm install` fails with "CustomResourceDefinition ... cannot be imported into the current release", it means you ran `make install` before. Clean up with `make uninstall` and retry.
-
-**Known gap**: at the time of writing, `test/e2e/e2e_suite_test.go:BeforeSuite` calls `make deploy`, not `helm install`. Until that is migrated, run e2e in two layers:
-
-1. Helm-install layer (manual/scripted, per the steps above) — confirms the chart works.
-2. Ginkgo layer (`make test-e2e` for scenario coverage) — accept that it currently uses `make deploy` for the controller. File a follow-up to migrate `BeforeSuite` to `helm install`.
-
-For chart-only validation that doesn't need the controller running, see Section 4 (`helm template` / `helm lint`) — that lane is fast and catches most chart regressions without spinning a Kind cluster.
+`heavy` Ginkgo label scope: `e2e_multirack_test.go`, `e2e_pvc_test.go`, and `e2e_template_test.go` are heavy at suite level; `e2e_cluster_test.go` and `e2e_features_test.go` mark specific Contexts heavy. Confirm against the test file before reasoning about scope.
 
 ---
 
-## 2. Run Modes — pick before invoking
+## Eval criteria (what counts as PASS)
 
-| Mode | Command | When to use |
-|------|---------|-------------|
-| **Smoke** (no `heavy`) | `make test-e2e GINKGO_FLAGS='--label-filter="!heavy"'` | PR validation, fast (~5-8 min) |
-| **Full** (default) | `make test-e2e` | Pre-release, post-rebase, weekly main | 
-| **Single suite** | `go test -tags=e2e -run TestE2E -ginkgo.focus="Multi-rack" ./test/e2e/` | Iterating on one scenario |
-| **Heavy only** | `make test-e2e GINKGO_FLAGS='--label-filter="heavy"'` | Soak / performance lane |
+Every section maps 1:1 to a script. The script's last-line contract `e2e:pass[scope=<X>]` is what tools (or humans) grep for to decide green/red.
 
-`heavy` label = scenarios that take >2 min, create PVCs, or scale ≥3 nodes. They're skipped in PR CI but mandatory before tagging a release.
+### Functional — operator + cluster lifecycle
 
-Heavy is applied at two levels in `test/e2e/`:
-- **Suite-level** (`var _ = Describe("X", Ordered, Label("heavy"), …)`): every scenario in `e2e_multirack_test.go`, `e2e_pvc_test.go`, and `e2e_template_test.go` is heavy by default.
-- **Context-level** (`Context("Y", Label("heavy"), …)`): used inside `e2e_cluster_test.go` and `e2e_features_test.go` to mark specific contexts as heavy while leaving siblings on the smoke lane.
+The operator reconciles AerospikeCluster CRs through every supported lifecycle event without losing data, leaking PVCs, or leaving the CR in a non-terminal phase.
 
-Either form satisfies `--label-filter`. Don't reason about heavy scope from a per-row annotation in this skill alone — confirm against the test file.
+PASS when:
 
----
+- **`scripts/21-asc-create-smoke.sh`** — applying `config/samples/acko_v1alpha1_aerospikecluster.yaml` results in `phase=Completed` within 3 min, the expected K8s resources exist (StatefulSet, headless Service, ConfigMap, PDB), `status.size == spec.size`, and `status.pods` reports the right number of running+ready entries. Deleting the CR removes the namespace's ASC count to 0.
+- **`scripts/20-ginkgo.sh`** — the in-tree Ginkgo suite (`test/e2e/`) passes 100% with no FAIL lines. Covers single-node + 3-node PVC + multi-rack 6-node + ACL/cascadeDelete + PVC create/retain/cleanup + multi-rack scale + custom metrics + perPodStatus configHash + rolling restart + scale up/down + RollingUpdateBatchSize + paused cluster + PDB enable/disable + template + drift detection.
 
-## 3. Functional Scenarios — must pass
+### Functional — webhook validation (CE constraints)
 
-Each row corresponds to a Ginkgo `Context` in `test/e2e/`. Status = green/red of the most recent `make test-e2e` you ran. Verify file:line still exists before claiming a scenario is covered (test names rot — see "Before recommending from memory" in the global CLAUDE.md).
+Every CE constraint is enforced at admission so users cannot accidentally configure an enterprise feature.
 
-### Cluster lifecycle (`e2e_cluster_test.go`)
+PASS when (currently asserted via Ginkgo, scheduled for split into a dedicated `22-webhook-asserts.sh`):
 
-- [ ] **Basic single-node cluster** — deploys, reaches `phase=Completed`, creates expected K8s resources (StatefulSet, ConfigMap, headless Service, PDB), populates `status.pods` correctly. Default lane.
-- [ ] **3-node cluster with PV storage** (`heavy`) — 3 pods, 3 PVCs, status reports cluster size + replication factor.
-- [ ] **Multi-rack 6-node cluster** (`heavy`) — 3 StatefulSets (one per rack), pods carry rack labels, 3 ConfigMaps, `status.size=6`, rack-distribution affinity is honored.
-- [ ] **ACL/Storage sample with cascadeDelete** (`heavy`) — admin user from Secret, PVCs created, cluster delete cleans PVCs. Confirms ACL Secret reconciliation does not block readiness.
+- `size > 8` is rejected
+- `namespaces > 2` is rejected
+- `network.tls`, `xdr`, enterprise images (`aerospike-server-enterprise`), `feature-key-file` are rejected
+- A duplicate `ServiceMonitor` when `monitoring.enabled=true` is rejected (#235)
 
-### Multi-rack specific (`e2e_multirack_test.go`) — entire suite is `heavy`
-- [ ] **Basic multi-rack deployment** — verifies StatefulSet count, pod-to-rack mapping, rack-aware service endpoints.
-- [ ] **Multi-rack scale up** — increase `spec.size`, pods land on the rack with capacity, no rebalance loop.
+### Helm chart — manifest matrix
 
-### PVC management (`e2e_pvc_test.go`) — entire suite is `heavy`
-- [ ] **PVC creation for storage volumes** — PVC name pattern `<cluster>-<rackID>-<podOrdinal>`, status reflects bound state.
-- [ ] **CascadeDelete PVC cleanup** — `cascadeDelete: true` removes PVCs on cluster delete.
-- [ ] **Retained PVCs without cascadeDelete** — `cascadeDelete: false` (default) keeps PVCs after cluster delete; reattach on recreate.
+The chart renders correctly across all supported toggle combinations and fails fast on incompatible ones.
 
-### Cluster templates (`e2e_template_test.go`) — entire suite is `heavy`
-- [ ] **Create cluster from template** — `AerospikeClusterTemplate` (cluster-scoped) → `AerospikeCluster` references it, fields are inherited correctly.
-- [ ] **Template drift detection** — modifying the template surfaces drift in `status.conditions`.
+PASS when **`scripts/40-helm-matrix.sh`** verifies all 7 modes:
 
-### Enhanced features (`e2e_features_test.go`)
-- [ ] **Prometheus Custom Metrics** — `acko_*` metrics scrape on `:8080/metrics` after a cluster is created. Smoke lane.
-- [ ] **Per-Pod Status (configHash + podSpecHash)** — `status.pods[*].configHash` matches the pod annotation; `podSpecHash` reflects template hash. Smoke lane.
-- [ ] **Config change triggers Rolling Restart** (`heavy`) — patch `spec.aerospikeConfig`, pods restart in order, `phase` flows `Updating → Completed`.
-- [ ] **Scale Up and Down** (`heavy`) — `spec.size` change scales StatefulSet, `status.size` matches, no orphaned PVCs on scale-down + cascadeDelete.
-- [ ] **RollingUpdateBatchSize** (`heavy`) — `spec.rollingUpdate.batchSize=2` actually deletes 2 pods at a time during a config change.
-- [ ] **Paused Cluster** (`heavy`) — `spec.paused=true` halts reconciliation; resume continues from where it stopped. Phase reports `Paused`.
-- [ ] **PodDisruptionBudget** (`heavy`) — PDB is created by default for every cluster; setting `spec.disablePDB=true` deletes it on the next reconcile. (Verify against `e2e_features_test.go` "PodDisruptionBudget" Context.)
+| Mode | Contract |
+|------|----------|
+| **operator-only** (`--set ui.enabled=false`) | Operator Deployment present; NO ui-api/ui-web; NO ServiceMonitor |
+| **UI full** (api + web) | api + web Deployments; NetworkPolicy with both `:8000` and `:3100`; helm-test pod present |
+| **UI api-only** | api only; NetworkPolicy with ONLY `:8000`; helm-test pod present |
+| **UI web-only** | web only; NetworkPolicy with ONLY `:3100`; web pod has `automountServiceAccountToken=false`; NO helm-test pod |
+| **OTel disabled (default)** | `OTEL_SDK_DISABLED=true` in api env; no OTLP endpoint |
+| **OTel enabled** | `OTEL_SDK_DISABLED=false`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`, `OTEL_SERVICE_NAME` all set |
+| **`ingress.target` failfast** | `helm template` MUST fail with an error mentioning `ui.ingress.target` |
 
-### Webhook validation (covered by unit tests, but smoke-check during e2e)
-- [ ] CE constraint violations are rejected at admission: `size>8`, `namespaces>2`, `network.tls`, `xdr`, enterprise image (`aerospike-server-enterprise`), `feature-key-file`. Each must surface a clear error string.
-- [ ] Duplicate ServiceMonitor when `monitoring.enabled=true` is rejected (added in #235).
+> ⚠️ **Drift note**: The chart's current default is `ui.enabled=true`. The "operator-only" row uses `--set ui.enabled=false` explicitly to satisfy the contract — change this if the default flips.
 
-### API CRUD smoke (UI api → DB → Aerospike)
+### Helm chart — real install + helm test
 
-Until the cluster-manager `ui/` ships a Playwright e2e suite, exercise the api directly with `curl` against a live `helm install`. This catches regressions that the helm-template lane and the operator Ginkgo suite both miss — DB persistence, aerospike-py wiring, the policy/error envelope of every router. It also re-exercises the four 500-error fixes from cluster-manager #261 (sample-data partial failure, query `pkType`, records empty namespace, indexes idempotency) on the real binary.
+`helm template` catches static regressions but misses things that only surface during apply (CRD ordering, hook race, RBAC propagation, helm-test pod regressions like #236).
 
-Prereq: a `Completed`-phase `AerospikeCluster` is up in the cluster (Section 3 "Basic single-node cluster" satisfies this) and you have a port-forward to the ui-api. Full bash recipe is in `reference/quick-commands.md` (Section "API CRUD smoke"); the must-pass checks are:
+PASS when **`scripts/41-helm-real-install.sh`**:
 
-- [ ] **Connection lifecycle** — `POST /api/v1/connections` returns 201 + a `id` + `createdAt`. `GET /api/v1/connections` includes it. `DELETE /api/v1/connections/{id}` returns 204 and a subsequent `GET` returns 404. Confirms PostgreSQL persistence is wired correctly.
-- [ ] **Cluster reachability** — `GET /api/v1/clusters/{conn_id}` returns 200 with `namespaces[].name == ["test"]` (or whatever the test cluster has). Confirms aerospike-py connection from inside the api pod to the in-cluster Aerospike service is working.
-- [ ] **sample-data partial-success contract** (#261/#257) — `POST /api/v1/sample-data/{conn_id}` body `{"namespace":"test","setName":"smoke","recordCount":10}` returns 201 with `recordsCreated`, `recordsFailed`, `indexesCreated`, `indexesFailed`. Critical: never 500 even if some indexes fail.
-- [ ] **records empty/sparse namespace** (#261/#259) — `GET /api/v1/records/{conn_id}?ns=test&pageSize=3` against a namespace with zero records returns 200 with `records: []`, NOT 500.
-- [ ] **query with `pkType=auto`** (#261/#258) — `POST /api/v1/query/{conn_id}` body `{"namespace":"test","maxRecords":3,"pkType":"auto"}` returns 200, behavior identical to omitting `pkType`. Confirms the spec default is honored at runtime.
-- [ ] **indexes create+delete idempotency** (#261/#260) — `POST /api/v1/indexes/{conn_id}` returns 201 with `state: building`. `DELETE /api/v1/indexes/{conn_id}?name=...&ns=...` returns 204. Both must agree with `GET /api/v1/indexes/{conn_id}` afterwards (no orphaned 500 + actual-success state divergence).
-- [ ] **500 envelope shape** (#261 follow-up) — when an endpoint genuinely 500s (force one with a known-bad request), the body has `detail`, `error`, and `requestId`, and the response carries `X-Request-ID`. Caller can grep server logs without backchanneling.
+- `helm install` on a fresh namespace succeeds and pods reach Running
+- `helm test <release>` reports `Phase: Succeeded`
+- `helm uninstall` + namespace deletion leaves no leftover state
 
-### Logging + tracing runtime (UI api pod)
+### UI api — CRUD smokes
 
-These are NOT in `test/e2e/` Ginkgo. They run against a live `helm install` and confirm the cluster-manager api's logging stack works as intended. Both are required before any release that ships UI api changes.
+The cluster-manager api is the user-facing surface for record browsing, query, sample data, and indexes. Several router-level regressions historically returned 500 instead of well-formed responses (#257–#260) — these are re-asserted on every run.
 
-- [ ] **Default log format is text** — `helm install` with no overrides puts `LOG_FORMAT=text`. `kubectl logs <ui-api>` shows `2026-... INFO [logger] message` lines, not JSON.
-- [ ] **`LOG_FORMAT=json` produces structured logs** — `helm upgrade --reuse-values --set ui.env.logFormat=json` makes the api emit one JSON object per record. Each line has `timestamp`, `level`, `logger`, `message`, `request_id`.
-- [ ] **X-Request-ID correlation** — `curl -H "X-Request-ID: <id>" http://<ui-api-svc>/api/health` produces a JSON log line whose `request_id` field equals `<id>`, AND the response carries `x-request-id: <id>` so the caller can correlate without server access.
-- [ ] **`OTEL_SDK_DISABLED=true` (default)** — pod env shows `OTEL_SDK_DISABLED=true`. No `OTEL_EXPORTER_OTLP_*` env, no outbound traffic to common collector ports (4317/4318) — Section 5 has a tcpdump check for the latter.
-- [ ] **OTel opt-in — env wiring** — `helm upgrade --set ui.api.otel.enabled=true,ui.api.otel.endpoint=http://<collector>:4317` flips `OTEL_SDK_DISABLED=false` and adds `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_TRACES_SAMPLER`, `OTEL_SERVICE_NAME=aerospike-cluster-manager-api`.
-- [ ] **OTel opt-in — runtime export** — deploy an OpenTelemetry Collector (e.g. `otel/opentelemetry-collector-contrib` with the `debug` exporter) at `otel-collector.otel.svc.cluster.local:4317`, generate traffic to a few endpoints (`/api/v1/connections`, `/api/openapi.json`), and confirm the collector logs:
-   1. `Traces resource spans` with `service.name: aerospike-cluster-manager-api`.
-   2. Parent HTTP spans (`Name: GET /api/v1/connections`, `http.method=GET`, `http.route=...`) sharing a Trace ID with the corresponding asyncpg `SELECT` child spans — proves trace propagation across HTTP → DB.
-   3. `Metrics resource metrics` data points on the same service.
-- [ ] **trace_id in middleware-emitted logs is null — by design** — the `request_logging_middleware` writes its `GET <path> <status> <ms>ms` record AFTER the route handler returns, when the OTel span is already closed. So that JSON log line shows `"trace_id": null, "span_id": null` even with OTel fully enabled. Logs emitted from inside route handlers (where the span is still active) DO carry real trace/span IDs. Don't treat the middleware null as a regression. If future work moves the access log emit inside the span, this line gets deleted.
+PASS when **`scripts/30-api-crud-smoke.sh`** verifies all of:
 
-Quick recipes:
+- **A. Connection lifecycle** — `POST /api/v1/connections` returns 201 + `id` + `createdAt`; `GET` list contains it; `DELETE` returns 204; subsequent `GET` returns 404.
+- **B. Cluster reachability** — `GET /api/v1/clusters/{conn_id}` returns 200 with `namespaces[].name` including `test`. Confirms aerospike-py wiring inside the api pod.
+- **C. sample-data partial-success** (#257) — `POST /api/v1/sample-data/{conn_id}` returns 201 with `recordsCreated`, `recordsFailed`, `indexesCreated`, `indexesFailed` keys. **Critical**: NEVER 500 even when some indexes fail.
+- **D. records empty/sparse namespace** (#259) — `GET /api/v1/records/{conn_id}?ns=test&set=does-not-exist` returns 200 with `records:[]` (NOT 500).
+- **E. query `pkType=auto`** (#258) — `POST /api/v1/query/{conn_id}` with `{"pkType":"auto"}` returns 200, identical behavior to omitting `pkType`.
+- **F. indexes idempotency** (#260) — `POST` returns 201 with `state: building|ready`; `DELETE` returns 204; calling `DELETE` again on the same name still returns 204 (no orphaned 500).
+- **G. X-Request-ID round-trip** — every response carries `x-request-id` echoing whatever the caller sent.
 
-```bash
-# (a) X-Request-ID round-trip
-NS=aerospike-operator
-POD=$(kubectl get pod -n $NS -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}')
-kubectl port-forward -n $NS svc/acko-aerospike-ce-kubernetes-operator-ui-api 18000:80 &
-sleep 2
-curl -sI -H "X-Request-ID: my-trace-001" http://localhost:18000/api/health | grep -i x-request-id   # response header
-kubectl logs -n $NS $POD -c api --since=30s | grep my-trace-001                                       # log correlation
-```
+### UI api — K8s management create/delete
 
-```bash
-# (b) OTel runtime — collector + helm upgrade + verify spans
-# Deploy a collector with the debug exporter so spans land in collector stdout.
-# (Full collector YAML lives in reference/quick-commands.md.)
-kubectl apply -f reference/otel-collector.yaml
-kubectl wait deploy/otel-collector --for=condition=Available -n otel --timeout=3m
+Real UI users create AerospikeCluster CRs through the api, not directly with `kubectl`. The whole `/api/v1/k8s/clusters/...` family was previously untested.
 
-helm upgrade acko ./charts/aerospike-ce-kubernetes-operator -n aerospike-operator --reuse-values \
-  --set ui.env.logFormat=json \
-  --set ui.api.otel.enabled=true \
-  --set ui.api.otel.endpoint=http://otel-collector.otel.svc.cluster.local:4317 \
-  --set ui.api.otel.protocol=grpc \
-  --wait --timeout 5m
+PASS when **`scripts/33-api-k8s-create-smoke.sh`**:
 
-# Wait for the new ui-api rollout and refresh the POD variable
-kubectl rollout status deploy/acko-aerospike-ce-kubernetes-operator-ui-api -n $NS
+- `POST /api/v1/k8s/clusters` creates a 1-node CR via the api → 200/201/202
+- The CR appears in `kubectl get asc` and reaches `phase=Completed`
+- `GET .../{ns}/{name}` returns 200 with the right `metadata.name`
+- `GET .../health` returns 200
+- `GET .../yaml` returns parseable YAML
+- `DELETE .../{ns}/{name}` removes the CR; subsequent `GET` returns 404
 
-# Generate traffic and look for HTTP + DB spans sharing a trace
-kubectl port-forward -n $NS svc/acko-aerospike-ce-kubernetes-operator-ui-api 18000:80 &
-sleep 2
-for ep in /api/health /api/v1/connections /api/openapi.json; do curl -s -o /dev/null http://localhost:18000$ep; done
+### Logging — text vs JSON, request correlation
 
-kubectl logs -n otel deploy/otel-collector --since=60s | \
-  grep -E "service.name|Trace ID|Name |http.method|http.route|db.system"
-# Expect: service.name=aerospike-cluster-manager-api; one Trace ID
-# spanning a "GET /api/v1/connections" parent + asyncpg SELECT children.
-```
+PASS when **`scripts/31-logging.sh`**:
+
+- Default `LOG_FORMAT=text` produces `YYYY-... INFO [logger] message` lines
+- `helm upgrade --set ui.env.logFormat=json` switches every record to a JSON object with `timestamp`, `level`, `logger`, `message`, `request_id` keys
+- A `curl -H "X-Request-ID: <id>"` request echoes the id in `x-request-id` response header AND embeds it as `request_id` in the matching JSON log record. Caller can correlate without server access.
+- Note: the middleware-emitted access log line shows `trace_id: null, span_id: null` even when OTel is fully enabled — this is by design (the middleware writes after the OTel span closes). Logs emitted from inside route handlers carry the real trace IDs.
+
+### OTel — opt-in env wiring + runtime export
+
+PASS when **`scripts/32-otel-runtime.sh`**:
+
+- `helm upgrade --set ui.api.otel.enabled=true,...endpoint=...` flips `OTEL_SDK_DISABLED=false` and sets `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_TRACES_SAMPLER`, `OTEL_SERVICE_NAME=aerospike-cluster-manager-api`.
+- A deployed OpenTelemetry collector (`reference/otel-collector.yaml`) receives traces with `service.name: aerospike-cluster-manager-api`.
+- **Both** `opentelemetry.instrumentation.fastapi` and `opentelemetry.instrumentation.asyncpg` instrumentation scopes appear at the collector. (Regression guard for cluster-manager #265 — the FastAPIInstrumentor fix; before that PR only asyncpg spans showed up, parent-less.)
+- At least one trace contains a Server-kind FastAPI span (HTTP request) **and** an asyncpg child span sharing the same trace ID — proving HTTP→DB context propagation.
+
+### Performance / soak (release-tag only)
+
+These are **not** gated on every PR but are required before tagging a minor release. Currently captured as TODOs; record results in `project-hub/docs/docs/history/releases/<version>/perf.md`.
+
+PASS targets:
+
+- **Reconcile loop** — 6-node multi-rack, 10× no-op `kubectl edit` → p99 reconcile < 2 s, circuit breaker stays Closed.
+- **Rolling restart** — 8-node + `RollingUpdateBatchSize=2` → restart in `(size/batchSize) × (warm_restart + 30s)`, no `BackoffActive`.
+- **Scale-up burst** — 1 → 8 nodes in one patch → all Ready < 5 min on Kind, no PVC stuck.
+- **Webhook latency** — `kubectl apply` 100 invalid CRs in a tight loop → 100% rejected, no API server timeout, operator stays Ready.
+- **Memory ceiling** — 1h soak under 6-node multi-rack → operator RSS < 256 MiB, no OOM, no fd leak.
+- **OTel egress when disabled** — default install + `tcpdump :4317,4318` for 10 min → 0 packets.
 
 ---
 
-## 4. Helm Chart Scenarios — `helm template` + `helm lint`
+## Scripts map (single source of truth)
 
-Run from `charts/aerospike-ce-kubernetes-operator/`. These are NOT in `test/e2e/`; they're a separate gate that catches chart regressions like the split-mode toggle bugs from PR #236.
+| Script | Purpose | Last-line contract scope |
+|--------|---------|--------------------------|
+| `scripts/lib.sh` | Shared library: logging, asserts, kubectl/helm/podman wrappers, port-forward management, env defaults | (sourced) |
+| `scripts/00-prereqs.sh` | Tool versions, podman runtime, chart reachability | `prereqs` |
+| `scripts/10-kind-up.sh` | `make setup-test-e2e` + `docker-build` + `kind load` | `kind-up` |
+| `scripts/11-cert-manager.sh` | Install pinned cert-manager, wait for webhook | `cert-manager` |
+| `scripts/12-helm-install.sh` | Parametric `helm install` (image / OTel / log-format flags) | `helm-install` |
+| `scripts/20-ginkgo.sh` | `go test ./test/e2e/` directly (preserves Kind cluster) | `ginkgo` |
+| `scripts/21-asc-create-smoke.sh` | Fast 1-node create/verify/delete (PR gate, api smoke prereq) | `asc-create` |
+| `scripts/30-api-crud-smoke.sh` | UI api CRUD smokes A–G | `api-crud` |
+| `scripts/31-logging.sh` | text/json LOG_FORMAT + X-Request-ID correlation | `logging` |
+| `scripts/32-otel-runtime.sh` | OTel collector deploy + traffic + parent/child span verification | `otel-runtime` |
+| `scripts/33-api-k8s-create-smoke.sh` | api-mediated AerospikeCluster CRUD (`/api/v1/k8s/clusters/...`) | `api-k8s-create` |
+| `scripts/40-helm-matrix.sh` | `helm lint` + 7-mode `helm template` matrix (no cluster needed) | `helm-matrix` |
+| `scripts/41-helm-real-install.sh` | `helm install` + `helm test` + `helm uninstall` | `helm-real` |
+| `scripts/60-diag-bundle.sh` | Capture cluster state, logs, CRDs, helm values, collector logs | `diag-bundle` |
+| `scripts/99-cleanup.sh` | helm uninstall + namespace delete (`--kind` also deletes Kind cluster) | `cleanup` |
+| `scripts/run-all.sh` | Orchestrator: `--mode {chart,smoke,full,ginkgo}`; emits Section 8 report | `run-all` |
 
-```bash
-cd charts/aerospike-ce-kubernetes-operator && helm lint .
-```
-
-For each mode below, run `helm template foo . --set <args>` and verify the listed resources / properties exist:
-
-| Mode | Set args | Must exist | Must NOT exist |
-|------|----------|------------|----------------|
-| Operator only | (defaults) | Operator Deployment, CRD, ClusterRole | UI Deployment, ServiceMonitor |
-| UI full (api+web) | `ui.enabled=true,ui.networkPolicy.enabled=true,ui.tests.enabled=true` | api Deployment, web Deployment, both Services, NetworkPolicy with both ports (`8000` + `3100`), helm-test pod | — |
-| UI api-only | `ui.enabled=true,ui.web.enabled=false,ui.ingress.target=api,ui.networkPolicy.enabled=true,ui.tests.enabled=true` | api Deployment, api Service, NetworkPolicy with ONLY `:8000`, helm-test pod | web Deployment, web Service |
-| UI web-only | `ui.enabled=true,ui.api.enabled=false,ui.web.env.apiUrl=http://x,ui.networkPolicy.enabled=true,ui.tests.enabled=true` | web Deployment, web Service, NetworkPolicy with ONLY `:3100`, web Pod has `automountServiceAccountToken: false` | api Deployment, api Service, helm-test pod |
-| OTel disabled (default) | `ui.enabled=true` | api env contains `OTEL_SDK_DISABLED=true` | (no `OTEL_EXPORTER_OTLP_ENDPOINT`) |
-| OTel enabled | `ui.enabled=true,ui.api.otel.enabled=true,ui.api.otel.endpoint=http://col:4317` | api env contains `OTEL_SDK_DISABLED=false` AND `OTEL_EXPORTER_OTLP_ENDPOINT=http://col:4317` AND `OTEL_TRACES_SAMPLER` | — |
-| ingress.target failfast | `ui.enabled=true,ui.web.enabled=false,ui.ingress.enabled=true` (default `target=web`) | `helm template` must FAIL with a clear error pointing at `ui.ingress.target` | — |
-
-A successful chart pass = `helm lint` clean + every row above renders / fails as documented.
-
-Beyond `helm template`, run a real `helm install` against the Kind cluster at least once per release to catch issues that only surface during apply (CRD ordering, hook race, RBAC propagation):
-
-```bash
-helm install acko-test ./charts/aerospike-ce-kubernetes-operator \
-  --namespace aerospike-operator-test --create-namespace \
-  --wait --timeout 5m
-helm test acko-test -n aerospike-operator-test          # runs the bundled test pods
-helm uninstall acko-test -n aerospike-operator-test
-kubectl delete ns aerospike-operator-test
-```
-
-`helm test` is what surfaces the `tests/test-api-connectivity.yaml` regression discussed in PR #236 — the helm-template lane alone won't catch a hanging test pod.
+Each script has a header comment listing inputs (env vars + flags), the eval criteria it asserts, and the contract output line. Read those before changing the script body.
 
 ---
 
-## 5. Performance / Soak Checks
+## Reporting
 
-These don't gate PRs but are required before tagging a minor release. Record results in `project-hub/docs/docs/history/releases/<version>/perf.md`.
-
-| Check | How | Acceptance |
-|-------|-----|------------|
-| Reconcile loop budget | Enable operator metrics, deploy a 6-node multi-rack, run `kubectl edit asc` 10× with no-op edits | p99 reconcile duration < 2 s; circuit breaker stays in `Closed` |
-| Rolling restart cadence | 8-node cluster + `RollingUpdateBatchSize=2`, trigger config change | Restart completes in `(size / batchSize) * (warm_restart_seconds + 30s)`; no `BackoffActive` |
-| Scale-up burst | Single-node → 8-node in one patch | All pods `Ready` < 5 min on Kind; PVC creation does not block |
-| Webhook latency | `kubectl apply` 100 invalid CRs in a tight loop | 100% rejected, no API-server timeout, operator stays `Ready` |
-| Memory ceiling | Operator pod under 6-node multi-rack soak (1h) | RSS < 256 MiB; no OOM, no fd leak |
-| OTel egress when disabled | Default install + `tcpdump -i any port 4317 or port 4318` for 10 min | 0 packets — confirms `OTEL_SDK_DISABLED=true` actually short-circuits |
-
----
-
-## 6. Diagnostic Bundle on Failure
-
-When any scenario fails, capture this BEFORE running `make cleanup-test-e2e` (which deletes the Kind cluster):
-
-```bash
-# 1. Operator + workload state
-kubectl get pods,asc,statefulset,configmap,pvc,pdb -A -o wide > /tmp/e2e-state.txt
-kubectl describe asc -A > /tmp/e2e-describe.txt
-kubectl logs -n aerospike-operator -l control-plane=controller-manager --tail=2000 > /tmp/e2e-operator.log
-
-# 2. Failing pod
-kubectl logs -n <ns> <failing-pod> --previous > /tmp/e2e-pod.log 2>&1 || true
-kubectl describe pod -n <ns> <failing-pod> > /tmp/e2e-pod-describe.txt
-
-# 3. Events (chronological)
-kubectl get events -A --sort-by='.lastTimestamp' > /tmp/e2e-events.txt
-
-# 4. CRD + webhook config
-kubectl get crd aerospikeclusters.acko.io -o yaml > /tmp/e2e-crd.yaml
-kubectl get validatingwebhookconfiguration -o yaml > /tmp/e2e-webhook.yaml
-```
-
-Attach all of `/tmp/e2e-*` to the failing PR / issue. Then run `make cleanup-test-e2e`.
-
----
-
-## 7. Common Failures — first-look table
-
-| Symptom | Likely cause | Fix |
-|---------|--------------|-----|
-| `kind create cluster` hangs on macOS | Podman machine not running, or rootful socket missing | `podman machine start && podman system service --time=0 &` |
-| Operator pod `ImagePullBackOff` for `controller:latest` | `make docker-build` skipped, image not loaded into Kind | `make docker-build IMG=... && kind load docker-image ...` |
-| `phase=Error` on first reconcile, no useful logs | Webhook rejected the CR but kubectl apply was server-side | check `kubectl get events`; webhook errors land there as Warning |
-| `phase=BackoffActive` (not Error, not Completed) | Reconciliation Circuit Breaker tripped after repeated failures | dump `status.conditions[?(@.type=="ReconcileBackoff")]`; reset by editing the CR or restarting the operator |
-| Helm template fails for `ingress.target=web` + `web.enabled=false` | This is the chart's own failfast (intentional, since #236) | set `ui.ingress.target=api` or enable web |
-| e2e test passes locally, fails in CI | Different `CONTAINER_TOOL` (Docker vs Podman) | confirm the workflow sets `CONTAINER_TOOL=podman KIND_PROVIDER=podman` |
-
----
-
-## 8. Reporting Format
-
-After a run, summarize for the user in this exact shape:
+`scripts/run-all.sh` emits this format (Section 8 of the legacy playbook):
 
 ```
 e2e run on <branch>@<short-sha> — <date>
-Mode:        smoke / full / heavy-only
-Duration:    <Xm>
+Mode:        chart / smoke / full / ginkgo
+Duration:    <Xm Ys>
 Outcome:     PASS / FAIL
 
-Functional:  N/M scenarios passed
-Helm chart:  N/M modes verified
-Performance: <list>
+Steps: N passed, M failed (of T total)
+  ✅ <scope>             <pass summary>
+  ❌ <scope>             <fail reason>
 
-Failures (if any):
-  - <Context name> — <one-line cause> — <link to logs>
+Failed steps: <names>
+Per-step output: /tmp/run-all-<step>.out
+Diagnostic bundle: /tmp/e2e-diag-<timestamp>/
 ```
 
-Do NOT claim "all scenarios pass" without listing the file paths you verified — historical drift between the test file and this checklist has happened before (e.g. when scenarios were renamed during the rack-per-StatefulSet refactor).
+Do not claim "all scenarios pass" without the `e2e:pass[scope=...]` line for that scope being present in the output. Historical drift between this checklist and the test file has happened before (rack-per-StatefulSet refactor renamed several Contexts).
 
 ---
 
-## 9. When to Update This Playbook
+## Common failures — first-look table
 
-Add a new row whenever:
-- A new `Context(...)` is added in `test/e2e/`
-- A new chart-level toggle is introduced (e.g. the `ui.api.enabled` / `ui.web.enabled` split in #236, or future `ui.postgresql.external`)
-- A regression is caught in production that the existing checklist did not surface — add the smallest possible reproducer
-- A performance budget is renegotiated — the previous value goes into the table footnote so future-us can spot drift
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `kind create cluster` hangs on macOS | Podman machine not running | `podman machine start && podman system service --time=0 &` |
+| Operator pod `ImagePullBackOff` for `controller:latest` | Image not loaded into Kind | re-run `scripts/10-kind-up.sh` |
+| `phase=Error` on first reconcile, no useful logs | Webhook rejected CR (server-side apply ate the message) | `kubectl get events -n <ns>` — webhook errors land there as Warning |
+| `phase=BackoffActive` (not Error, not Completed) | Reconciliation Circuit Breaker tripped | `kubectl get asc -o jsonpath='{.status.conditions[?(@.type=="ReconcileBackoff")]}'`; reset by editing the CR or restarting operator |
+| `helm template` fails for `ingress.target=web` + `web.enabled=false` | Chart's intentional failfast (since #236) | set `ui.ingress.target=api` or enable web |
+| e2e passes locally, fails in CI | Different `CONTAINER_TOOL` (Docker vs Podman) | confirm CI sets `CONTAINER_TOOL=podman KIND_PROVIDER=podman` |
+| Collector image `0.115.0` not found on docker.io | Tag rotated out | `scripts/32-otel-runtime.sh` auto-falls back to `$COLLECTOR_IMAGE` (defaults to `:latest`) and reloads |
+| OTel env wired but no spans at collector | `FastAPIInstrumentor` regression | check `scripts/32-otel-runtime.sh` output for "no FastAPIInstrumentor scope" — re-apply cluster-manager #265 |
 
-Skill version is implicit (commit hash). Don't bump anything in this file; the git log is the changelog.
+---
+
+## When to update
+
+- A new `Context(...)` lands in `test/e2e/` → the contract is owned by `scripts/20-ginkgo.sh` (it doesn't enumerate; the suite does), but if it tests a brand-new concern (e.g. backup), add a section above and a new `2X-foo.sh`.
+- A new chart toggle is introduced (e.g. `ui.postgresql.external`) → add a new row to the M-matrix in `scripts/40-helm-matrix.sh`.
+- A regression caught in production → add the smallest reproducer to the relevant script. Don't grow the markdown.
+- A perf budget renegotiated → record both old and new values in the perf section.
+
+The skill version is implicit in `git log` — don't bump anything in this file.

--- a/skills/acko-e2e-test/scripts/00-prereqs.sh
+++ b/skills/acko-e2e-test/scripts/00-prereqs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# 00-prereqs.sh — verify host has the tools / runtime needed for e2e.
+#
+# Eval criteria (PASS when):
+#   - kind / go / podman / kubectl / helm / yq / jq / curl all resolve
+#   - go >= 1.25, kind >= 0.31
+#   - podman machine is Running (macOS)
+#   - the operator chart and Makefile are reachable from $OPERATOR_REPO
+#
+# Env: OPERATOR_REPO (default: workspace sibling)
+# Exit: 0 on PASS, non-zero on FAIL. Last stdout line follows e2e:pass/fail contract.
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="prereqs"
+
+log_step "Checking required tools"
+for t in kind go podman kubectl helm yq jq curl; do
+    require_tool "$t"
+    log_ok "$t found at $(command -v "$t")"
+done
+
+log_step "Checking versions"
+go_ver=$(go version | awk '{print $3}' | sed 's/^go//')
+kind_ver=$(kind --version | awk '{print $NF}')
+log "go=$go_ver kind=$kind_ver"
+
+# Numeric compare — bail if go < 1.25 or kind < 0.31.
+ver_ge() {
+    # ver_ge <a> <b>  → true if a >= b
+    [ "$(printf '%s\n%s' "$1" "$2" | sort -V | head -1)" = "$2" ]
+}
+ver_ge "$go_ver" "1.25" || fail "$SCOPE" "go $go_ver < 1.25"
+ver_ge "$kind_ver" "0.31" || fail "$SCOPE" "kind $kind_ver < 0.31"
+
+log_step "Checking podman runtime"
+if [ "$(uname)" = "Darwin" ]; then
+    pm_state=$(podman machine list --format '{{.LastUp}}' 2>/dev/null | head -1)
+    case "$pm_state" in
+        "Currently running") log_ok "podman machine running" ;;
+        *) fail "$SCOPE" "podman machine not running (state: ${pm_state:-unknown})" ;;
+    esac
+fi
+podman info >/dev/null 2>&1 || fail "$SCOPE" "podman info failed (daemon/socket not reachable)"
+log_ok "podman info OK"
+
+log_step "Checking operator repo + chart"
+[ -n "$OPERATOR_REPO" ] || fail "$SCOPE" "OPERATOR_REPO not resolvable"
+[ -d "$OPERATOR_REPO" ] || fail "$SCOPE" "OPERATOR_REPO=$OPERATOR_REPO does not exist"
+[ -f "$OPERATOR_REPO/Makefile" ] || fail "$SCOPE" "no Makefile in $OPERATOR_REPO"
+require_chart
+log_ok "operator repo at $OPERATOR_REPO"
+log_ok "chart at $CHART_PATH"
+
+pass "$SCOPE" "tools=$(go version | awk '{print $3}'),$(kind --version | awk '{print $3}') podman=running chart=ok"

--- a/skills/acko-e2e-test/scripts/10-kind-up.sh
+++ b/skills/acko-e2e-test/scripts/10-kind-up.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# 10-kind-up.sh — bring up the Kind cluster + load the operator image.
+#
+# Eval criteria (PASS when):
+#   - Kind cluster $KIND_CLUSTER exists with all 4 default nodes Ready
+#   - $IMG is loaded on every node (control-plane + 3 workers)
+#
+# Why $IMG defaults to ghcr.io/.../v0.0.1: BeforeSuite in
+# test/e2e/e2e_suite_test.go:47 hardcodes that tag. Loading any other tag
+# is wasted work — Ginkgo will rebuild and re-load with v0.0.1 anyway.
+# (We still build under that tag here so the helm-install layer can run
+# before the Ginkgo layer.)
+#
+# Env: KIND_CLUSTER, CONTAINER_TOOL=podman, KIND_PROVIDER=podman, IMG, OPERATOR_REPO
+# Exit: 0 PASS / 1 FAIL
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="kind-up"
+
+[ -d "$OPERATOR_REPO" ] || fail "$SCOPE" "OPERATOR_REPO=$OPERATOR_REPO not found"
+
+log_step "Ensuring Kind cluster '$KIND_CLUSTER' exists"
+if kind get clusters 2>/dev/null | grep -qx "$KIND_CLUSTER"; then
+    log_ok "Kind cluster already exists — reusing"
+else
+    log "Creating cluster (this takes ~60–90s)"
+    (cd "$OPERATOR_REPO" && make setup-test-e2e) >&2 || fail "$SCOPE" "make setup-test-e2e failed"
+fi
+
+kubectl config use-context "kind-$KIND_CLUSTER" >&2 || fail "$SCOPE" "cannot switch context"
+
+log_step "Waiting for nodes Ready"
+kubectl wait --for=condition=Ready nodes --all --timeout=3m >&2 || fail "$SCOPE" "nodes did not become Ready"
+n_nodes=$(kubectl get nodes --no-headers | wc -l | tr -d ' ')
+assert_count ge 4 "$n_nodes" "expected ≥4 Kind nodes"
+
+log_step "Building operator image $IMG via $CONTAINER_TOOL"
+(cd "$OPERATOR_REPO" && make docker-build IMG="$IMG" CONTAINER_TOOL="$CONTAINER_TOOL") >&2 \
+    || fail "$SCOPE" "docker-build failed for $IMG"
+
+log_step "Loading image into Kind via tarball"
+local_tag="${IMG#localhost/}"   # podman saves with the registry prefix; keep IMG as-is
+tar=/tmp/acko-image-load.tar
+"$CONTAINER_TOOL" save -o "$tar" "$IMG" >&2 || fail "$SCOPE" "$CONTAINER_TOOL save failed"
+KIND_EXPERIMENTAL_PROVIDER="$KIND_PROVIDER" \
+    kind load image-archive "$tar" --name "$KIND_CLUSTER" >&2 \
+    || fail "$SCOPE" "kind load image-archive failed"
+rm -f "$tar"
+
+log_step "Verifying image on every node"
+missing=0
+for n in $(kubectl get nodes -o name | sed 's|node/||'); do
+    if podman exec "$n" crictl images 2>/dev/null | grep -q "$(echo "$IMG" | cut -d: -f1 | sed 's|.*/||')"; then
+        log_ok "$n has the image"
+    else
+        log_err "$n is missing the image"
+        missing=$((missing + 1))
+    fi
+done
+[ "$missing" -eq 0 ] || fail "$SCOPE" "$missing nodes missing $IMG"
+
+pass "$SCOPE" "cluster=$KIND_CLUSTER nodes=$n_nodes image=$IMG"

--- a/skills/acko-e2e-test/scripts/11-cert-manager.sh
+++ b/skills/acko-e2e-test/scripts/11-cert-manager.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# 11-cert-manager.sh — install cert-manager (required by the operator chart's webhook).
+#
+# Eval criteria (PASS when):
+#   - cert-manager-webhook deployment is Available
+#   - extra 10s sleep after Available, since webhook CA propagation takes a beat
+#
+# Pinned to $CERT_MANAGER_VERSION matching test/utils/utils.go.
+#
+# Idempotent — if already installed, just waits for readiness.
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="cert-manager"
+
+if ns_exists cert-manager && deploy_ready cert-manager cert-manager-webhook; then
+    log_ok "cert-manager already healthy — reusing"
+    pass "$SCOPE" "version=$CERT_MANAGER_VERSION (reused)"
+fi
+
+log_step "Applying cert-manager $CERT_MANAGER_VERSION manifest"
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml" >&2 \
+    || fail "$SCOPE" "kubectl apply failed"
+
+log_step "Waiting for cert-manager-webhook Available"
+kubectl wait deployment/cert-manager-webhook --for=condition=Available -n cert-manager --timeout=5m >&2 \
+    || fail "$SCOPE" "webhook did not become Available within 5m"
+
+log "Sleeping 10s for webhook CA propagation"
+sleep 10
+
+n_pods=$(kubectl get pods -n cert-manager --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l | tr -d ' ')
+assert_count ge 3 "$n_pods" "expected ≥3 Running cert-manager pods (got $n_pods)"
+
+pass "$SCOPE" "version=$CERT_MANAGER_VERSION pods=$n_pods"

--- a/skills/acko-e2e-test/scripts/12-helm-install.sh
+++ b/skills/acko-e2e-test/scripts/12-helm-install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# 12-helm-install.sh — parametric helm install/upgrade of the operator chart.
+#
+# Eval criteria (PASS when):
+#   - helm release '$HELM_RELEASE' STATUS=deployed in $NS_OPERATOR
+#   - operator + (optionally) ui-api + ui-web Deployments are Available
+#   - both AerospikeCluster CRDs are present
+#
+# Flags (all optional):
+#   --image <repo>     operator image repo (default: $IMG repo part)
+#   --tag <tag>        operator image tag (default: $IMG tag part)
+#   --pull-policy <p>  default: Never (we always pre-load)
+#   --api-image <repo> override ui-api image (e.g. for testing a patched build)
+#   --api-tag <tag>
+#   --log-format <fmt> text | json (default: text)
+#   --otel <on|off>    enable OTel (sets endpoint to in-cluster collector)
+#   --otel-endpoint <url>  default: http://otel-collector.otel.svc.cluster.local:4317
+#   --upgrade          run `helm upgrade --reuse-values` instead of install
+#   --extra <kv>       repeatable: passes --set <kv> through to helm
+#
+# Env: HELM_RELEASE, NS_OPERATOR, IMG, API_IMG, CHART_PATH
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="helm-install"
+require_chart
+
+img_repo="${IMG%:*}"
+img_tag="${IMG##*:}"
+api_repo="${API_IMG%:*}"
+api_tag="${API_IMG##*:}"
+pull_policy="Never"
+log_format="text"
+otel="off"
+otel_endpoint="http://otel-collector.${NS_OTEL}.svc.cluster.local:4317"
+mode="install"
+extras=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --image)        img_repo="$2"; shift 2 ;;
+        --tag)          img_tag="$2"; shift 2 ;;
+        --pull-policy)  pull_policy="$2"; shift 2 ;;
+        --api-image)    api_repo="$2"; shift 2 ;;
+        --api-tag)      api_tag="$2"; shift 2 ;;
+        --log-format)   log_format="$2"; shift 2 ;;
+        --otel)         otel="$2"; shift 2 ;;
+        --otel-endpoint) otel_endpoint="$2"; shift 2 ;;
+        --upgrade)      mode="upgrade"; shift ;;
+        --extra)        extras+=("--set" "$2"); shift 2 ;;
+        *) fail "$SCOPE" "unknown flag: $1" ;;
+    esac
+done
+
+set_args=(
+    --set "image.repository=$img_repo"
+    --set "image.tag=$img_tag"
+    --set "image.pullPolicy=$pull_policy"
+    --set "ui.api.image.repository=$api_repo"
+    --set "ui.api.image.tag=$api_tag"
+    --set "ui.api.image.pullPolicy=$pull_policy"
+    --set "ui.env.logFormat=$log_format"
+)
+
+case "$otel" in
+    on)
+        set_args+=(--set "ui.api.otel.enabled=true")
+        set_args+=(--set "ui.api.otel.endpoint=$otel_endpoint")
+        set_args+=(--set "ui.api.otel.protocol=grpc")
+        ;;
+    off|"") ;;
+    *) fail "$SCOPE" "--otel must be on|off, got '$otel'" ;;
+esac
+
+set_args+=("${extras[@]}")
+
+log_step "$mode helm release '$HELM_RELEASE' (operator=$img_repo:$img_tag api=$api_repo:$api_tag log=$log_format otel=$otel)"
+case "$mode" in
+    install)
+        helm install "$HELM_RELEASE" "$CHART_PATH" \
+            --namespace "$NS_OPERATOR" --create-namespace \
+            "${set_args[@]}" \
+            --wait --timeout 5m >&2 \
+            || fail "$SCOPE" "helm install failed"
+        ;;
+    upgrade)
+        helm upgrade "$HELM_RELEASE" "$CHART_PATH" \
+            --namespace "$NS_OPERATOR" --reuse-values \
+            "${set_args[@]}" \
+            --wait --timeout 5m >&2 \
+            || fail "$SCOPE" "helm upgrade failed"
+        ;;
+esac
+
+log_step "Verifying release state"
+status=$(helm status "$HELM_RELEASE" -n "$NS_OPERATOR" -o json 2>/dev/null | yq -r .info.status)
+assert_eq "deployed" "$status" "helm release status"
+
+# Wait for the rollouts
+kubectl rollout status -n "$NS_OPERATOR" deploy --timeout=3m >&2 || fail "$SCOPE" "deploy rollout did not finish"
+
+# CRDs
+for crd in aerospikeclusters.acko.io aerospikeclustertemplates.acko.io; do
+    kubectl get crd "$crd" >/dev/null 2>&1 || fail "$SCOPE" "CRD $crd missing"
+    log_ok "CRD $crd present"
+done
+
+n_running=$(kubectl get pods -n "$NS_OPERATOR" --field-selector=status.phase=Running --no-headers | wc -l | tr -d ' ')
+pass "$SCOPE" "release=$HELM_RELEASE mode=$mode pods=$n_running otel=$otel"

--- a/skills/acko-e2e-test/scripts/20-ginkgo.sh
+++ b/skills/acko-e2e-test/scripts/20-ginkgo.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# 20-ginkgo.sh — run the in-tree Ginkgo e2e suite.
+#
+# Eval criteria (PASS when):
+#   - `go test -tags=e2e ./test/e2e/` exits 0
+#   - "Ran N of N Specs" with no FAIL lines
+#
+# We invoke `go test` directly instead of `make test-e2e` because the latter
+# always runs `cleanup-test-e2e` at the end (deletes the Kind cluster), which
+# would invalidate every step run after this one. The cluster is preserved
+# unless the caller passes --tear-down.
+#
+# Modes (--mode):
+#   smoke   → --label-filter='!heavy'   (~5–8 min)
+#   full    → no filter                 (~15–60 min)  [default]
+#   heavy   → --label-filter='heavy'    (~25–50 min)
+#   focus:<regex>  → -ginkgo.focus='<regex>'  for iterating on one Context
+#
+# Flags:
+#   --mode <mode>      see above
+#   --timeout <dur>    go test -timeout (default: 60m)
+#   --tear-down        run `make cleanup-test-e2e` after the run
+#
+# Env: OPERATOR_REPO, KIND_CLUSTER, CONTAINER_TOOL, KIND_PROVIDER
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="ginkgo"
+
+mode="full"
+timeout="60m"
+teardown=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mode)      mode="$2"; shift 2 ;;
+        --timeout)   timeout="$2"; shift 2 ;;
+        --tear-down) teardown=1; shift ;;
+        *) fail "$SCOPE" "unknown flag: $1" ;;
+    esac
+done
+
+ginkgo_args=()
+case "$mode" in
+    smoke) ginkgo_args+=(-ginkgo.label-filter='!heavy') ;;
+    full)  ;;
+    heavy) ginkgo_args+=(-ginkgo.label-filter='heavy') ;;
+    focus:*) ginkgo_args+=(-ginkgo.focus="${mode#focus:}") ;;
+    *) fail "$SCOPE" "unknown mode '$mode' (smoke|full|heavy|focus:<regex>)" ;;
+esac
+
+[ -d "$OPERATOR_REPO/test/e2e" ] || fail "$SCOPE" "no test/e2e under $OPERATOR_REPO"
+
+log_step "Running Ginkgo suite mode=$mode timeout=$timeout"
+log_file=/tmp/ginkgo-${mode//:/-}.log
+(
+    cd "$OPERATOR_REPO" && \
+    KIND="$(command -v kind)" KIND_CLUSTER="$KIND_CLUSTER" \
+    CONTAINER_TOOL="$CONTAINER_TOOL" KIND_PROVIDER="$KIND_PROVIDER" \
+    KIND_EXPERIMENTAL_PROVIDER="$KIND_PROVIDER" \
+    go test -tags=e2e -timeout "$timeout" ./test/e2e/ -v -ginkgo.v "${ginkgo_args[@]}"
+) 2>&1 | tee "$log_file" >&2
+exit_code=${PIPESTATUS[0]}
+
+# Post-run summary
+ran_line=$(grep -E '^Ran [0-9]+ of [0-9]+ Specs' "$log_file" | tail -1 || true)
+n_fail=$(grep -c '^FAIL!' "$log_file" || true)
+
+if [ "$exit_code" -ne 0 ] || [ "${n_fail:-0}" -gt 0 ]; then
+    [ "$teardown" -eq 1 ] && (cd "$OPERATOR_REPO" && make cleanup-test-e2e >&2 || true)
+    fail "$SCOPE" "go test exit=$exit_code FAIL!=$n_fail (log: $log_file)"
+fi
+
+[ "$teardown" -eq 1 ] && (cd "$OPERATOR_REPO" && make cleanup-test-e2e >&2 || true)
+pass "$SCOPE" "${ran_line:-passed} mode=$mode (log: $log_file)"

--- a/skills/acko-e2e-test/scripts/21-asc-create-smoke.sh
+++ b/skills/acko-e2e-test/scripts/21-asc-create-smoke.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# 21-asc-create-smoke.sh — fast happy-path AerospikeCluster CR create/delete.
+#
+# Eval criteria (PASS when):
+#   1. Apply config/samples/acko_v1alpha1_aerospikecluster.yaml succeeds
+#   2. Cluster reaches phase=Completed within $TIMEOUT seconds
+#   3. Expected K8s resources present:
+#        - StatefulSet  named like aerospike-basic-<rackID>
+#        - Headless Service named aerospike-basic
+#        - ConfigMap matching the rack
+#        - PodDisruptionBudget for the cluster
+#   4. status.size == spec.size
+#   5. status.pods has 1 entry with IsRunningAndReady=true
+#   6. Delete the CR and verify the namespace returns to no asc CRs and pods
+#
+# This is the lightweight cousin of the Ginkgo Basic single-node Context.
+# Used as:
+#   - PR-time fast gate (1–2 min) instead of the full 15-min Ginkgo run
+#   - Prerequisite for 30-api-crud-smoke / 33-api-k8s-create-smoke (api needs
+#     a Completed cluster to talk to)
+#
+# Env: NS_AEROSPIKE, OPERATOR_REPO
+# Flags: --keep   leave the CR running after PASS (caller wants to re-use it)
+#        --name <n>   override CR name (default: aerospike-basic)
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="asc-create"
+
+keep=0
+name="aerospike-basic"
+timeout=180
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --keep) keep=1; shift ;;
+        --name) name="$2"; shift 2 ;;
+        --timeout) timeout="$2"; shift 2 ;;
+        *) fail "$SCOPE" "unknown flag: $1" ;;
+    esac
+done
+
+sample="$OPERATOR_REPO/config/samples/acko_v1alpha1_aerospikecluster.yaml"
+[ -f "$sample" ] || fail "$SCOPE" "sample not found: $sample"
+
+log_step "Applying sample CR (ns=$NS_AEROSPIKE name=$name)"
+kubectl create namespace "$NS_AEROSPIKE" --dry-run=client -o yaml | kubectl apply -f - >&2
+# Use yq to rename the CR if --name was overridden so we don't collide.
+if [ "$name" != "aerospike-basic" ]; then
+    yq "(.metadata.name = \"$name\") | (.metadata.namespace = \"$NS_AEROSPIKE\") | (.spec.aerospikeConfig.service.cluster-name = \"$name\")" \
+        "$sample" | kubectl apply -f - >&2 || fail "$SCOPE" "kubectl apply failed"
+else
+    yq "(.metadata.namespace = \"$NS_AEROSPIKE\")" "$sample" | kubectl apply -f - >&2 \
+        || fail "$SCOPE" "kubectl apply failed"
+fi
+
+log_step "Waiting for phase=Completed (up to ${timeout}s)"
+wait_phase_completed "$NS_AEROSPIKE" "$name" "$timeout"
+
+log_step "Verifying Kubernetes resources"
+ss_count=$(kubectl get statefulset -n "$NS_AEROSPIKE" -l "aerospike.com/cluster-name=$name" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+if [ "$ss_count" -eq 0 ]; then
+    # Fallback: most ACKO StatefulSets don't carry that label — match by name prefix.
+    ss_count=$(kubectl get statefulset -n "$NS_AEROSPIKE" --no-headers 2>/dev/null | grep -c "^${name}-" || true)
+fi
+assert_count ge 1 "$ss_count" "≥1 StatefulSet for $name"
+
+svc_count=$(kubectl get svc -n "$NS_AEROSPIKE" "$name" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+assert_count eq 1 "$svc_count" "headless Service '$name'"
+
+cm_count=$(kubectl get cm -n "$NS_AEROSPIKE" --no-headers 2>/dev/null | grep -c "^${name}-" || true)
+assert_count ge 1 "$cm_count" "≥1 ConfigMap for $name"
+
+pdb_count=$(kubectl get pdb -n "$NS_AEROSPIKE" --no-headers 2>/dev/null | grep -c "^${name}" || true)
+assert_count ge 1 "$pdb_count" "≥1 PodDisruptionBudget for $name"
+
+log_step "Verifying status fields"
+spec_size=$(kubectl get asc -n "$NS_AEROSPIKE" "$name" -o jsonpath='{.spec.size}')
+status_size=$(kubectl get asc -n "$NS_AEROSPIKE" "$name" -o jsonpath='{.status.size}')
+assert_eq "$spec_size" "$status_size" "status.size matches spec.size"
+
+ready_pods=$(kubectl get asc -n "$NS_AEROSPIKE" "$name" -o json \
+    | jq '[.status.pods // {} | to_entries[] | select(.value.isRunningAndReady == true)] | length')
+assert_count eq "$spec_size" "$ready_pods" "$spec_size pods reported running+ready in status"
+
+if [ "$keep" -eq 1 ]; then
+    pass "$SCOPE" "name=$name size=$spec_size — kept (callers will reuse it)"
+fi
+
+log_step "Deleting CR and verifying cleanup"
+kubectl delete asc -n "$NS_AEROSPIKE" "$name" --wait=true --timeout=2m >&2 \
+    || fail "$SCOPE" "kubectl delete asc failed"
+
+# Cluster pods should be gone after delete (PVC cleanup depends on
+# cascadeDelete; the basic sample uses memory storage, so no PVCs).
+remaining=$(kubectl get asc -n "$NS_AEROSPIKE" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+assert_count eq 0 "$remaining" "no ASC CRs remaining in $NS_AEROSPIKE"
+
+pass "$SCOPE" "name=$name size=$spec_size lifecycle ok"

--- a/skills/acko-e2e-test/scripts/30-api-crud-smoke.sh
+++ b/skills/acko-e2e-test/scripts/30-api-crud-smoke.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# 30-api-crud-smoke.sh — exercise the cluster-manager UI api against a live
+# Aerospike cluster. Re-runs the four 500-error fixes from cluster-manager
+# #261 against the real binary every release.
+#
+# Prerequisites:
+#   - 12-helm-install.sh succeeded (api pod Running)
+#   - 21-asc-create-smoke.sh ran with --keep, so an asc named '$ASC_NAME'
+#     in '$NS_AEROSPIKE' is in phase=Completed
+#
+# Eval criteria (PASS when all of):
+#   A. Connection lifecycle  : POST 201 + id, GET list contains it,
+#                              DELETE 204, GET 404 afterwards
+#   B. Cluster reachability  : GET /api/v1/clusters/{conn_id} 200 with
+#                              namespaces[].name including 'test'
+#   C. sample-data #257       : POST 201 with recordsCreated, recordsFailed,
+#                              indexesCreated, indexesFailed in body
+#                              (NEVER 500 even if some indexes fail)
+#   D. records empty #259    : GET ?ns=test&set=does-not-exist&pageSize=3
+#                              200 with records:[]  (NOT 500)
+#   E. query pkType=auto #258: POST {pkType:'auto'} 200, behaves like default
+#   F. indexes idempotency #260: POST 201 (state:building) → DELETE 204 →
+#                                DELETE-again 204 (no 500 on already-deleted)
+#   G. X-Request-ID header   : every response carries x-request-id
+#
+# Env: NS_OPERATOR, NS_AEROSPIKE, ASC_NAME (default: aerospike-basic),
+#      LOCAL_PORT (default: 18000)
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="api-crud"
+
+ASC_NAME="${ASC_NAME:-aerospike-basic}"
+LOCAL_PORT="${LOCAL_PORT:-18000}"
+
+# Sanity check the prereqs before opening a port-forward.
+phase=$(kubectl get asc -n "$NS_AEROSPIKE" "$ASC_NAME" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+[ "$phase" = "Completed" ] || fail "$SCOPE" "asc/$ASC_NAME not Completed (run 21-asc-create-smoke.sh --keep first; phase='$phase')"
+
+log_step "Opening port-forward to ui-api"
+ui_svc=$(kubectl get svc -n "$NS_OPERATOR" -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}')
+[ -n "$ui_svc" ] || fail "$SCOPE" "ui-api Service not found"
+pf_open "$NS_OPERATOR" "$ui_svc" "$LOCAL_PORT" 80 >/dev/null
+
+UI="http://localhost:${LOCAL_PORT}"
+SEED=$(asc_seed_host "$ASC_NAME" "$NS_AEROSPIKE")
+
+# -------- A. Connection lifecycle --------
+log_step "A. Connection lifecycle"
+http=$(curl -sS -o /tmp/api-conn.json -w '%{http_code}' \
+    -X POST "$UI/api/v1/connections" \
+    -H 'Content-Type: application/json' \
+    -d "{\"name\":\"smoke\",\"hosts\":[\"$SEED\"],\"port\":3000}")
+assert_eq 201 "$http" "POST /api/v1/connections"
+conn_id=$(jq -r '.id' /tmp/api-conn.json)
+[ -n "$conn_id" ] && [ "$conn_id" != "null" ] || fail "$SCOPE" "no id in connection response"
+log_ok "created connection id=$conn_id"
+
+curl -sS "$UI/api/v1/connections" | jq -e --arg id "$conn_id" 'map(.id) | index($id) != null' >/dev/null \
+    || fail "$SCOPE" "GET list does not contain $conn_id"
+log_ok "GET list contains $conn_id"
+
+# -------- B. Cluster reachability --------
+log_step "B. Cluster reachability"
+http=$(curl -sS -o /tmp/api-cluster.json -w '%{http_code}' "$UI/api/v1/clusters/$conn_id")
+assert_eq 200 "$http" "GET /api/v1/clusters/$conn_id"
+ns_names=$(jq -r '.namespaces[].name' /tmp/api-cluster.json | tr '\n' ',')
+assert_match 'test' "$ns_names" "namespace 'test' visible in cluster ns list"
+
+# -------- C. sample-data #257 --------
+log_step "C. sample-data partial-success contract (#257)"
+http=$(curl -sS -o /tmp/api-sample.json -w '%{http_code}' \
+    -X POST "$UI/api/v1/sample-data/$conn_id" \
+    -H 'Content-Type: application/json' \
+    -d '{"namespace":"test","setName":"smoke30","recordCount":10}')
+assert_eq 201 "$http" "POST /api/v1/sample-data (success path)"
+for k in recordsCreated recordsFailed indexesCreated indexesFailed; do
+    jq -e "has(\"$k\")" /tmp/api-sample.json >/dev/null || fail "$SCOPE" "sample-data response missing '$k'"
+done
+log_ok "response body has recordsCreated/Failed + indexesCreated/Failed"
+
+# Force partial failure to confirm we still get 201 (NOT 500).
+http=$(curl -sS -o /tmp/api-sample-bad.json -w '%{http_code}' \
+    -X POST "$UI/api/v1/sample-data/$conn_id" \
+    -H 'Content-Type: application/json' \
+    -d '{"namespace":"this-ns-does-not-exist-XYZ","setName":"smoke30","recordCount":1}')
+assert_eq 201 "$http" "POST /api/v1/sample-data (bad-ns must be 201 partial-success, NEVER 500)"
+fail_count=$(jq -r '.recordsFailed // 0' /tmp/api-sample-bad.json)
+assert_count ge 1 "$fail_count" "bad-ns case reports recordsFailed≥1"
+
+# -------- D. records empty/sparse #259 --------
+log_step "D. records empty set (#259)"
+http=$(curl -sS -o /tmp/api-records.json -w '%{http_code}' \
+    "$UI/api/v1/records/$conn_id?ns=test&set=does-not-exist&pageSize=3")
+assert_eq 200 "$http" "GET /api/v1/records (empty set)"
+records_len=$(jq '.records | length' /tmp/api-records.json)
+assert_eq 0 "$records_len" "records:[] for non-existent set"
+
+# -------- E. query pkType=auto #258 --------
+log_step "E. query pkType=auto (#258)"
+http=$(curl -sS -o /tmp/api-query.json -w '%{http_code}' \
+    -X POST "$UI/api/v1/query/$conn_id" \
+    -H 'Content-Type: application/json' \
+    -d '{"namespace":"test","maxRecords":3,"pkType":"auto"}')
+assert_eq 200 "$http" "POST /api/v1/query (pkType=auto)"
+jq -e '.records | type == "array"' /tmp/api-query.json >/dev/null \
+    || fail "$SCOPE" "query response has no .records array"
+
+# -------- F. indexes idempotency #260 --------
+log_step "F. indexes idempotency (#260)"
+http=$(curl -sS -o /tmp/api-idx-create.json -w '%{http_code}' \
+    -X POST "$UI/api/v1/indexes/$conn_id" \
+    -H 'Content-Type: application/json' \
+    -d '{"namespace":"test","set":"smoke30","name":"idx_smoke30_int","bin":"bin_int","type":"numeric"}')
+assert_eq 201 "$http" "POST /api/v1/indexes (create)"
+state=$(jq -r '.state' /tmp/api-idx-create.json)
+assert_match 'building|ready' "$state" "index state ∈ {building, ready}"
+
+http=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X DELETE "$UI/api/v1/indexes/$conn_id?name=idx_smoke30_int&ns=test")
+assert_eq 204 "$http" "DELETE /api/v1/indexes (first call)"
+
+http=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -X DELETE "$UI/api/v1/indexes/$conn_id?name=idx_smoke30_int&ns=test")
+assert_eq 204 "$http" "DELETE /api/v1/indexes (idempotent — same as first)"
+
+# -------- G. X-Request-ID round-trip --------
+log_step "G. X-Request-ID header always present"
+rid="probe-$(date +%s%N)"
+got_rid=$(curl -sS -D - -H "X-Request-ID: $rid" "$UI/api/v1/connections" -o /dev/null \
+    | tr -d '\r' | awk '/^x-request-id:/ {print $2}' | tail -1)
+assert_eq "$rid" "$got_rid" "x-request-id echoed back unchanged"
+
+# -------- A2. Close out the connection lifecycle --------
+log_step "A2. Closing connection"
+http=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE "$UI/api/v1/connections/$conn_id")
+assert_eq 204 "$http" "DELETE /api/v1/connections/$conn_id"
+http=$(curl -sS -o /dev/null -w '%{http_code}' "$UI/api/v1/connections/$conn_id")
+assert_eq 404 "$http" "GET /api/v1/connections/$conn_id (after delete)"
+
+pass "$SCOPE" "7 contracts verified (A–G) against asc/$ASC_NAME"

--- a/skills/acko-e2e-test/scripts/31-logging.sh
+++ b/skills/acko-e2e-test/scripts/31-logging.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# 31-logging.sh — verify the cluster-manager api logging stack.
+#
+# Eval criteria (PASS when):
+#   1. Default LOG_FORMAT=text                — server logs are 'YYYY-... LEVEL [logger] message'
+#   2. helm upgrade --set ui.env.logFormat=json — every record becomes a JSON
+#      object with timestamp/level/logger/message/request_id keys
+#   3. X-Request-ID round-trip                — header echoed in response AND
+#      embedded as 'request_id' in the JSON log record
+#   4. OTEL_SDK_DISABLED=true (default)        — pod env confirms the toggle
+#
+# This script intentionally toggles between text and json modes, so it must
+# run AFTER 12-helm-install.sh and BEFORE 32-otel-runtime.sh (which expects
+# json + otel both on).
+#
+# Env: NS_OPERATOR, HELM_RELEASE, CHART_PATH, LOCAL_PORT (default: 18002)
+# Flags: --skip-text  skip the text-default check (useful when chart was
+#                     already upgraded to json by a previous step)
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="logging"
+
+LOCAL_PORT="${LOCAL_PORT:-18002}"
+skip_text=0
+for a in "$@"; do
+    case "$a" in
+        --skip-text) skip_text=1 ;;
+    esac
+done
+
+ui_svc=$(kubectl get svc -n "$NS_OPERATOR" -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}')
+[ -n "$ui_svc" ] || fail "$SCOPE" "ui-api Service not found"
+
+# -------- 1. Default LOG_FORMAT=text --------
+if [ "$skip_text" -eq 0 ]; then
+    log_step "1. Default LOG_FORMAT=text"
+    pod=$(kubectl get pod -n "$NS_OPERATOR" -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}')
+    cur=$(kubectl exec -n "$NS_OPERATOR" "$pod" -c api -- printenv LOG_FORMAT 2>/dev/null || echo "")
+    if [ "$cur" = "text" ] || [ -z "$cur" ]; then
+        # Sample 10 lines from the api container; at least one must look like the text format.
+        sample=$(kubectl logs -n "$NS_OPERATOR" "$pod" -c api --tail=20 2>/dev/null || true)
+        assert_match '[0-9]{4}-[0-9]{2}-[0-9]{2}.*INFO.*\[' "$sample" "log line in text format"
+    else
+        log_warn "LOG_FORMAT='$cur' already non-text — skipping default-text assertion"
+    fi
+fi
+
+# -------- 2. Upgrade to LOG_FORMAT=json --------
+log_step "2. helm upgrade --set ui.env.logFormat=json"
+helm upgrade "$HELM_RELEASE" "$CHART_PATH" \
+    --namespace "$NS_OPERATOR" --reuse-values \
+    --set ui.env.logFormat=json \
+    --wait --timeout 3m >&2 \
+    || fail "$SCOPE" "helm upgrade to json failed"
+kubectl rollout status deploy -n "$NS_OPERATOR" --timeout=2m >&2 \
+    || fail "$SCOPE" "rollout did not complete"
+
+# Refresh pod handle after rollout
+pod=$(kubectl get pod -n "$NS_OPERATOR" -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}')
+log "current api pod: $pod"
+
+# -------- 3. X-Request-ID round-trip --------
+log_step "3. X-Request-ID round-trip in JSON mode"
+pf_open "$NS_OPERATOR" "$ui_svc" "$LOCAL_PORT" 80 >/dev/null
+
+rid="probe-json-$(date +%s%N)"
+got_rid=$(curl -sS -D - -H "X-Request-ID: $rid" "http://localhost:${LOCAL_PORT}/api/health" -o /dev/null \
+    | tr -d '\r' | awk '/^x-request-id:/ {print $2}' | tail -1)
+assert_eq "$rid" "$got_rid" "x-request-id echoed in response"
+
+# Allow logs to flush
+sleep 2
+# The middleware-emitted access log line carries request_id even with trace_id=null.
+log_line=$(kubectl logs -n "$NS_OPERATOR" "$pod" -c api --since=30s 2>/dev/null | grep -F "$rid" | head -1)
+[ -n "$log_line" ] || fail "$SCOPE" "no log line correlated with $rid"
+echo "$log_line" | jq -e --arg rid "$rid" '.request_id == $rid' >/dev/null \
+    || fail "$SCOPE" "log record present but request_id field != $rid"
+log_ok "log record JSON has request_id=$rid"
+
+# -------- 4. OTEL_SDK_DISABLED default behavior --------
+log_step "4. OTEL_SDK_DISABLED env in api pod"
+otel_disabled=$(kubectl exec -n "$NS_OPERATOR" "$pod" -c api -- printenv OTEL_SDK_DISABLED 2>/dev/null || echo "")
+log "OTEL_SDK_DISABLED='$otel_disabled'"
+# This script is agnostic — both states are valid here; 32-otel-runtime.sh
+# is responsible for the OTel state. We just record the current value.
+
+pass "$SCOPE" "text-default ok, json upgrade ok, X-Request-ID correlation ok"

--- a/skills/acko-e2e-test/scripts/32-otel-runtime.sh
+++ b/skills/acko-e2e-test/scripts/32-otel-runtime.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# 32-otel-runtime.sh — verify OTel opt-in actually exports spans end-to-end.
+#
+# This script is the regression guard for cluster-manager #265 — the
+# FastAPIInstrumentor fix. Before that PR the env wiring was correct but
+# zero spans reached the collector because FastAPI was never instrumented.
+# If a future change reverts that, this script fails immediately.
+#
+# Eval criteria (PASS when):
+#   1. Helm upgrade with ui.api.otel.enabled=true succeeds
+#   2. OTEL_SDK_DISABLED=false + OTLP endpoint env in api pod
+#   3. otel-collector deployed and Available
+#   4. After traffic to /api/health + /api/v1/connections + /api/openapi.json,
+#      the collector receives spans with service.name=aerospike-cluster-manager-api
+#   5. Both instrumentation scopes appear:
+#        - opentelemetry.instrumentation.fastapi  (HTTP server spans)
+#        - opentelemetry.instrumentation.asyncpg  (DB client spans)
+#   6. At least one trace contains BOTH a Server kind FastAPI span AND
+#      an asyncpg child span sharing the trace ID — proving HTTP→DB context propagation.
+#
+# Env: NS_OPERATOR, NS_OTEL, HELM_RELEASE, CHART_PATH, LOCAL_PORT (default: 18003)
+# Flags: --collector-image <ref>  override $COLLECTOR_IMAGE
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="otel-runtime"
+
+LOCAL_PORT="${LOCAL_PORT:-18003}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --collector-image) COLLECTOR_IMAGE="$2"; shift 2 ;;
+        *) fail "$SCOPE" "unknown flag: $1" ;;
+    esac
+done
+
+ref_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../reference" && pwd)"
+collector_yaml="$ref_dir/otel-collector.yaml"
+[ -f "$collector_yaml" ] || fail "$SCOPE" "missing $collector_yaml"
+
+# -------- 1+2. Upgrade with OTel enabled and verify env --------
+log_step "1. helm upgrade with OTel enabled"
+helm upgrade "$HELM_RELEASE" "$CHART_PATH" \
+    --namespace "$NS_OPERATOR" --reuse-values \
+    --set ui.env.logFormat=json \
+    --set ui.api.otel.enabled=true \
+    --set "ui.api.otel.endpoint=http://otel-collector.${NS_OTEL}.svc.cluster.local:4317" \
+    --set ui.api.otel.protocol=grpc \
+    --wait --timeout 3m >&2 \
+    || fail "$SCOPE" "helm upgrade failed"
+
+kubectl rollout status -n "$NS_OPERATOR" deploy --timeout=2m >&2 || fail "$SCOPE" "rollout did not finish"
+pod=$(kubectl get pod -n "$NS_OPERATOR" -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}')
+log "api pod: $pod"
+
+log_step "2. Verifying OTEL_* env in api pod"
+otel_env=$(kubectl exec -n "$NS_OPERATOR" "$pod" -c api -- printenv 2>/dev/null | grep '^OTEL_')
+assert_match 'OTEL_SDK_DISABLED=false'         "$otel_env" "OTEL_SDK_DISABLED=false"
+assert_match 'OTEL_EXPORTER_OTLP_ENDPOINT='   "$otel_env" "OTEL_EXPORTER_OTLP_ENDPOINT set"
+assert_match 'OTEL_EXPORTER_OTLP_PROTOCOL=grpc' "$otel_env" "OTEL_EXPORTER_OTLP_PROTOCOL=grpc"
+assert_match 'OTEL_SERVICE_NAME=aerospike-cluster-manager-api' "$otel_env" "OTEL_SERVICE_NAME"
+assert_match 'OTEL_TRACES_SAMPLER='           "$otel_env" "OTEL_TRACES_SAMPLER set"
+
+# -------- 3. Deploy collector --------
+log_step "3. Deploying OTel collector"
+kubectl apply -f "$collector_yaml" >&2 || fail "$SCOPE" "kubectl apply collector yaml failed"
+
+# Hot-swap to a tag we can resolve. The yaml pins 0.115.0 historically; the
+# collector floor is moving fast and the pinned tag is sometimes gone from
+# docker.io. Try the latest tag we can pull locally.
+if ! kubectl wait deploy/otel-collector --for=condition=Available -n "$NS_OTEL" --timeout=60s >/dev/null 2>&1; then
+    log_warn "collector did not come up with the manifest's pinned image — patching to $COLLECTOR_IMAGE"
+    "$CONTAINER_TOOL" pull "$COLLECTOR_IMAGE" >&2 || fail "$SCOPE" "failed to pull $COLLECTOR_IMAGE"
+    "$CONTAINER_TOOL" save -o /tmp/otel-collector-image.tar "$COLLECTOR_IMAGE" >&2
+    KIND_EXPERIMENTAL_PROVIDER="$KIND_PROVIDER" \
+        kind load image-archive /tmp/otel-collector-image.tar --name "$KIND_CLUSTER" >&2
+    rm -f /tmp/otel-collector-image.tar
+    kubectl set image -n "$NS_OTEL" deploy/otel-collector "collector=$COLLECTOR_IMAGE" >&2
+    kubectl patch deploy -n "$NS_OTEL" otel-collector --type='json' \
+        -p='[{"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"Never"}]' >&2
+    kubectl rollout status -n "$NS_OTEL" deploy/otel-collector --timeout=2m >&2 \
+        || fail "$SCOPE" "collector did not become Ready after patch"
+fi
+
+# -------- 4. Generate traffic --------
+log_step "4. Generating traffic"
+ui_svc=$(kubectl get svc -n "$NS_OPERATOR" -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}')
+pf_open "$NS_OPERATOR" "$ui_svc" "$LOCAL_PORT" 80 >/dev/null
+for _ in 1 2 3 4 5; do
+    curl -sS -o /dev/null "http://localhost:${LOCAL_PORT}/api/health"
+    curl -sS -o /dev/null "http://localhost:${LOCAL_PORT}/api/v1/connections"
+    curl -sS -o /dev/null "http://localhost:${LOCAL_PORT}/api/openapi.json"
+done
+log "15 requests sent — sleeping 8s for batch flush"
+sleep 8
+
+# -------- 5+6. Verify spans + parent/child propagation --------
+log_step "5. Pulling collector logs"
+clog=/tmp/otel-collector-spans.log
+kubectl logs -n "$NS_OTEL" deploy/otel-collector --since=120s > "$clog" 2>&1 || fail "$SCOPE" "kubectl logs collector failed"
+
+log_step "5a. service.name resource span"
+grep -q 'service.name: Str(aerospike-cluster-manager-api)' "$clog" \
+    || fail "$SCOPE" "no resource span with service.name=aerospike-cluster-manager-api"
+log_ok "service.name=aerospike-cluster-manager-api seen"
+
+log_step "5b. Both instrumentation scopes present"
+grep -q 'InstrumentationScope opentelemetry.instrumentation.fastapi' "$clog" \
+    || fail "$SCOPE" "no FastAPIInstrumentor scope (cluster-manager #265 may have regressed)"
+grep -q 'InstrumentationScope opentelemetry.instrumentation.asyncpg' "$clog" \
+    || fail "$SCOPE" "no AsyncPGInstrumentor scope"
+log_ok "fastapi + asyncpg scopes both present"
+
+log_step "6. Parent/child propagation (HTTP server → asyncpg client)"
+# Find a server-kind FastAPI span (HTTP request) and check that at least one
+# asyncpg child span carries the same trace ID.
+server_traces=$(awk '
+    /InstrumentationScope opentelemetry.instrumentation.fastapi/ { in_fastapi=1 }
+    in_fastapi && /^Span #/ { in_span=1; trace=""; kind="" }
+    in_span && /^[[:space:]]*Trace ID[[:space:]]*:/ { trace=$NF }
+    in_span && /^[[:space:]]*Kind[[:space:]]*: Server/ { kind="Server" }
+    in_span && /^$/ { if (kind=="Server") print trace; in_span=0 }
+    /^InstrumentationScope/ && !/fastapi/ { in_fastapi=0 }
+' "$clog" | sort -u)
+[ -n "$server_traces" ] || fail "$SCOPE" "no Server-kind FastAPI span found (HTTP requests not instrumented)"
+log "Server FastAPI traces: $(echo "$server_traces" | tr '\n' ' ')"
+
+correlated=0
+for tid in $server_traces; do
+    asyncpg_child=$(awk -v tid="$tid" '
+        /InstrumentationScope opentelemetry.instrumentation.asyncpg/ { in_pg=1 }
+        in_pg && /^Span #/ { in_span=1; trace=""; parent="" }
+        in_span && /^[[:space:]]*Trace ID[[:space:]]*:/ { trace=$NF }
+        in_span && /^[[:space:]]*Parent ID[[:space:]]*:/ { parent=$NF }
+        in_span && /^$/ { if (trace==tid && parent != "") print trace"|"parent; in_span=0 }
+        /^InstrumentationScope/ && !/asyncpg/ { in_pg=0 }
+    ' "$clog" | head -1)
+    if [ -n "$asyncpg_child" ]; then
+        log_ok "trace $tid has asyncpg child (parent=${asyncpg_child#*|})"
+        correlated=$((correlated + 1))
+    fi
+done
+assert_count ge 1 "$correlated" "≥1 trace contains both a FastAPI server span and an asyncpg child span"
+
+pass "$SCOPE" "spans=$(grep -c '^Span #' "$clog") server-traces=$(echo "$server_traces" | wc -l | tr -d ' ') correlated=$correlated"

--- a/skills/acko-e2e-test/scripts/33-api-k8s-create-smoke.sh
+++ b/skills/acko-e2e-test/scripts/33-api-k8s-create-smoke.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# 33-api-k8s-create-smoke.sh — exercise the api's K8s management endpoints.
+#
+# Real users create AerospikeCluster CRs from the UI, which goes through:
+#   POST /api/v1/k8s/clusters
+#   GET  /api/v1/k8s/clusters
+#   GET  /api/v1/k8s/clusters/{ns}/{name}
+#   GET  /api/v1/k8s/clusters/{ns}/{name}/health
+#   GET  /api/v1/k8s/clusters/{ns}/{name}/yaml
+#   DELETE /api/v1/k8s/clusters/{ns}/{name}
+#
+# Until this script existed the UI cluster-creation path was never exercised
+# end-to-end in CI, even though it's the most common production code path.
+#
+# Eval criteria (PASS when):
+#   1. POST /api/v1/k8s/clusters — creates a 1-node CR via api → 201/202
+#   2. The CR appears in `kubectl get asc -n <ns>` and reaches Completed
+#   3. GET /api/v1/k8s/clusters/{ns}/{name} returns 200 with status fields
+#   4. GET .../health returns 200 with healthy=true (or equivalent)
+#   5. GET .../yaml returns 200 with a parseable YAML body
+#   6. DELETE removes the CR; subsequent GET returns 404
+#
+# Prereq: 12-helm-install.sh ran with K8s management enabled (chart default).
+#
+# Env: NS_OPERATOR, LOCAL_PORT (default: 18001 to avoid collision)
+# Flags: --ns <ns>     namespace to create the CR in (default: $NS_AEROSPIKE)
+#        --name <n>    CR name (default: api-smoke)
+#        --timeout <s> wait for Completed (default: 180)
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="api-k8s-create"
+
+LOCAL_PORT="${LOCAL_PORT:-18001}"
+ns="$NS_AEROSPIKE"
+name="api-smoke"
+timeout=180
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ns) ns="$2"; shift 2 ;;
+        --name) name="$2"; shift 2 ;;
+        --timeout) timeout="$2"; shift 2 ;;
+        *) fail "$SCOPE" "unknown flag: $1" ;;
+    esac
+done
+
+log_step "Opening port-forward to ui-api"
+ui_svc=$(kubectl get svc -n "$NS_OPERATOR" -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}')
+[ -n "$ui_svc" ] || fail "$SCOPE" "ui-api Service not found"
+pf_open "$NS_OPERATOR" "$ui_svc" "$LOCAL_PORT" 80 >/dev/null
+
+UI="http://localhost:${LOCAL_PORT}"
+
+# -------- 0. Confirm the endpoint group is enabled --------
+log_step "0. K8s management routes are exposed"
+paths=$(curl -sS "$UI/api/openapi.json" | jq -r '.paths | keys[]' | grep -c '^/api/v1/k8s/' || true)
+assert_count ge 5 "$paths" "≥5 /api/v1/k8s/* routes in openapi (K8S_MANAGEMENT_ENABLED)"
+
+# -------- 1. POST create --------
+log_step "1. POST /api/v1/k8s/clusters (create CR)"
+kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f - >&2
+
+# The schema for CreateClusterRequest may differ across releases. We probe it.
+schema=$(curl -sS "$UI/api/openapi.json" | jq -r '
+    .paths["/api/v1/k8s/clusters"].post.requestBody.content["application/json"].schema."$ref" // empty
+' | sed 's|.*/||')
+[ -n "$schema" ] || fail "$SCOPE" "POST /api/v1/k8s/clusters missing requestBody schema in openapi"
+log "request schema: $schema"
+
+# Build a minimal payload — CE memory namespace, 1 node.
+payload=$(jq -n --arg ns "$ns" --arg name "$name" '{
+    namespace: $ns,
+    name: $name,
+    size: 1,
+    image: "aerospike:ce-8.1.1.1",
+    aerospikeConfig: {
+        service: { "cluster-name": $name, "proto-fd-max": 15000 },
+        network: {
+            service: { address: "any", port: 3000 },
+            heartbeat: { mode: "mesh", port: 3002 },
+            fabric: { address: "any", port: 3001 }
+        },
+        namespaces: [{
+            name: "test",
+            "replication-factor": 1,
+            "storage-engine": { type: "memory", "data-size": 1073741824 }
+        }],
+        logging: [{ name: "console", any: "info" }]
+    }
+}')
+
+http=$(curl -sS -o /tmp/api-k8s-create.json -w '%{http_code}' \
+    -X POST "$UI/api/v1/k8s/clusters" \
+    -H 'Content-Type: application/json' \
+    -d "$payload")
+case "$http" in
+    201|202|200) log_ok "POST returned $http" ;;
+    *) cat /tmp/api-k8s-create.json >&2; fail "$SCOPE" "POST /api/v1/k8s/clusters got $http (want 200/201/202)" ;;
+esac
+
+# Cluster CR should now exist
+log_step "2. CR exists and reaches Completed"
+wait_for 30 1 "asc/$name appears in $ns" -- kubectl get asc -n "$ns" "$name"
+wait_phase_completed "$ns" "$name" "$timeout"
+
+# -------- 3. GET single cluster --------
+log_step "3. GET /api/v1/k8s/clusters/$ns/$name"
+http=$(curl -sS -o /tmp/api-k8s-get.json -w '%{http_code}' "$UI/api/v1/k8s/clusters/$ns/$name")
+assert_eq 200 "$http" "GET single cluster"
+jq -e '.metadata.name == "'"$name"'"' /tmp/api-k8s-get.json >/dev/null \
+    || fail "$SCOPE" "GET single response missing .metadata.name=$name"
+
+# -------- 4. GET health --------
+log_step "4. GET .../health"
+http=$(curl -sS -o /tmp/api-k8s-health.json -w '%{http_code}' "$UI/api/v1/k8s/clusters/$ns/$name/health")
+assert_eq 200 "$http" "GET health"
+
+# -------- 5. GET yaml --------
+log_step "5. GET .../yaml"
+http=$(curl -sS -o /tmp/api-k8s-yaml.txt -w '%{http_code}' "$UI/api/v1/k8s/clusters/$ns/$name/yaml")
+assert_eq 200 "$http" "GET yaml"
+yq . /tmp/api-k8s-yaml.txt >/dev/null 2>&1 || fail "$SCOPE" "yaml endpoint did not return parseable YAML"
+
+# -------- 6. DELETE --------
+log_step "6. DELETE .../$ns/$name"
+http=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE "$UI/api/v1/k8s/clusters/$ns/$name")
+case "$http" in
+    200|202|204) log_ok "DELETE returned $http" ;;
+    *) fail "$SCOPE" "DELETE got $http (want 200/202/204)" ;;
+esac
+
+wait_for 60 2 "asc/$name removed from $ns" -- bash -c "! kubectl get asc -n '$ns' '$name' >/dev/null 2>&1"
+
+http=$(curl -sS -o /dev/null -w '%{http_code}' "$UI/api/v1/k8s/clusters/$ns/$name")
+assert_eq 404 "$http" "GET after DELETE returns 404"
+
+pass "$SCOPE" "create→Completed→get→health→yaml→delete cycle ok (ns=$ns name=$name)"

--- a/skills/acko-e2e-test/scripts/40-helm-matrix.sh
+++ b/skills/acko-e2e-test/scripts/40-helm-matrix.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# 40-helm-matrix.sh — chart lint + 7-mode helm template assertion matrix.
+#
+# Eval criteria (PASS when all 7 modes render or fail-fast as expected):
+#   M1 operator-only (--set ui.enabled=false)
+#       → Operator Deployment present, NO ui-api/ui-web Deployment, NO ServiceMonitor.
+#   M2 UI full (api+web)
+#       → operator+api+web Deployments, NetworkPolicy with both :8000 and :3100,
+#         helm-test pod present.
+#   M3 UI api-only (ui.web.enabled=false, ingress.target=api)
+#       → operator+api Deployments only, NetworkPolicy with ONLY :8000,
+#         helm-test pod present.
+#   M4 UI web-only (ui.api.enabled=false)
+#       → operator+web Deployments only, NetworkPolicy with ONLY :3100,
+#         web pod has automountServiceAccountToken=false, NO helm-test pod.
+#   M5 OTel disabled (default)
+#       → api env contains OTEL_SDK_DISABLED=true, no OTLP endpoint.
+#   M6 OTel enabled (ui.api.otel.enabled=true,endpoint=...)
+#       → api env contains OTEL_SDK_DISABLED=false, OTEL_EXPORTER_OTLP_ENDPOINT,
+#         OTEL_TRACES_SAMPLER, OTEL_SERVICE_NAME.
+#   M7 ingress.target failfast
+#       → helm template MUST FAIL with a clear error.
+#
+# This script does NOT need a Kind cluster — only `helm` + `yq`. Useful as
+# a fast PR gate.
+#
+# Env: CHART_PATH (must point to charts/aerospike-ce-kubernetes-operator)
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="helm-matrix"
+require_chart
+require_tool helm
+require_tool yq
+
+# ---- helm lint ----
+log_step "helm lint"
+out=$(helm lint "$CHART_PATH" 2>&1) || fail "$SCOPE" "helm lint failed: $out"
+log_ok "helm lint clean"
+
+render() {
+    # render <out_file> <set_args...>
+    local out="$1"; shift
+    helm template foo "$CHART_PATH" "$@" > "$out" 2>&1
+}
+
+# yq emits one document per match plus '---' separators; awk strips both
+# blank and '---' lines without erroring on empty input (which `grep -v` would
+# under `set -o pipefail`).
+strip_yaml_noise() { awk 'NF && $0 != "---"'; }
+
+deploy_names() {
+    yq -r 'select(.kind == "Deployment") | .metadata.name' "$1" | strip_yaml_noise
+}
+
+helm_test_count() {
+    yq -r 'select(.kind == "Pod" and .metadata.annotations["helm.sh/hook"] == "test") | .metadata.name' "$1" \
+        | strip_yaml_noise | wc -l | tr -d ' '
+}
+
+np_ports() {
+    yq -r 'select(.kind == "NetworkPolicy") | .spec.ingress[]?.ports[]?.port' "$1" \
+        | strip_yaml_noise | sort -u
+}
+
+api_env_value() {
+    # api_env_value <out_file> <ENV_NAME>
+    yq -r '
+        select(.kind == "Deployment" and .metadata.name == "foo-aerospike-ce-kubernetes-operator-ui-api")
+        | .spec.template.spec.containers[]
+        | select(.name == "api")
+        | .env[]
+        | select(.name == "'"$2"'")
+        | .value
+    ' "$1" 2>/dev/null | head -1
+}
+
+# ---- M1: operator-only ----
+log_step "M1: operator-only (--set ui.enabled=false)"
+m1=/tmp/m1-operator-only.yaml
+render "$m1" --set ui.enabled=false || fail "$SCOPE" "M1 helm template failed"
+deploys=$(deploy_names "$m1")
+echo "$deploys" | grep -qx 'foo-aerospike-ce-kubernetes-operator' || fail "$SCOPE" "M1 operator Deployment missing"
+echo "$deploys" | grep -q 'ui-api\|ui-web' && fail "$SCOPE" "M1 should have no UI Deployments, got: $deploys"
+yq -r 'select(.kind == "ServiceMonitor")' "$m1" | grep -q . && fail "$SCOPE" "M1 should have no ServiceMonitor"
+log_ok "M1 ok"
+
+# ---- M2: UI full ----
+log_step "M2: UI full (api + web + NetworkPolicy + helm-test)"
+m2=/tmp/m2-ui-full.yaml
+render "$m2" --set ui.enabled=true --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true \
+    || fail "$SCOPE" "M2 helm template failed"
+deploys=$(deploy_names "$m2")
+echo "$deploys" | grep -qx 'foo-aerospike-ce-kubernetes-operator-ui-api' || fail "$SCOPE" "M2 ui-api missing"
+echo "$deploys" | grep -qx 'foo-aerospike-ce-kubernetes-operator-ui-web' || fail "$SCOPE" "M2 ui-web missing"
+ports=$(np_ports "$m2")
+echo "$ports" | grep -qx 8000 || fail "$SCOPE" "M2 NetworkPolicy missing :8000 (got: $ports)"
+echo "$ports" | grep -qx 3100 || fail "$SCOPE" "M2 NetworkPolicy missing :3100 (got: $ports)"
+n_test=$(helm_test_count "$m2")
+assert_count ge 1 "$n_test" "M2 helm-test pod count"
+log_ok "M2 ok"
+
+# ---- M3: UI api-only ----
+log_step "M3: UI api-only"
+m3=/tmp/m3-ui-api-only.yaml
+render "$m3" --set ui.enabled=true --set ui.web.enabled=false --set ui.ingress.target=api \
+    --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true \
+    || fail "$SCOPE" "M3 helm template failed"
+deploys=$(deploy_names "$m3")
+echo "$deploys" | grep -qx 'foo-aerospike-ce-kubernetes-operator-ui-api' || fail "$SCOPE" "M3 ui-api missing"
+echo "$deploys" | grep -q 'ui-web' && fail "$SCOPE" "M3 should have no ui-web Deployment"
+ports=$(np_ports "$m3")
+echo "$ports" | grep -qx 8000 || fail "$SCOPE" "M3 NetworkPolicy missing :8000"
+echo "$ports" | grep -qx 3100 && fail "$SCOPE" "M3 NetworkPolicy must NOT contain :3100 (got: $ports)"
+log_ok "M3 ok"
+
+# ---- M4: UI web-only ----
+log_step "M4: UI web-only"
+m4=/tmp/m4-ui-web-only.yaml
+render "$m4" --set ui.enabled=true --set ui.api.enabled=false --set ui.web.env.apiUrl=http://x \
+    --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true \
+    || fail "$SCOPE" "M4 helm template failed"
+deploys=$(deploy_names "$m4")
+echo "$deploys" | grep -qx 'foo-aerospike-ce-kubernetes-operator-ui-web' || fail "$SCOPE" "M4 ui-web missing"
+echo "$deploys" | grep -q 'ui-api' && fail "$SCOPE" "M4 should have no ui-api Deployment"
+ports=$(np_ports "$m4")
+echo "$ports" | grep -qx 3100 || fail "$SCOPE" "M4 NetworkPolicy missing :3100"
+echo "$ports" | grep -qx 8000 && fail "$SCOPE" "M4 NetworkPolicy must NOT contain :8000"
+amst=$(yq -r 'select(.kind == "Deployment" and .metadata.name == "foo-aerospike-ce-kubernetes-operator-ui-web") | .spec.template.spec.automountServiceAccountToken' "$m4" | head -1)
+assert_eq "false" "$amst" "M4 ui-web automountServiceAccountToken=false"
+n_test=$(helm_test_count "$m4")
+assert_count eq 0 "$n_test" "M4 helm-test pod count (api disabled → no test pod)"
+log_ok "M4 ok"
+
+# ---- M5: OTel disabled (default) ----
+log_step "M5: OTel disabled (default)"
+m5=/tmp/m5-otel-default.yaml
+render "$m5" --set ui.enabled=true || fail "$SCOPE" "M5 helm template failed"
+val=$(api_env_value "$m5" OTEL_SDK_DISABLED)
+assert_eq "true" "$val" "M5 OTEL_SDK_DISABLED env"
+val=$(api_env_value "$m5" OTEL_EXPORTER_OTLP_ENDPOINT)
+[ -z "$val" ] || fail "$SCOPE" "M5 should not set OTEL_EXPORTER_OTLP_ENDPOINT (got '$val')"
+log_ok "M5 ok"
+
+# ---- M6: OTel enabled ----
+log_step "M6: OTel enabled"
+m6=/tmp/m6-otel-enabled.yaml
+render "$m6" --set ui.enabled=true --set ui.api.otel.enabled=true \
+    --set ui.api.otel.endpoint=http://col:4317 \
+    || fail "$SCOPE" "M6 helm template failed"
+assert_eq "false" "$(api_env_value "$m6" OTEL_SDK_DISABLED)"            "M6 OTEL_SDK_DISABLED"
+assert_eq "http://col:4317" "$(api_env_value "$m6" OTEL_EXPORTER_OTLP_ENDPOINT)" "M6 OTEL_EXPORTER_OTLP_ENDPOINT"
+[ -n "$(api_env_value "$m6" OTEL_TRACES_SAMPLER)" ] || fail "$SCOPE" "M6 OTEL_TRACES_SAMPLER not set"
+[ -n "$(api_env_value "$m6" OTEL_SERVICE_NAME)" ]    || fail "$SCOPE" "M6 OTEL_SERVICE_NAME not set"
+log_ok "M6 ok"
+
+# ---- M7: ingress.target failfast ----
+log_step "M7: ingress.target failfast (must FAIL)"
+m7=/tmp/m7-failfast.yaml
+if helm template foo "$CHART_PATH" \
+    --set ui.enabled=true --set ui.web.enabled=false --set ui.ingress.enabled=true \
+    > "$m7" 2>&1; then
+    fail "$SCOPE" "M7 helm template should have failed but succeeded"
+fi
+grep -qE 'ui\.ingress\.target' "$m7" \
+    || fail "$SCOPE" "M7 failed but error did not mention ui.ingress.target"
+log_ok "M7 fails as documented"
+
+pass "$SCOPE" "lint clean + 7/7 modes verified"

--- a/skills/acko-e2e-test/scripts/41-helm-real-install.sh
+++ b/skills/acko-e2e-test/scripts/41-helm-real-install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# 41-helm-real-install.sh — `helm install` + `helm test` + `helm uninstall`.
+#
+# `helm template` (40-helm-matrix.sh) catches manifest-level regressions but
+# misses things that only surface during apply: CRD ordering, hook race,
+# RBAC propagation, pre/post-install hooks. This script exercises those.
+#
+# Eval criteria (PASS when):
+#   1. helm install $RELEASE -n $TEST_NS succeeds (chart defaults)
+#   2. all pods reach Running
+#   3. helm test $RELEASE -n $TEST_NS passes (TEST SUITE Phase: Succeeded)
+#   4. helm uninstall + delete ns leaves no leftover state
+#
+# This deliberately uses a SEPARATE namespace (default: aerospike-operator-test)
+# and release name so it doesn't collide with the long-lived install used by
+# other scripts.
+#
+# Env: CHART_PATH
+# Flags: --release <n>  default: acko-test
+#        --ns <n>       default: aerospike-operator-test
+#        --image <repo> default: localhost/acko-controller (use whatever's loaded)
+#        --tag <t>      default: e2e
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="helm-real"
+require_chart
+
+release="acko-test"
+ns="aerospike-operator-test"
+img_repo="localhost/acko-controller"
+img_tag="e2e"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --release) release="$2"; shift 2 ;;
+        --ns) ns="$2"; shift 2 ;;
+        --image) img_repo="$2"; shift 2 ;;
+        --tag) img_tag="$2"; shift 2 ;;
+        *) fail "$SCOPE" "unknown flag: $1" ;;
+    esac
+done
+
+log_step "helm install $release -n $ns"
+helm install "$release" "$CHART_PATH" \
+    --namespace "$ns" --create-namespace \
+    --set "image.repository=$img_repo" \
+    --set "image.tag=$img_tag" \
+    --set image.pullPolicy=Never \
+    --wait --timeout 5m >&2 \
+    || fail "$SCOPE" "helm install failed"
+
+log_step "helm test $release"
+test_log=$(helm test "$release" -n "$ns" 2>&1) || {
+    log_err "$test_log"
+    helm uninstall "$release" -n "$ns" >&2 || true
+    kubectl delete ns "$ns" --ignore-not-found >&2 || true
+    fail "$SCOPE" "helm test failed"
+}
+echo "$test_log" | grep -q 'Phase:[[:space:]]*Succeeded' \
+    || fail "$SCOPE" "helm test output missing 'Phase: Succeeded'"
+log_ok "helm test passed"
+
+log_step "Cleanup (helm uninstall + delete ns)"
+helm uninstall "$release" -n "$ns" --wait --timeout 2m >&2 || true
+kubectl delete ns "$ns" --ignore-not-found --wait=false >&2 || true
+
+pass "$SCOPE" "release=$release install+test+uninstall ok"

--- a/skills/acko-e2e-test/scripts/60-diag-bundle.sh
+++ b/skills/acko-e2e-test/scripts/60-diag-bundle.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# 60-diag-bundle.sh — capture a diagnostic bundle for a failing run.
+#
+# Always call BEFORE 99-cleanup.sh — once the namespaces are gone, half of
+# this is unrecoverable. The orchestrator (run-all.sh) does this automatically
+# on any e2e:fail line.
+#
+# Output: a directory under $BUNDLE_DIR (default: /tmp/e2e-diag-<timestamp>)
+# containing:
+#   * state.txt          — kubectl get pods,asc,statefulset,configmap,pvc,pdb -A -o wide
+#   * describe-asc.txt   — kubectl describe asc -A
+#   * operator.log       — operator pod logs (--tail=2000)
+#   * api.log            — ui-api pod logs (--tail=2000)
+#   * api-prev.log       — previous container logs (if any)
+#   * events.txt         — kubectl get events -A --sort-by=lastTimestamp
+#   * crd.yaml           — both ACKO CRDs
+#   * webhook.yaml       — validating + mutating webhook configs
+#   * helm-values.yaml   — current release values (if a release exists)
+#   * collector.log      — last 200 lines (if otel namespace exists)
+#
+# Env: NS_OPERATOR, NS_OTEL, HELM_RELEASE, BUNDLE_DIR
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="diag-bundle"
+
+BUNDLE_DIR="${BUNDLE_DIR:-/tmp/e2e-diag-$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$BUNDLE_DIR"
+
+log_step "Capturing cluster state into $BUNDLE_DIR"
+
+kubectl get pods,asc,statefulset,configmap,pvc,pdb -A -o wide > "$BUNDLE_DIR/state.txt" 2>&1 || true
+kubectl describe asc -A > "$BUNDLE_DIR/describe-asc.txt" 2>&1 || true
+kubectl get events -A --sort-by='.lastTimestamp' > "$BUNDLE_DIR/events.txt" 2>&1 || true
+
+# Operator logs
+op_pod=$(kubectl get pod -n "$NS_OPERATOR" -l control-plane=controller-manager -o name 2>/dev/null | head -1 || true)
+if [ -n "$op_pod" ]; then
+    kubectl logs -n "$NS_OPERATOR" "$op_pod" --tail=2000 > "$BUNDLE_DIR/operator.log" 2>&1 || true
+fi
+
+# API + UI logs
+api_pod=$(kubectl get pod -n "$NS_OPERATOR" -l app.kubernetes.io/component=ui-api -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -n "$api_pod" ]; then
+    kubectl logs -n "$NS_OPERATOR" "$api_pod" -c api --tail=2000 > "$BUNDLE_DIR/api.log" 2>&1 || true
+    kubectl logs -n "$NS_OPERATOR" "$api_pod" -c api --tail=2000 --previous > "$BUNDLE_DIR/api-prev.log" 2>&1 || true
+fi
+
+# CRDs + webhook configs
+for crd in aerospikeclusters.acko.io aerospikeclustertemplates.acko.io; do
+    kubectl get crd "$crd" -o yaml >> "$BUNDLE_DIR/crd.yaml" 2>&1 || true
+done
+kubectl get validatingwebhookconfiguration -o yaml > "$BUNDLE_DIR/webhook.yaml" 2>&1 || true
+kubectl get mutatingwebhookconfiguration -o yaml >> "$BUNDLE_DIR/webhook.yaml" 2>&1 || true
+
+# Helm values
+if helm status "$HELM_RELEASE" -n "$NS_OPERATOR" >/dev/null 2>&1; then
+    helm get values "$HELM_RELEASE" -n "$NS_OPERATOR" > "$BUNDLE_DIR/helm-values.yaml" 2>&1 || true
+    helm get manifest "$HELM_RELEASE" -n "$NS_OPERATOR" > "$BUNDLE_DIR/helm-manifest.yaml" 2>&1 || true
+fi
+
+# Collector logs
+if ns_exists "$NS_OTEL"; then
+    kubectl logs -n "$NS_OTEL" deploy/otel-collector --tail=200 > "$BUNDLE_DIR/collector.log" 2>&1 || true
+fi
+
+n_files=$(find "$BUNDLE_DIR" -type f | wc -l | tr -d ' ')
+log_ok "captured $n_files files"
+pass "$SCOPE" "bundle=$BUNDLE_DIR files=$n_files"

--- a/skills/acko-e2e-test/scripts/99-cleanup.sh
+++ b/skills/acko-e2e-test/scripts/99-cleanup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# 99-cleanup.sh — tear down everything an e2e run created.
+#
+# Steps:
+#   1. helm uninstall release (if exists)
+#   2. delete ns aerospike, otel, cert-manager, aerospike-operator
+#   3. (optional) kind delete cluster — only when --kind is passed
+#
+# Env: KIND_CLUSTER, NS_OPERATOR, NS_AEROSPIKE, NS_OTEL, HELM_RELEASE
+# Flags: --kind  → also delete the Kind cluster
+# Exit: 0 (cleanup is best-effort; a missing resource is not a failure)
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="cleanup"
+
+KILL_KIND=0
+for a in "$@"; do
+    case "$a" in
+        --kind) KILL_KIND=1 ;;
+    esac
+done
+
+log_step "Uninstalling helm release if present"
+if helm status "$HELM_RELEASE" -n "$NS_OPERATOR" >/dev/null 2>&1; then
+    helm uninstall "$HELM_RELEASE" -n "$NS_OPERATOR" --wait --timeout 2m >&2 || true
+    log_ok "helm release '$HELM_RELEASE' uninstalled"
+else
+    log "no helm release '$HELM_RELEASE' in $NS_OPERATOR"
+fi
+
+log_step "Deleting test namespaces"
+for ns in "$NS_AEROSPIKE" "$NS_OTEL" "$NS_OPERATOR" cert-manager; do
+    if ns_exists "$ns"; then
+        kubectl delete ns "$ns" --ignore-not-found --wait=false >&2 || true
+        log_ok "delete ns/$ns scheduled"
+    fi
+done
+
+# Best-effort wait so a follow-up `helm install` doesn't trip on a still-Terminating ns.
+for ns in "$NS_AEROSPIKE" "$NS_OTEL" "$NS_OPERATOR" cert-manager; do
+    deadline=$(( $(date +%s) + 60 ))
+    while ns_exists "$ns" && [ "$(date +%s)" -lt "$deadline" ]; do
+        sleep 2
+    done
+done
+
+if [ "$KILL_KIND" -eq 1 ]; then
+    log_step "Deleting Kind cluster '$KIND_CLUSTER'"
+    kind delete cluster --name "$KIND_CLUSTER" >&2 || true
+    pass "$SCOPE" "namespaces removed, Kind cluster '$KIND_CLUSTER' deleted"
+fi
+
+pass "$SCOPE" "namespaces removed (Kind cluster preserved — pass --kind to also delete)"

--- a/skills/acko-e2e-test/scripts/lib.sh
+++ b/skills/acko-e2e-test/scripts/lib.sh
@@ -1,0 +1,226 @@
+# shellcheck shell=bash
+# Shared helpers for ACKO e2e scripts. Source from every script:
+#   source "$(dirname "$0")/lib.sh"
+#
+# Output contract every script honors:
+#   * On success, the LAST line on stdout MUST be:   e2e:pass[scope=<name>] <one-line summary>
+#   * On failure, the LAST line on stdout MUST be:   e2e:fail[scope=<name>] reason: <one-liner>
+#   Exit code matches (0 / non-zero).
+#
+# The orchestrator (run-all.sh) parses these lines to assemble the final report.
+# Diagnostics, kubectl output, etc. go to STDERR so they don't pollute the contract.
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Defaults — override via env. We intentionally match the values that ACKO's
+# Makefile and BeforeSuite hardcode so scripts compose without surprises.
+# --------------------------------------------------------------------------
+: "${KIND_CLUSTER:=aerospike-ce-kubernetes-operator-test-e2e}"
+: "${CONTAINER_TOOL:=podman}"
+: "${KIND_PROVIDER:=podman}"
+: "${KIND_EXPERIMENTAL_PROVIDER:=$KIND_PROVIDER}"
+: "${NS_OPERATOR:=aerospike-operator}"
+: "${NS_AEROSPIKE:=aerospike}"
+: "${NS_OTEL:=otel}"
+: "${HELM_RELEASE:=acko}"
+# IMG matches test/e2e/e2e_suite_test.go:47 — BeforeSuite hardcodes this tag.
+# Pre-loading any other tag is wasted work because Ginkgo will re-build with
+# this name anyway.
+: "${IMG:=ghcr.io/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator:v0.0.1}"
+: "${API_IMG:=ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api:latest}"
+: "${OPERATOR_REPO:=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../aerospike-ce-kubernetes-operator" 2>/dev/null && pwd || echo "")}"
+: "${CHART_PATH:=${OPERATOR_REPO}/charts/aerospike-ce-kubernetes-operator}"
+: "${CERT_MANAGER_VERSION:=v1.19.3}"
+: "${COLLECTOR_IMAGE:=docker.io/otel/opentelemetry-collector-contrib:latest}"
+
+export KIND_CLUSTER CONTAINER_TOOL KIND_PROVIDER KIND_EXPERIMENTAL_PROVIDER
+
+# --------------------------------------------------------------------------
+# Logging — colored to stderr, contract lines to stdout.
+# --------------------------------------------------------------------------
+if [ -t 2 ]; then
+    _C_RESET=$'\033[0m'; _C_INFO=$'\033[36m'; _C_WARN=$'\033[33m'
+    _C_ERR=$'\033[31m'; _C_OK=$'\033[32m'; _C_BOLD=$'\033[1m'
+else
+    _C_RESET=''; _C_INFO=''; _C_WARN=''; _C_ERR=''; _C_OK=''; _C_BOLD=''
+fi
+
+log()       { printf '%s[%s]%s %s\n' "$_C_INFO"  "$(date +%H:%M:%S)" "$_C_RESET" "$*" >&2; }
+log_warn()  { printf '%s[%s WARN]%s %s\n' "$_C_WARN" "$(date +%H:%M:%S)" "$_C_RESET" "$*" >&2; }
+log_err()   { printf '%s[%s ERR]%s %s\n'  "$_C_ERR"  "$(date +%H:%M:%S)" "$_C_RESET" "$*" >&2; }
+log_step()  { printf '%s[%s]%s %s%s%s\n' "$_C_INFO" "$(date +%H:%M:%S)" "$_C_RESET" "$_C_BOLD" "$*" "$_C_RESET" >&2; }
+log_ok()    { printf '%s[%s OK]%s %s\n'  "$_C_OK"   "$(date +%H:%M:%S)" "$_C_RESET" "$*" >&2; }
+
+# Final contract emitter. Use these — never raw printf for the contract line.
+pass() {
+    local scope="$1"; shift
+    printf 'e2e:pass[scope=%s] %s\n' "$scope" "$*"
+    exit 0
+}
+fail() {
+    local scope="$1"; shift
+    printf 'e2e:fail[scope=%s] reason: %s\n' "$scope" "$*"
+    exit 1
+}
+
+# --------------------------------------------------------------------------
+# Asserts — print a clean error context and call fail(scope, ...).
+# Each assert needs the caller to have set $SCOPE so failures route properly.
+# --------------------------------------------------------------------------
+: "${SCOPE:=unknown}"
+
+assert_eq() {
+    # assert_eq <expected> <actual> <description>
+    local expected="$1" actual="$2" desc="$3"
+    if [ "$expected" != "$actual" ]; then
+        log_err "$desc — expected '$expected', got '$actual'"
+        fail "$SCOPE" "$desc (expected='$expected', got='$actual')"
+    fi
+    log_ok "$desc (= '$expected')"
+}
+
+assert_match() {
+    # assert_match <regex> <text> <description>
+    local re="$1" text="$2" desc="$3"
+    if ! grep -qE "$re" <<<"$text"; then
+        log_err "$desc — pattern '$re' not in text"
+        log_err "  text: $(echo "$text" | head -3)"
+        fail "$SCOPE" "$desc (pattern='$re' not matched)"
+    fi
+    log_ok "$desc (matches '$re')"
+}
+
+assert_count() {
+    # assert_count <op> <expected> <actual> <description>
+    # op: eq, ge, le, gt, lt
+    local op="$1" expected="$2" actual="$3" desc="$4" ok=0
+    case "$op" in
+        eq) [ "$actual" -eq "$expected" ] && ok=1 ;;
+        ge) [ "$actual" -ge "$expected" ] && ok=1 ;;
+        le) [ "$actual" -le "$expected" ] && ok=1 ;;
+        gt) [ "$actual" -gt "$expected" ] && ok=1 ;;
+        lt) [ "$actual" -lt "$expected" ] && ok=1 ;;
+        *) fail "$SCOPE" "assert_count: unknown op '$op'" ;;
+    esac
+    if [ "$ok" -ne 1 ]; then
+        log_err "$desc — expected $op $expected, got $actual"
+        fail "$SCOPE" "$desc (op=$op expected=$expected actual=$actual)"
+    fi
+    log_ok "$desc ($actual $op $expected)"
+}
+
+assert_http() {
+    # assert_http <expected_status> <method> <url> [curl_extra_args...]
+    local expected="$1" method="$2" url="$3"; shift 3
+    local actual
+    actual=$(curl -sS -o /dev/null -w '%{http_code}' -X "$method" "$@" "$url" || echo "000")
+    if [ "$actual" != "$expected" ]; then
+        log_err "$method $url — expected HTTP $expected, got $actual"
+        fail "$SCOPE" "$method $url got $actual (want $expected)"
+    fi
+    log_ok "$method $url → $actual"
+}
+
+# --------------------------------------------------------------------------
+# Polling helpers
+# --------------------------------------------------------------------------
+wait_for() {
+    # wait_for <timeout_sec> <interval_sec> <description> -- <command...>
+    local timeout="$1" interval="$2" desc="$3"; shift 3
+    [ "$1" = "--" ] && shift
+    local deadline=$(( $(date +%s) + timeout ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if "$@" >/dev/null 2>&1; then
+            log_ok "$desc (within $timeout s)"
+            return 0
+        fi
+        sleep "$interval"
+    done
+    log_err "$desc — timeout after $timeout s"
+    fail "$SCOPE" "$desc (timeout after ${timeout}s)"
+}
+
+wait_phase_completed() {
+    # wait_phase_completed <ns> <asc-name> <timeout_sec>
+    local ns="$1" name="$2" timeout="${3:-180}"
+    local deadline=$(( $(date +%s) + timeout ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        local phase
+        phase=$(kubectl get asc -n "$ns" "$name" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+        if [ "$phase" = "Completed" ]; then
+            log_ok "asc/$name in ns/$ns reached Completed"
+            return 0
+        fi
+        log "asc/$name phase=$phase, waiting…"
+        sleep 5
+    done
+    fail "$SCOPE" "asc/$name did not reach Completed within ${timeout}s"
+}
+
+# --------------------------------------------------------------------------
+# Tooling guards
+# --------------------------------------------------------------------------
+require_tool() {
+    local t="$1"
+    command -v "$t" >/dev/null 2>&1 || fail "${SCOPE:-prereqs}" "missing tool: $t"
+}
+
+require_chart() {
+    [ -d "$CHART_PATH" ] || fail "${SCOPE:-prereqs}" "chart not found at $CHART_PATH (override CHART_PATH)"
+}
+
+# --------------------------------------------------------------------------
+# Port-forward management — every script that opens a PF must register the
+# PID via pf_register so pf_cleanup_all kills it on exit.
+# --------------------------------------------------------------------------
+# bash 3.2 (macOS default) doesn't support `declare -g`, but top-level array
+# assignment is already global, so the bare form is fine.
+_PF_PIDS=()
+
+pf_open() {
+    # pf_open <ns> <svc> <local_port> <svc_port> — returns the PID on stdout
+    local ns="$1" svc="$2" local_port="$3" svc_port="$4"
+    local logfile="/tmp/pf-${svc}-${local_port}.log"
+    : > "$logfile"
+    kubectl port-forward -n "$ns" "svc/$svc" "${local_port}:${svc_port}" >"$logfile" 2>&1 &
+    local pid=$!
+    _PF_PIDS+=("$pid")
+    # Wait briefly for the forward to be ready
+    local deadline=$(( $(date +%s) + 10 ))
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if grep -q "Forwarding from" "$logfile" 2>/dev/null; then
+            echo "$pid"
+            return 0
+        fi
+        sleep 0.3
+    done
+    fail "$SCOPE" "port-forward to svc/$svc:$svc_port did not become ready"
+}
+
+pf_cleanup_all() {
+    local pid
+    for pid in "${_PF_PIDS[@]:-}"; do
+        [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+    done
+    _PF_PIDS=()
+}
+
+trap 'pf_cleanup_all' EXIT
+
+# --------------------------------------------------------------------------
+# Misc
+# --------------------------------------------------------------------------
+ns_exists() { kubectl get ns "$1" >/dev/null 2>&1; }
+
+# Returns 0 if a deploy is Available with all replicas Ready.
+deploy_ready() {
+    local ns="$1" name="$2"
+    kubectl wait --for=condition=Available "deploy/$name" -n "$ns" --timeout=1s >/dev/null 2>&1
+}
+
+# Stable hostname helper — Aerospike service inside a cluster.
+asc_seed_host() {
+    # asc_seed_host <asc-name> <ns>
+    printf '%s.%s.svc.cluster.local' "$1" "$2"
+}

--- a/skills/acko-e2e-test/scripts/run-all.sh
+++ b/skills/acko-e2e-test/scripts/run-all.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# run-all.sh — orchestrate a full ACKO e2e run.
+#
+# Each step is one of the numbered scripts. We tally e2e:pass / e2e:fail lines
+# and print the standard SKILL.md Section 8 report at the end.
+#
+# Modes:
+#   smoke      40 → 41 → 10 → 11 → 12 → 21 → 30 → 33 → 31 → 32 → 99 (no Ginkgo)
+#   full       40 → 41 → 10 → 11 → 12 → 21 → 30 → 33 → 31 → 32 → 20[full] → 99
+#   chart      40 → 41 (no cluster work; fast PR gate)
+#   ginkgo     10 → 20[<mode>] → 99[--kind]
+#
+# Flags:
+#   --mode <m>           default: full
+#   --ginkgo-mode <m>    forwarded to 20-ginkgo.sh (smoke|full|heavy|focus:<re>)
+#   --tear-down-kind     also delete the Kind cluster at the end
+#   --skip-prereqs       skip 00-prereqs.sh (you already validated)
+#   --bundle-on-fail     capture diag bundle when any step fails (default: on)
+#
+# Exit: 0 if every executed step PASSed, 1 otherwise.
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+SCOPE="run-all"
+
+mode="full"
+ginkgo_mode="full"
+tear_down=0
+skip_prereqs=0
+bundle=1
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mode) mode="$2"; shift 2 ;;
+        --ginkgo-mode) ginkgo_mode="$2"; shift 2 ;;
+        --tear-down-kind) tear_down=1; shift ;;
+        --skip-prereqs) skip_prereqs=1; shift ;;
+        --bundle-on-fail) bundle=1; shift ;;
+        --no-bundle) bundle=0; shift ;;
+        *) fail "$SCOPE" "unknown flag: $1" ;;
+    esac
+done
+
+scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+declare -a results=()      # "pass:scope:summary" or "fail:scope:reason"
+declare -a failed_steps=()
+overall_start=$(date +%s)
+
+run_step() {
+    # run_step <script_name> [args...]
+    local script="$1"; shift
+    local path="$scripts_dir/$script"
+    [ -x "$path" ] || chmod +x "$path"
+
+    local label="${script%.sh}"
+    log_step ">>> $label $* <<<"
+    local out_file="/tmp/run-all-${label}.out"
+    local rc=0
+    "$path" "$@" 2>&1 | tee "$out_file" >&2 || rc=$?
+    # Parse the contract line (last e2e:pass or e2e:fail)
+    local contract
+    contract=$(grep -E '^e2e:(pass|fail)\[' "$out_file" | tail -1 || true)
+    if [[ "$contract" == e2e:pass* ]]; then
+        local scope summary
+        scope=$(echo "$contract" | sed -E 's/^e2e:pass\[scope=([^]]+)\].*$/\1/')
+        summary=$(echo "$contract" | sed -E 's/^e2e:pass\[scope=[^]]+\] *//')
+        results+=("pass:$scope:$summary")
+        log_ok "$label PASS — $summary"
+        return 0
+    elif [[ "$contract" == e2e:fail* ]]; then
+        local scope reason
+        scope=$(echo "$contract" | sed -E 's/^e2e:fail\[scope=([^]]+)\].*$/\1/')
+        reason=$(echo "$contract" | sed -E 's/^e2e:fail\[scope=[^]]+\] reason: *//')
+        results+=("fail:$scope:$reason")
+        failed_steps+=("$label")
+        log_err "$label FAIL — $reason"
+        return 1
+    else
+        results+=("fail:$label:no contract line in output")
+        failed_steps+=("$label")
+        log_err "$label produced no contract line (rc=$rc)"
+        return 1
+    fi
+}
+
+declare -a sequence=()
+case "$mode" in
+    smoke)
+        sequence=(40-helm-matrix.sh 41-helm-real-install.sh 10-kind-up.sh 11-cert-manager.sh \
+                  12-helm-install.sh 21-asc-create-smoke.sh:--keep 30-api-crud-smoke.sh \
+                  33-api-k8s-create-smoke.sh 31-logging.sh 32-otel-runtime.sh 99-cleanup.sh)
+        ;;
+    full)
+        sequence=(40-helm-matrix.sh 41-helm-real-install.sh 10-kind-up.sh 11-cert-manager.sh \
+                  12-helm-install.sh 21-asc-create-smoke.sh:--keep 30-api-crud-smoke.sh \
+                  33-api-k8s-create-smoke.sh 31-logging.sh 32-otel-runtime.sh \
+                  99-cleanup.sh 20-ginkgo.sh:--mode:full)
+        ;;
+    chart)
+        sequence=(40-helm-matrix.sh)
+        ;;
+    ginkgo)
+        sequence=(10-kind-up.sh "20-ginkgo.sh:--mode:$ginkgo_mode")
+        ;;
+    *)
+        fail "$SCOPE" "unknown --mode '$mode' (smoke|full|chart|ginkgo)"
+        ;;
+esac
+
+[ "$skip_prereqs" -eq 0 ] && run_step 00-prereqs.sh
+
+trap 'true' ERR
+last_rc=0
+for entry in "${sequence[@]}"; do
+    # Allow inline args separated by ':'
+    IFS=':' read -ra parts <<<"$entry"
+    script="${parts[0]}"
+    args=("${parts[@]:1}")
+    # bash 3.2 + set -u: ${args[@]} on empty array is "unbound"; use the
+    # ${arr[@]+"${arr[@]}"} idiom to expand safely.
+    if ! run_step "$script" ${args[@]+"${args[@]}"}; then
+        last_rc=1
+        # Don't abort on chart failures or cleanup failures, but DO abort if a
+        # setup step (10/11/12) fails — later steps would just cascade.
+        case "$script" in
+            10-kind-up.sh|11-cert-manager.sh|12-helm-install.sh)
+                log_err "setup step failed — aborting remaining sequence"
+                break
+                ;;
+        esac
+    fi
+done
+
+# Collect diagnostics if anything failed
+if [ "$last_rc" -ne 0 ] && [ "$bundle" -eq 1 ]; then
+    log_step "Collecting diagnostic bundle"
+    "$scripts_dir/60-diag-bundle.sh" >&2 || true
+fi
+
+# Optional: kind teardown
+if [ "$tear_down" -eq 1 ]; then
+    "$scripts_dir/99-cleanup.sh" --kind >&2 || true
+fi
+
+# ---- Final report (Section 8 format) ----
+overall_dur=$(( $(date +%s) - overall_start ))
+n_pass=$(printf '%s\n' "${results[@]}" | grep -c '^pass:' || true)
+n_fail=$(printf '%s\n' "${results[@]}" | grep -c '^fail:' || true)
+total=${#results[@]}
+
+branch=$(git -C "$OPERATOR_REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+sha=$(git -C "$OPERATOR_REPO" rev-parse --short HEAD 2>/dev/null || echo unknown)
+date_iso=$(date -u +%Y-%m-%dT%H:%MZ)
+
+printf '\n========================================================================\n'
+printf 'e2e run on %s@%s — %s\n' "$branch" "$sha" "$date_iso"
+printf 'Mode:        %s\n' "$mode"
+printf 'Duration:    %sm %ss\n' "$((overall_dur / 60))" "$((overall_dur % 60))"
+printf 'Outcome:     %s\n\n' "$([ "$last_rc" -eq 0 ] && echo PASS || echo FAIL)"
+
+printf 'Steps: %d passed, %d failed (of %d total)\n\n' "$n_pass" "$n_fail" "$total"
+for r in "${results[@]}"; do
+    case "$r" in
+        pass:*) printf '  ✅ %-22s %s\n' "$(echo "$r" | cut -d: -f2)" "$(echo "$r" | cut -d: -f3-)" ;;
+        fail:*) printf '  ❌ %-22s %s\n' "$(echo "$r" | cut -d: -f2)" "$(echo "$r" | cut -d: -f3-)" ;;
+    esac
+done
+
+if [ "${#failed_steps[@]}" -gt 0 ]; then
+    printf '\nFailed steps: %s\n' "${failed_steps[*]}"
+    printf 'Per-step output:  /tmp/run-all-<step>.out\n'
+    printf 'Diagnostic bundle: ls /tmp/e2e-diag-* 2>/dev/null | tail -1\n'
+fi
+
+printf '========================================================================\n'
+
+exit "$last_rc"


### PR DESCRIPTION
## Summary

`skills/acko-e2e-test/`를 **자연어 평가 컨트랙트(SKILL.md) + 실행 스크립트(`scripts/`)** 로 분리. 332→228 lines로 슬림화하면서 inline bash blob을 모두 스크립트화. 각 스크립트는 마지막 stdout 줄로 표준 컨트랙트를 출력:

```
e2e:pass[scope=<name>] <one-line summary>
e2e:fail[scope=<name>] reason: <one-liner>
```

`scripts/run-all.sh`가 이 컨트랙트를 파싱해 표준 보고서(`Section 8` 포맷)를 만듭니다.

## What changed

### `scripts/` (16 files, 1,700 lines)

| Script | 역할 | scope |
|--------|------|-------|
| `lib.sh` | 공통: 로깅·asserts·port-forward·env 기본값 | (sourced) |
| `00-prereqs.sh` | tool 버전, podman runtime, chart reachability | `prereqs` |
| `10-kind-up.sh` | `make setup-test-e2e` + `docker-build` + `kind load` | `kind-up` |
| `11-cert-manager.sh` | cert-manager $CERT_MANAGER_VERSION 설치 | `cert-manager` |
| `12-helm-install.sh` | parametric `helm install` (`--image / --tag / --otel / --log-format`) | `helm-install` |
| `20-ginkgo.sh` | `go test ./test/e2e/` 직접 호출 (Kind 클러스터 보존) | `ginkgo` |
| `21-asc-create-smoke.sh` | 1-node 빠른 생성/검증/삭제 (PR 게이트, api smoke prereq) | `asc-create` |
| `30-api-crud-smoke.sh` | UI api CRUD A–G (cluster-manager #257–#260 회귀 가드) | `api-crud` |
| `31-logging.sh` | text/json LOG_FORMAT + X-Request-ID 상관관계 | `logging` |
| `32-otel-runtime.sh` | collector + 트래픽 + parent/child span (cluster-manager #265 가드) | `otel-runtime` |
| `33-api-k8s-create-smoke.sh` | **신규**: api 경유 AerospikeCluster CRUD | `api-k8s-create` |
| `40-helm-matrix.sh` | `helm lint` + 7-mode `helm template` 단정 (cluster 불필요) | `helm-matrix` |
| `41-helm-real-install.sh` | `helm install` + `helm test` + uninstall | `helm-real` |
| `60-diag-bundle.sh` | 실패 시 진단 번들 캡처 | `diag-bundle` |
| `99-cleanup.sh` | helm uninstall + ns 삭제 (`--kind`로 클러스터까지) | `cleanup` |
| `run-all.sh` | 오케스트레이터: `--mode {chart, smoke, full, ginkgo}` | `run-all` |

### SKILL.md

- 모든 inline `kubectl` / `curl` / `helm template` 블록 제거
- 각 섹션을 평가 컨트랙트(자연어) + 매핑되는 `scripts/X.sh`로 변경
- Run modes / Common failures / Reporting Format은 보존 (참조용)
- 스크립트 매핑 표 추가

### 33-api-k8s-create-smoke.sh가 새로 추가된 이유

UI에서 cluster를 생성하는 실제 사용자 경로(`POST /api/v1/k8s/clusters`)가 그동안 e2e에서 한 번도 검증된 적이 없었습니다. Ginkgo는 `kubectl apply` 경로만 다루고, 30-api-crud는 read 위주라 create write가 비어있었음.

## Why this shape

1. **드리프트 자동 감지** — 차트 매트릭스 행 "operator-only (defaults)"이 stale였던 사례처럼, 단정이 코드에 박혀있으면 다음 PR 매트릭스 실행에서 즉시 빨간불.
2. **중복 디버깅 제거** — collector 이미지 0.115.0이 docker.io에서 없어진 사례, 시스템 python3로 OTel 패키지 점검한 오진 등을 다음 사람이 다시 디버깅하지 않도록 스크립트가 처리.
3. **회귀 가드** — `32-otel-runtime.sh`는 cluster-manager #265(FastAPIInstrumentor 누락) 회귀를 자동 잡아내고, `30-api-crud-smoke.sh`는 #257–#260을 매 릴리즈에서 재확인.

## Verification

- [x] `bash -n` 16/16 syntax pass
- [x] macOS bash 3.2.57(1) 호환 (declare -g 제거, `${arr[@]+"${arr[@]}"}` idiom)
- [x] `./scripts/00-prereqs.sh` 단독 PASS
- [x] `./scripts/40-helm-matrix.sh` 단독 PASS (lint + 7/7 modes)
- [x] `./scripts/run-all.sh --mode chart` PASS (표준 보고서 출력 정상)
- [ ] `--mode smoke` 전체 실행 (다음 단계, 실제 클러스터 필요)
- [ ] `--mode full` 전체 실행 (릴리즈 검증 시점)

## Test plan

```bash
cd skills/acko-e2e-test

# Fast PR gate (no cluster, ~1 min)
./scripts/run-all.sh --mode chart

# Smoke (cluster + api + OTel, ~10 min)
./scripts/run-all.sh --mode smoke

# Full (smoke + Ginkgo full suite, ~30–45 min)
./scripts/run-all.sh --mode full
```

## Notes

- 스크립트들은 `${OPERATOR_REPO}` 기본값으로 `../../../../aerospike-ce-kubernetes-operator`를 잡지만, 워크스페이스 외부에서는 `OPERATOR_REPO=/path/to/repo` 명시 필요.
- 첫 머지 후 한 번 `--mode smoke` 또는 `--mode full`을 돌려 실제 클러스터에서도 컨트랙트가 일치하는지 확인 권장.