### PR TITLE
docs(aerospike-py-api): cross-link Secondary Index alternative on PK regex notes

### DIFF
--- a/skills/aerospike-py-api/reference/read.md
+++ b/skills/aerospike-py-api/reference/read.md
@@ -429,7 +429,12 @@ Operational notes:
 - Records written without `POLICY_KEY_SEND` have no stored user key and never
   match a `key()` expression (the scan returns an empty list).
 - Avoid for hot-path prefix lookups on large sets. For production prefix
-  search, model with a separate prefix bin + secondary index, or a lookup-set.
+  search, denormalize a fixed-width prefix bin (e.g. `name_prefix_3 = name[:3]`)
+  and index it with `INDEX_STRING`, then query via
+  [Query & Secondary Index](#query--secondary-index) using
+  `predicates.equals("name_prefix_3", "aaa")` — Aerospike string SI supports
+  equality only (no range/prefix), so the prefix must be materialized at
+  write time. Alternatively, use a lookup-set keyed by the prefix.
 
 #### Metadata Filters
 


### PR DESCRIPTION
Closes #12.

Follow-up to #11. The PK Regex Filter Scan section's operational notes recommend "prefix bin + secondary index" without telling readers what that pattern actually looks like. This PR concretizes the recommendation and corrects an implicit assumption.

## Change

`skills/aerospike-py-api/reference/read.md` — replace the one-line bullet with a precise pattern: denormalize a fixed-width prefix bin (e.g. `name_prefix_3 = name[:3]`), index it with `INDEX_STRING`, query via `predicates.equals("name_prefix_3", "aaa")`. Cross-links the [Query & Secondary Index](#query--secondary-index) section.

## Why this matters

Aerospike string secondary indexes support **equality only** — no range, no prefix. The reviewer's original suggestion mentioned `predicates.starts_with`, but that predicate does not exist in `aerospike_py.predicates` (only `equals`, `between`, `contains`, plus geo helpers). Without naming the materialize-prefix pattern, readers will look for `starts_with` and not find it.

## Test plan

- [x] Markdown renders cleanly; anchor `#query--secondary-index` resolves.
- [x] Verified `predicates.starts_with` is **not** in `aerospike-py/src/aerospike_py/predicates.py` — only `equals`, `between`, `contains`, geo helpers.