### PR TITLE
docs(aerospike-py-api): add PK regex filter scan guide and REGEX_* constants

### DIFF
--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -153,17 +153,27 @@ Predicates: `p.equals(bin, val)`, `p.between(bin, min, max)`, `p.contains(bin, i
 Server-side filtering (Aerospike 5.2+). No secondary index required. Policy key: `"filter_expression"`.
 
 ```python
+import aerospike_py
 from aerospike_py import exp
+
 expr = exp.and_(exp.gt(exp.int_bin("age"), exp.int_val(18)),
                 exp.eq(exp.string_bin("status"), exp.string_val("active")))
 record = client.get(key, policy={"filter_expression": expr})
 
-# Also: exp.bin_exists("f"), exp.ttl(), exp.regex_compare(r"^u_", 0, exp.string_bin("n"))
+# Regex (use REGEX_* constants, not magic integers):
+exp.regex_compare(r"^u_", aerospike_py.REGEX_NONE, exp.string_bin("n"))
+
+# PK regex filter scan (Java client Exp.regexCompare(..., Exp.key(...)) equivalent).
+# Requires POLICY_KEY_SEND on writes; performs a full set scan with server-side
+# filtering — NOT a primary-index lookup.
+exp.regex_compare("^aaa.*", aerospike_py.REGEX_NONE, exp.key(exp.EXP_TYPE_STRING))
+
+# Also: exp.bin_exists("f"), exp.ttl()
 # Variable binding: exp.let_(exp.def_("x", exp.int_bin("a")), exp.gt(exp.var("x"), exp.int_val(10)))
 # Works with: get, put, batch_read, query.results, operate
 ```
 
-Detail: `./reference/read.md`
+Detail: `./reference/read.md` · Constants: `./reference/constants.md` (Regex Flags)
 
 ## 10. Admin & Infrastructure
 

--- a/skills/aerospike-py-api/reference/constants.md
+++ b/skills/aerospike-py-api/reference/constants.md
@@ -27,6 +27,7 @@ All constants are importable from `aerospike_py`.
   - [Index Data Type](#index-data-type)
   - [Index Collection Type](#index-collection-type)
 - [Privilege Constants](#privilege-constants)
+- [Regex Flags](#regex-flags)
 - [Auth & Log Constants](#auth--log-constants)
   - [Auth Mode](#auth-mode)
   - [Log Level](#log-level)
@@ -256,6 +257,32 @@ For use with `operate()` and `operate_ordered()`.
 | PRIV_READ_WRITE_UDF | 12 | Read-write with UDF |
 | PRIV_WRITE | 13 | Write privilege |
 | PRIV_TRUNCATE | 14 | Truncate privilege |
+
+---
+
+## Regex Flags
+
+Used as the `flags` argument to `exp.regex_compare(pattern, flags, bin_expr)`.
+Values mirror POSIX `regex.h` and can be combined with bitwise OR.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| REGEX_NONE | 0 | Use regex defaults |
+| REGEX_EXTENDED | 1 | POSIX extended regular expression syntax |
+| REGEX_ICASE | 2 | Case-insensitive matching |
+| REGEX_NOSUB | 4 | Do not report match positions |
+| REGEX_NEWLINE | 8 | `.` does not match newline |
+
+```python
+import aerospike_py
+from aerospike_py import exp
+
+expr = exp.regex_compare(
+    "^aaa.*",
+    aerospike_py.REGEX_ICASE | aerospike_py.REGEX_NEWLINE,
+    exp.string_bin("name"),
+)
+```
 
 ---
 

--- a/skills/aerospike-py-api/reference/read.md
+++ b/skills/aerospike-py-api/reference/read.md
@@ -307,7 +307,18 @@ All take `(left, right)` and return a boolean expression.
 | `regex_compare(regex, flags, bin_expr)` | Regex match on string expression |
 | `geo_compare(left, right)` | Geospatial contains/within comparison |
 
-`regex_compare` flags: `0` = default, `1` = extended, `2` = icase, `4` = nosub, `8` = newline.
+`regex_compare` flags are exposed as module-level constants on `aerospike_py`
+(values mirror POSIX `regex.h`):
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `REGEX_NONE` | 0 | Defaults |
+| `REGEX_EXTENDED` | 1 | POSIX extended syntax |
+| `REGEX_ICASE` | 2 | Case-insensitive |
+| `REGEX_NOSUB` | 4 | Don't report match position |
+| `REGEX_NEWLINE` | 8 | `.` doesn't match newline |
+
+Combine with `|`: `REGEX_ICASE | REGEX_NEWLINE`. Avoid passing magic integers.
 
 ### Control Flow
 
@@ -355,13 +366,49 @@ expr = exp.cond(
 #### Regex and Geo
 
 ```python
-expr = exp.regex_compare(r"^user_\d+$", 0, exp.string_bin("username"))
+import aerospike_py
+expr = exp.regex_compare(
+    r"^user_\d+$", aerospike_py.REGEX_NONE, exp.string_bin("username"))
 
 expr = exp.geo_compare(
     exp.geo_bin("location"),
     exp.geo_val('{"type":"AeroCircle","coordinates":[[-122.0,37.5],5000.0]}'),
 )
 ```
+
+#### PK Regex Filter Scan
+
+Filter records by a regex match on the **user key** (PK). Equivalent to
+the Java client's `Exp.regexCompare(pattern, RegexFlag.NONE, Exp.key(Exp.Type.STRING))`.
+
+```python
+import aerospike_py
+from aerospike_py import exp
+
+# Records must be written with POLICY_KEY_SEND so the user key is stored.
+client.put(("test", "users", "aaa001"), {"v": 1},
+           policy={"key": aerospike_py.POLICY_KEY_SEND})
+
+expr = exp.regex_compare(
+    "^aaa.*",
+    aerospike_py.REGEX_NONE,
+    exp.key(exp.EXP_TYPE_STRING),
+)
+records = client.query("test", "users").results(
+    policy={"filter_expression": expr})
+for r in records:
+    print(r.key.user_key, r.bins)
+```
+
+Operational notes:
+
+- This is a **full set scan + server-side filter**, not a primary-index lookup.
+  Aerospike's primary index keys on the digest, not the user key string —
+  there is no PK B-tree range scan.
+- Records written without `POLICY_KEY_SEND` have no stored user key and never
+  match a `key()` expression (the scan returns an empty list).
+- Avoid for hot-path prefix lookups on large sets. For production prefix
+  search, model with a separate prefix bin + secondary index, or a lookup-set.
 
 #### Metadata Filters
 


### PR DESCRIPTION
## Summary

- Document the **PK regex filter scan** pattern (`exp.regex_compare(pat, flags, exp.key(EXP_TYPE_STRING))`) as a first-class section in the `aerospike-py-api` skill, with the Java client equivalence explicitly called out.
- Replace magic-integer regex flags (`0`, `2`) with the new `REGEX_NONE/EXTENDED/ICASE/NOSUB/NEWLINE` constants exposed by aerospike-ce-ecosystem/aerospike-py#338.
- Add a "Regex Flags" section to `constants.md`.

## Changes

| File | Change |
|---|---|
| `skills/aerospike-py-api/reference/read.md` | Constants table for regex flags; new "PK Regex Filter Scan" subsection with operational caveats |
| `skills/aerospike-py-api/reference/constants.md` | New "Regex Flags" section + ToC entry |
| `skills/aerospike-py-api/SKILL.md` | §9 rewritten: regex example now uses `REGEX_NONE`; PK regex pattern added with caveat link |

## Operational caveats (mirrored in skill)

- **Not a PK index scan**: full set scan + server-side filter. Aerospike's primary index keys on the digest, not the user key string — there is no PK B-tree range scan.
- **`POLICY_KEY_SEND` required at write time**: records without a stored user key never match a `key()` expression.
- **Avoid on hot paths**: prefer a separate prefix bin + secondary index, or a lookup-set, for production prefix lookups.

## Cross-repo

- Depends on aerospike-ce-ecosystem/aerospike-py#338 (`REGEX_*` constants exposure). Merge order: aerospike-py PR first, then this PR.
- Cluster Manager UI exposure tracked at aerospike-ce-ecosystem/aerospike-cluster-manager#287 (independent).

## Test plan

- [ ] Render-check the skill locally (`SKILL.md`, `reference/read.md`, `reference/constants.md`) — markdown renders cleanly, ToC anchors resolve.
- [ ] Skill triggers correctly on prompts like "PK regex search with aerospike-py" and surfaces the new section.
- [ ] After aerospike-py PR ships, copy/paste the documented snippet against a local Aerospike CE — verify the prefix match returns only matching records and that records without `POLICY_KEY_SEND` are excluded.