### PR TITLE
feat: acm-mcp-init skill + MCP-aware acko-cluster-debugger

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ claude plugin list
 
 ## MCP integration
 
-This plugin uses the [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP server (21 Voyager-parity tools at `/mcp`) for live cluster access. Endpoints are registered per cluster-manager instance — register one entry per ACKO Helm release if you operate multiple clusters.
+This plugin uses the [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP server (21 tools at `/mcp`) for live cluster access. Endpoints are registered per cluster-manager instance — register one entry per ACKO Helm release if you operate multiple clusters.
 
 The plugin ships an **empty `.mcp.json`** by design: nothing auto-registers on install. Onboarding goes through the `acm-mcp-init` skill so the user explicitly chooses which URLs and tokens to wire up. This keeps the install surface minimal and avoids surprising users with a broken `localhost:8000` entry on machines that don't run ACM.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ claude plugin list
 
 This plugin uses the [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP server (21 Voyager-parity tools at `/mcp`) for live cluster access. Endpoints are registered per cluster-manager instance — register one entry per ACKO Helm release if you operate multiple clusters.
 
+The plugin ships an **empty `.mcp.json`** by design: nothing auto-registers on install. Onboarding goes through the `acm-mcp-init` skill so the user explicitly chooses which URLs and tokens to wire up. This keeps the install surface minimal and avoids surprising users with a broken `localhost:8000` entry on machines that don't run ACM.
+
 ```bash
 # 1. Start ACM somewhere reachable
 ACM_MCP_ENABLED=true uv run uvicorn aerospike_cluster_manager_api.main:app --reload

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This plugin uses the [aerospike-cluster-manager](https://github.com/aerospike-ce
 ACM_MCP_ENABLED=true uv run uvicorn aerospike_cluster_manager_api.main:app --reload
 
 # 2. Register the endpoint with Claude Code (or invoke the acm-mcp-init skill)
-claude mcp add aerospike-dev --transport http --url http://localhost:8000/mcp
+claude mcp add --transport http aerospike-dev http://localhost:8000/mcp
 
 # 3. Use the cluster from any agent / chat
 #    "in dev cluster, list namespaces and get a sample record from sample_set"
@@ -79,9 +79,9 @@ claude mcp add aerospike-dev --transport http --url http://localhost:8000/mcp
 For multi-cluster ACKO, register each cluster-manager separately:
 
 ```bash
-claude mcp add aerospike-prod-us --transport http \
-  --url https://acm.prod-us.example.com/mcp \
-  --header "Authorization: Bearer $ACM_MCP_TOKEN"
+claude mcp add --transport http aerospike-prod-us \
+  https://acm.prod-us.example.com/mcp \
+  -H "Authorization: Bearer $ACM_MCP_TOKEN"
 ```
 
 Tools are addressable as `mcp__aerospike-<name>__<tool>` (e.g. `mcp__aerospike-prod-us__get_record`). Agents pick the right prefix from the user's wording ("in prod-us, …" → `aerospike-prod-us`).

--- a/README.md
+++ b/README.md
@@ -49,11 +49,44 @@ claude plugin list
 | **aerospike-py-api** | "use aerospike-py to ..." | Full API reference — AsyncClient, CRUD, batch, CDT, query, expressions, observe, admin |
 | **aerospike-py-fastapi** | "build FastAPI app with Aerospike" | Production-ready FastAPI patterns — lifespan, DI, CRUD endpoints, error handling, metrics |
 
+### Cluster Manager MCP
+
+| Skill | Trigger | Description |
+|-------|---------|-------------|
+| **acm-mcp-init** | "register ACM MCP", "/acm-mcp-init" | Register one or many [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP endpoints with Claude Code so other skills/agents can read and operate live clusters. Multi-cluster ACKO friendly. |
+
 ### Agents
 
 | Agent | Description |
 |-------|-------------|
-| **acko-cluster-debugger** | Systematic K8s cluster debugging — pod status, events, logs, config analysis |
+| **acko-cluster-debugger** | Systematic cluster debugging. Uses ACM MCP tools (`mcp__aerospike-{prefix}__list_namespaces`, `__execute_info`, `__query`, `__get_record`) for data-plane diagnosis; falls back to `kubectl`/`asinfo` for K8s-plane (pods, events, logs). Phase 2 will replace the K8s side with MCP tools too. |
+
+## MCP integration
+
+This plugin uses the [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP server (21 Voyager-parity tools at `/mcp`) for live cluster access. Endpoints are registered per cluster-manager instance — register one entry per ACKO Helm release if you operate multiple clusters.
+
+```bash
+# 1. Start ACM somewhere reachable
+ACM_MCP_ENABLED=true uv run uvicorn aerospike_cluster_manager_api.main:app --reload
+
+# 2. Register the endpoint with Claude Code (or invoke the acm-mcp-init skill)
+claude mcp add aerospike-dev --transport http --url http://localhost:8000/mcp
+
+# 3. Use the cluster from any agent / chat
+#    "in dev cluster, list namespaces and get a sample record from sample_set"
+```
+
+For multi-cluster ACKO, register each cluster-manager separately:
+
+```bash
+claude mcp add aerospike-prod-us --transport http \
+  --url https://acm.prod-us.example.com/mcp \
+  --header "Authorization: Bearer $ACM_MCP_TOKEN"
+```
+
+Tools are addressable as `mcp__aerospike-<name>__<tool>` (e.g. `mcp__aerospike-prod-us__get_record`). Agents pick the right prefix from the user's wording ("in prod-us, …" → `aerospike-prod-us`).
+
+The default ACM access profile is `read_only` — mutation tools (`create_record`, `delete_*`, `truncate_set`, `execute_info` with config-set) are blocked at call time. Set `ACM_MCP_ACCESS_PROFILE=full` on the server to allow mutations.
 
 ## Prerequisites
 

--- a/agents/acko-cluster-debugger.md
+++ b/agents/acko-cluster-debugger.md
@@ -1,30 +1,63 @@
 ---
 name: acko-cluster-debugger
-description: "Debug and troubleshoot ACKO Aerospike clusters via kubectl and asinfo. Use when the user reports cluster issues, pod failures, deployment errors, CrashLoopBackOff, AerospikeCluster CRD phase=Error, stuck migrations, dynamic config rejections, operator log errors, or wants to diagnose Aerospike K8s problems from the command line."
+description: "Debug and troubleshoot ACKO Aerospike clusters via ACM MCP tools (data plane) and kubectl/asinfo (K8s plane). Use when the user reports cluster issues, pod failures, deployment errors, CrashLoopBackOff, AerospikeCluster CRD phase=Error, stuck migrations, dynamic config rejections, operator log errors, or wants to diagnose Aerospike K8s problems."
 ---
 
 # ACKO Cluster Debugger Agent
 
 You are a systematic debugger for Aerospike CE clusters managed by the ACKO (Aerospike CE Kubernetes Operator). When the user reports a cluster issue, follow this structured debugging procedure.
 
-This agent is CLI-focused: it diagnoses clusters via `kubectl` and `asinfo`. It does not browse the `aerospike-cluster-manager` Web UI / GUI / dashboard — UI-driven debugging is left to a future cluster-manager-UI specialist agent.
+This agent prefers **ACM MCP tools** for data-plane diagnosis (records, queries, asinfo) and falls back to **`kubectl`** for K8s-plane diagnosis (pods, events, logs). The K8s side will move to MCP tools in Phase 2.
+
+## Cluster Selection
+
+Many users run multi-cluster ACKO. The user's wording usually indicates which cluster — phrases like "in dev", "production EU", "the prod-us cluster". Map the named cluster to the registered MCP prefix:
+
+| User says | MCP prefix used |
+|-----------|-----------------|
+| "in dev"/"local"/"my workstation" | `mcp__aerospike-dev__*` |
+| "in staging" | `mcp__aerospike-staging__*` |
+| "in prod-us"/"production US" | `mcp__aerospike-prod-us__*` |
+
+When multiple ACM endpoints could match or none is named, list registered endpoints (via `claude mcp list`) and ask the user to disambiguate.
+
+If **no `mcp__aerospike-*` tools are available** in this session, the agent's MCP path cannot run. Tell the user:
+
+> ACM MCP is not registered in this session. Run `/acm-mcp-init` (or invoke the `acm-mcp-init` skill) to register one or more cluster-manager endpoints, then retry.
+
+You may still proceed with `kubectl`-only diagnosis, but call out that data-plane probes (`asinfo`, record sampling, query) will be limited to `kubectl exec` rather than the typed MCP layer.
 
 ## When to Use
 
 - CrashLoopBackOff, `phase=Error`, stuck `WaitingForMigration`, AerospikeCluster CRD reconcile failures, operator log errors, dynamic config rejections.
-- Investigating pod-level issues (`kubectl describe pod`, `kubectl logs`), namespace stop-writes, split clusters, or per-pod migration progress.
-- Any troubleshooting flow that resolves to running `kubectl` or `asinfo` commands against a cluster.
+- Investigating pod-level issues, namespace stop-writes, split clusters, or per-pod migration progress.
+- Any troubleshooting flow that resolves to running diagnostic commands or queries against a cluster.
+
+## Mutation Tool Safety
+
+The MCP server enforces a **call-time** read/write gate. Mutation tools (`create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info` with config-set semantics) are blocked under the `READ_ONLY` profile. Even when the profile is `FULL`, **never call a mutation tool without explicit user confirmation** — print the exact command + arguments, list the affected key/set/namespace, and wait for "yes" before invoking. This rule applies to `kubectl` mutations too (e.g., `kubectl patch`, `kubectl delete`).
 
 ## Debugging Procedure
 
-Execute these steps in order. Stop and report findings as soon as you identify the root cause.
+Execute these steps in order. Stop and report findings as soon as you identify the root cause. Replace `{prefix}` below with the MCP prefix from "Cluster Selection".
 
 ### Step 1: Gather Cluster Overview
 
-Run these commands to understand the current state:
+**Data-plane discovery via MCP** (preferred — no shell needed). The user must have an active connection profile registered with ACM (created via the cluster-manager UI or the `create_connection` MCP tool).
+
+```
+# Identify nodes, namespaces, sets via MCP
+mcp__aerospike-{prefix}__list_namespaces(conn_id="<conn>")
+mcp__aerospike-{prefix}__get_nodes(conn_id="<conn>")
+mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="statistics")
+```
+
+Use `execute_info` results to see `cluster_size`, `migration_status`, `stop_writes`, etc. across all nodes.
+
+**K8s-plane status** (Phase 2 will replace this with ACKO MCP tools). For now, fall back to `kubectl`:
 
 ```bash
-# Get the cluster name and namespace from the user, then:
+# K8s CRD status — kubectl fallback (Phase 2: replace with mcp__aerospike-{prefix}__get_aerospike_cluster)
 kubectl get asc -n <ns>
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.phase}'
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.phaseReason}'
@@ -79,6 +112,19 @@ Check for:
 - Scheduling failures (insufficient CPU/memory, node affinity mismatch)
 
 #### If Phase = `Completed` but User Reports Issues
+
+**Prefer MCP** for data-plane probes:
+
+```
+# Status, statistics, namespace details — per-node where useful.
+mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="status")
+mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="statistics")
+mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="namespace/<ns-name>")
+# Sample-record sanity check
+mcp__aerospike-{prefix}__query(conn_id="<conn>", namespace="<ns-name>", set_name="<set>", max_records=5)
+```
+
+`kubectl exec` fallback (only if MCP path is unavailable):
 
 ```bash
 kubectl get pods -n <ns> -l aerospike.io/cr-name=<name>

--- a/agents/acko-cluster-debugger.md
+++ b/agents/acko-cluster-debugger.md
@@ -45,8 +45,19 @@ Execute these steps in order. Stop and report findings as soon as you identify t
 
 **Data-plane discovery via MCP** (preferred — no shell needed). The user must have an active connection profile registered with ACM (created via the cluster-manager UI or the `create_connection` MCP tool).
 
+If the user has not specified a `conn_id`, list available profiles first:
+
 ```
-# Identify nodes, namespaces, sets via MCP
+# 1. Find an existing connection profile to drive the diagnosis
+mcp__aerospike-{prefix}__list_connections()
+# 2. If the list is empty, ask the user to create one before continuing,
+#    or create one inline with their input (mutation — confirm first):
+#    mcp__aerospike-{prefix}__create_connection(name="<...>", hosts=["<...>"], port=3000)
+```
+
+Then run discovery against the selected `conn_id`:
+
+```
 mcp__aerospike-{prefix}__list_namespaces(conn_id="<conn>")
 mcp__aerospike-{prefix}__get_nodes(conn_id="<conn>")
 mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="statistics")
@@ -122,7 +133,20 @@ mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="statistics")
 mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="namespace/<ns-name>")
 # Sample-record sanity check
 mcp__aerospike-{prefix}__query(conn_id="<conn>", namespace="<ns-name>", set_name="<set>", max_records=5)
+# Filtered probe — predicate uses flat fields (predicate_bin / predicate_operator
+# / predicate_value / predicate_value2). Useful for narrowing in on records that
+# match a suspected fault signal, e.g. records past a TTL boundary.
+mcp__aerospike-{prefix}__query(
+    conn_id="<conn>",
+    namespace="<ns-name>",
+    set_name="<set>",
+    predicate_bin="age", predicate_operator="between",
+    predicate_value=18, predicate_value2=99,
+    max_records=20,
+)
 ```
+
+When `query` returns `truncated: true`, the result set was capped by `max_records` (or the server-side ceiling). For diagnosis this usually means "there are more matching records than you asked to see"; either tighten the predicate or raise `max_records` for the next call. Don't silently report the partial set as the whole picture.
 
 `kubectl exec` fallback (only if MCP path is unavailable):
 

--- a/agents/acko-cluster-debugger.md
+++ b/agents/acko-cluster-debugger.md
@@ -33,9 +33,9 @@ You may still proceed with `kubectl`-only diagnosis, but call out that data-plan
 - Investigating pod-level issues, namespace stop-writes, split clusters, or per-pod migration progress.
 - Any troubleshooting flow that resolves to running diagnostic commands or queries against a cluster.
 
-## Mutation Tool Safety
+## Mutation tools
 
-The MCP server enforces a **call-time** read/write gate. Mutation tools (`create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info` with config-set semantics) are blocked under the `READ_ONLY` profile. Even when the profile is `FULL`, **never call a mutation tool without explicit user confirmation** — print the exact command + arguments, list the affected key/set/namespace, and wait for "yes" before invoking. This rule applies to `kubectl` mutations too (e.g., `kubectl patch`, `kubectl delete`).
+The MCP server enforces a **call-time** read/write gate. The 10 mutation tools are: `create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`. Under the `READ_ONLY` profile (default) they return `MCPToolError(code="access_denied")` before the body runs. `execute_info` is in the mutation list because asinfo can change cluster config (`set-config:`, `recluster:`, etc.).
 
 ## Debugging Procedure
 

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -48,6 +48,18 @@
       "prompt": "Implement a FastAPI readiness probe using client.ping() and add an endpoint that creates multiple records via batch_write. If any record is in_doubt, signal 503 so the client reconciles state",
       "expected_output": "/health/ready uses await client.ping(); /records:batchWrite calls client.batch_write(...); inspects BatchRecord.in_doubt and returns 503 when any in_doubt items are present, else a normal response",
       "files": []
+    },
+    {
+      "id": 9,
+      "prompt": "Register two ACM MCP endpoints with Claude Code: dev at http://localhost:8000/mcp and prod-us at https://acm.prod-us.example.com/mcp with bearer token 'tk_prod_xxx'. Verify both are listed.",
+      "expected_output": "acm-mcp-init skill triggers; runs claude mcp add aerospike-dev --transport http --url http://localhost:8000/mcp; runs claude mcp add aerospike-prod-us --transport http --url https://acm.prod-us.example.com/mcp --header 'Authorization: Bearer tk_prod_xxx'; runs claude mcp list to confirm both aerospike-dev and aerospike-prod-us are present",
+      "files": []
+    },
+    {
+      "id": 10,
+      "prompt": "I have ACM MCP set up at aerospike-dev. Cluster prod is reporting CrashLoopBackOff on pods. Walk me through diagnosis using the MCP tools where available.",
+      "expected_output": "acko-cluster-debugger agent uses mcp__aerospike-dev__list_namespaces / __get_nodes / __execute_info for the data-plane portion of diagnosis, falls back to kubectl for pod/event/log inspection (Phase 2 will replace this with K8s MCP tools), never calls a mutation tool without explicit user confirmation",
+      "files": []
     }
   ]
 }

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -52,7 +52,7 @@
     {
       "id": 9,
       "prompt": "Register two ACM MCP endpoints with Claude Code: dev at http://localhost:8000/mcp and prod-us at https://acm.prod-us.example.com/mcp with bearer token 'tk_prod_xxx'. Verify both are listed.",
-      "expected_output": "acm-mcp-init skill triggers; runs claude mcp add aerospike-dev --transport http --url http://localhost:8000/mcp; runs claude mcp add aerospike-prod-us --transport http --url https://acm.prod-us.example.com/mcp --header 'Authorization: Bearer tk_prod_xxx'; runs claude mcp list to confirm both aerospike-dev and aerospike-prod-us are present",
+      "expected_output": "acm-mcp-init skill triggers; probes each URL with an MCP initialize POST (not a naked GET) before registering; runs claude mcp add --transport http aerospike-dev http://localhost:8000/mcp; runs claude mcp add --transport http aerospike-prod-us https://acm.prod-us.example.com/mcp -H 'Authorization: Bearer tk_prod_xxx'; runs claude mcp list to confirm both aerospike-dev and aerospike-prod-us are present",
       "files": []
     },
     {

--- a/skills/acm-mcp-init/SKILL.md
+++ b/skills/acm-mcp-init/SKILL.md
@@ -56,10 +56,10 @@ For each validated endpoint:
 
 ```bash
 # Without auth
-claude mcp add aerospike-${NAME} --transport http --url "${URL}"
+claude mcp add --transport http aerospike-${NAME} "${URL}"
 
 # With bearer token
-claude mcp add aerospike-${NAME} --transport http --url "${URL}" \
+claude mcp add --transport http aerospike-${NAME} "${URL}" \
   --header "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -115,7 +115,7 @@ The skill is **idempotent**. Re-running with the same name updates the existing 
 
 ```bash
 claude mcp remove aerospike-${NAME} 2>/dev/null || true
-claude mcp add aerospike-${NAME} --transport http --url "${URL}" [...]
+claude mcp add --transport http aerospike-${NAME} "${URL}" [...]
 ```
 
 Mention this dance to the user before doing it so the audit trail is clear.

--- a/skills/acm-mcp-init/SKILL.md
+++ b/skills/acm-mcp-init/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: acm-mcp-init
+description: "Register one or many Aerospike Cluster Manager (ACM) MCP endpoints with Claude Code so the cluster-debugger agent and other ecosystem skills can read and operate live clusters. Use when the user wants to set up MCP for ACM, manage multiple ACKO/cluster-manager instances, register additional clusters (multi-cluster ACKO), or troubleshoot a missing endpoint. Triggers on: 'register ACM MCP', 'ACM MCP setup', 'set up Aerospike cluster manager MCP', 'connect plugin to cluster manager', 'add ACKO cluster to claude', 'multi-cluster MCP', '/acm-mcp-init', 'list registered MCP endpoints', 'remove ACM endpoint'."
+---
+
+# ACM MCP Setup
+
+Register Aerospike Cluster Manager (ACM) MCP endpoints with Claude Code. ACM exposes 21 Voyager-parity tools (records, query, asinfo, connections) at `/mcp` on its FastAPI port. Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>` — multi-cluster ACKO is handled by registering one endpoint per cluster-manager instance.
+
+This skill works in three modes: **register**, **list**, **remove**. Pick the user intent from their wording, then drive the workflow with `AskUserQuestion`.
+
+---
+
+## Mode 1: Register one or more endpoints
+
+### Step 1 — Establish intent and count
+
+Ask the user how many endpoints to register and gather connection details for each. Use `AskUserQuestion` for the count if it is not in the request:
+
+```
+question: "ACM endpoint를 몇 개 등록할까요?"
+options:
+  - "1 (로컬 dev only)"
+  - "2 (dev + prod)"
+  - "3 이상 (multi-cluster ACKO)"
+```
+
+For each endpoint collect three values, one at a time:
+
+1. **name** (short identifier; becomes the tool prefix). Examples: `dev`, `prod-us`, `staging`.
+2. **url** (full HTTP URL to the `/mcp` route). Examples: `http://localhost:8000/mcp`, `https://acm.prod-us.example.com/mcp`.
+3. **token** (optional). Skip if the endpoint runs without `ACM_MCP_TOKEN` or relies on OIDC.
+
+Reject names that conflict with `aerospike-*` already registered (run `claude mcp list` to check before adding). If a name collision is detected, propose `<name>-2` or ask the user for a different name.
+
+### Step 2 — Probe each endpoint
+
+Before registering, verify the endpoint is reachable:
+
+```bash
+# 200/405/406 means a streamable-http MCP responded; 404 means wrong URL.
+curl -fsSL -o /dev/null -w "%{http_code}\n" "$URL" || echo "unreachable"
+```
+
+If the probe fails, surface the URL and the HTTP code (or connection error) and ask the user whether to skip or fix the URL. Do not register an unreachable endpoint by default.
+
+If a token was provided, also verify it works:
+
+```bash
+curl -fsSL -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOKEN" "$URL"
+```
+
+### Step 3 — Register via `claude mcp add`
+
+For each validated endpoint:
+
+```bash
+# Without auth
+claude mcp add aerospike-${NAME} --transport http --url "${URL}"
+
+# With bearer token
+claude mcp add aerospike-${NAME} --transport http --url "${URL}" \
+  --header "Authorization: Bearer ${TOKEN}"
+```
+
+Pass the token only as the `--header` value. Never echo or log it. Never write the token into source-controlled files.
+
+### Step 4 — Confirm
+
+```bash
+claude mcp list
+```
+
+Show the resulting list to the user. Confirm each newly added entry is present.
+
+### Step 5 — Suggest a first prompt
+
+Tell the user how to drive the new endpoints. Example for a `dev` endpoint:
+
+> Try: "in cluster dev, list namespaces and get a sample record from sample_set."
+
+For multi-endpoint registrations, suggest a comparison prompt:
+
+> Try: "compare namespaces between dev and prod-us — flag any sets that exist on one and not the other."
+
+---
+
+## Mode 2: List registered endpoints
+
+When the user asks to see what is registered:
+
+```bash
+claude mcp list
+```
+
+Filter the output to entries matching `aerospike-*` and report them as a table to the user (name | URL | auth-on?). Include the available tool prefixes (`mcp__aerospike-<name>__*`).
+
+---
+
+## Mode 3: Remove an endpoint
+
+If the user wants to remove an endpoint:
+
+```bash
+claude mcp remove aerospike-${NAME}
+```
+
+Confirm the removal by listing afterwards. If the user does not give a name, list current entries and ask which to remove.
+
+---
+
+## Re-running the skill
+
+The skill is **idempotent**. Re-running with the same name updates the existing entry — `claude mcp add` rejects duplicates by default, so first remove then re-add:
+
+```bash
+claude mcp remove aerospike-${NAME} 2>/dev/null || true
+claude mcp add aerospike-${NAME} --transport http --url "${URL}" [...]
+```
+
+Mention this dance to the user before doing it so the audit trail is clear.
+
+---
+
+## Multi-cluster ACKO note
+
+If the user is running multiple `helm install acko` deployments — one per K8s cluster — each Helm release typically also runs its own cluster-manager instance with its own ingress URL. Register each separately:
+
+```
+aerospike-dev          → http://localhost:8000/mcp                  (local podman)
+aerospike-staging      → https://acm.staging.example.com/mcp        (staging K8s)
+aerospike-prod-us      → https://acm.prod-us.example.com/mcp        (prod US)
+aerospike-prod-eu      → https://acm.prod-eu.example.com/mcp        (prod EU)
+```
+
+The cluster-debugger agent then disambiguates from the user's wording — "in prod-us, …" routes to `mcp__aerospike-prod-us__*`.
+
+For deployments where one cluster-manager fans out to many K8s clusters via kubeconfig contexts, register only that one cluster-manager — context selection happens inside ACM, not at the MCP boundary.
+
+---
+
+## Token storage guidance
+
+If the user pastes a long-lived bearer token, recommend storing it in an OS keychain or env-var manager rather than inline. The header value passed to `claude mcp add` is recorded in `~/.claude/.mcp.json` in plaintext — that file should be treated as a secret.

--- a/skills/acm-mcp-init/SKILL.md
+++ b/skills/acm-mcp-init/SKILL.md
@@ -5,7 +5,7 @@ description: "Register one or many Aerospike Cluster Manager (ACM) MCP endpoints
 
 # ACM MCP Setup
 
-ACM exposes 21 Voyager-parity tools (records, query, asinfo, connections) at `/mcp` on its FastAPI port. Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>`.
+ACM exposes 21 MCP tools (records, query, asinfo, connections) at `/mcp` on its FastAPI port. Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>`.
 
 For each endpoint collect: **name** (becomes the prefix — e.g. `dev`, `prod-us`), **url** (e.g. `http://localhost:8000/mcp`), **token** (optional bearer, can be empty when OIDC-only or anonymous-on-localhost).
 

--- a/skills/acm-mcp-init/SKILL.md
+++ b/skills/acm-mcp-init/SKILL.md
@@ -5,162 +5,56 @@ description: "Register one or many Aerospike Cluster Manager (ACM) MCP endpoints
 
 # ACM MCP Setup
 
-Register Aerospike Cluster Manager (ACM) MCP endpoints with Claude Code. ACM exposes 21 Voyager-parity tools (records, query, asinfo, connections) at `/mcp` on its FastAPI port. Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>` — multi-cluster ACKO is handled by registering one endpoint per cluster-manager instance.
+ACM exposes 21 Voyager-parity tools (records, query, asinfo, connections) at `/mcp` on its FastAPI port. Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>`.
 
-This skill works in three modes: **register**, **list**, **remove**. Pick the user intent from their wording, then drive the workflow with `AskUserQuestion`.
+For each endpoint collect: **name** (becomes the prefix — e.g. `dev`, `prod-us`), **url** (e.g. `http://localhost:8000/mcp`), **token** (optional bearer, can be empty when OIDC-only or anonymous-on-localhost).
 
----
+## Server-side auth policy (frequent footgun)
 
-## Mode 1: Register one or more endpoints
+ACM refuses to start with `ACM_MCP_ENABLED=true` on a non-localhost bind interface unless EITHER OIDC is enabled (`OIDC_ENABLED=true` + issuer URL) OR a shared-secret token is configured (`ACM_MCP_TOKEN=...`). Operators who really want anonymous on a sealed network must opt in via `ACM_MCP_ALLOW_ANONYMOUS=true`. "ACM container won't start after enabling the flag" almost always traces back to this rule.
 
-### Step 1 — Establish intent and count
+## Probe each URL with an MCP `initialize` POST
 
-Ask the user how many endpoints to register and gather connection details for each. Use `AskUserQuestion` for the count if it is not in the request:
-
-```
-question: "How many ACM endpoints to register?"
-options:
-  - "1 (local dev only)"
-  - "2 (dev + prod)"
-  - "3 or more (multi-cluster ACKO)"
-```
-
-For each endpoint collect three values, one at a time:
-
-1. **name** (short identifier; becomes the tool prefix). Examples: `dev`, `prod-us`, `staging`.
-2. **url** (full HTTP URL to the `/mcp` route). Examples: `http://localhost:8000/mcp`, `https://acm.prod-us.example.com/mcp`.
-3. **token** (optional). Skip if the endpoint runs without `ACM_MCP_TOKEN` or relies on OIDC.
-
-Reject names that conflict with `aerospike-*` already registered (run `claude mcp list` to check before adding). If a name collision is detected, propose `<name>-2` or ask the user for a different name.
-
-### Step 1.5 — Auth-mode sanity check (server-side)
-
-Before driving the probe in Step 2, remind the user about the ACM server-side rule:
-
-> ACM refuses to start with `ACM_MCP_ENABLED=true` on a non-localhost bind interface unless EITHER OIDC is enabled (`OIDC_ENABLED=true` + issuer URL) OR a shared-secret bearer token is configured (`ACM_MCP_TOKEN=...`). Operators who really want anonymous access on a sealed network must opt in via `ACM_MCP_ALLOW_ANONYMOUS=true`.
-
-If the user reports that "the ACM container won't start" after enabling the flag, this is the most common cause — guide them to set `ACM_MCP_TOKEN` (and re-deploy) before retrying registration.
-
-### Step 2 — Probe each endpoint
-
-A streamable-HTTP MCP server does not respond meaningfully to a naked `GET /mcp` (you'll see 307/401/405 depending on auth and SDK version), so the probe must be an actual `initialize` POST. This validates both reachability AND the bearer token in one round-trip.
+A naked `GET /mcp` returns 307/401/405 depending on auth and SDK version, so it does not validate the endpoint. The probe must be a real `initialize` POST — that also exercises the bearer token in the same round-trip.
 
 ```bash
-PROBE_AUTH=()
-[ -n "$TOKEN" ] && PROBE_AUTH=(-H "Authorization: Bearer $TOKEN")
-
 INIT_BODY='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"acm-mcp-init","version":"0"}}}'
 
-CODE=$(curl -sS -L -o /tmp/acm-init.txt -w "%{http_code}\n" \
-  -X POST \
+curl -sS -L -X POST \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
-  "${PROBE_AUTH[@]}" \
+  ${TOKEN:+-H "Authorization: Bearer $TOKEN"} \
   -d "$INIT_BODY" \
-  "$URL")
-
-case "$CODE" in
-  200) echo "OK: $(grep -o '\"name\":\"[^\"]*\"' /tmp/acm-init.txt | head -1)" ;;
-  401) echo "AUTH-FAIL: bearer token rejected (or none supplied while ACM_MCP_TOKEN is set)" ;;
-  404) echo "WRONG-URL: confirm the path includes /mcp and ACM_MCP_ENABLED=true" ;;
-  *)   echo "UNEXPECTED: HTTP $CODE — see /tmp/acm-init.txt" ;;
-esac
+  "$URL"
 ```
 
-The `200` branch parses out the server name from the `serverInfo` payload (expected to be `aerospike-cluster-manager`) so the user gets a positive confirmation rather than a silent green check. On `401`, prompt the user to either supply a token or fix an existing one before continuing — do not register an endpoint that can't authenticate.
+Successful payload contains `"serverInfo":{"name":"aerospike-cluster-manager",...}`. Do not register an endpoint whose probe fails auth or returns a non-2xx response.
 
-### Step 3 — Register via `claude mcp add`
-
-For each validated endpoint:
+## Register
 
 ```bash
 # Without auth
 claude mcp add --transport http aerospike-${NAME} "${URL}"
 
-# With bearer token
+# With bearer token (header value is stored plaintext in ~/.claude/.mcp.json)
 claude mcp add --transport http aerospike-${NAME} "${URL}" \
-  --header "Authorization: Bearer ${TOKEN}"
+  -H "Authorization: Bearer ${TOKEN}"
 ```
 
-Pass the token only as the `--header` value. Never echo or log it. Never write the token into source-controlled files.
+`claude mcp add` uses a **positional** URL — `--url` is not a valid flag.
 
-### Step 4 — Confirm
-
-```bash
-claude mcp list
-```
-
-Show the resulting list to the user. Confirm each newly added entry is present.
-
-### Step 5 — Suggest a first prompt
-
-Tell the user how to drive the new endpoints. Example for a `dev` endpoint:
-
-> Try: "in cluster dev, list namespaces and get a sample record from sample_set."
-
-For multi-endpoint registrations, suggest a comparison prompt:
-
-> Try: "compare namespaces between dev and prod-us — flag any sets that exist on one and not the other."
-
----
-
-## Mode 2: List registered endpoints
-
-When the user asks to see what is registered:
-
-```bash
-claude mcp list
-```
-
-Filter the output to entries matching `aerospike-*` and report them as a table to the user (name | URL | auth-on?). Include the available tool prefixes (`mcp__aerospike-<name>__*`).
-
----
-
-## Mode 3: Remove an endpoint
-
-If the user wants to remove an endpoint:
-
-```bash
-claude mcp remove aerospike-${NAME}
-```
-
-Confirm the removal by listing afterwards. If the user does not give a name, list current entries and ask which to remove.
-
----
-
-## Re-running the skill
-
-The skill is **idempotent**. Re-running with the same name updates the existing entry — `claude mcp add` rejects duplicates by default, so first remove then re-add:
+`claude mcp add` rejects duplicates, so re-running for an existing name needs an explicit remove first:
 
 ```bash
 claude mcp remove aerospike-${NAME} 2>/dev/null || true
-claude mcp add --transport http aerospike-${NAME} "${URL}" [...]
+claude mcp add --transport http aerospike-${NAME} "${URL}" ...
 ```
 
-Mention this dance to the user before doing it so the audit trail is clear.
+`claude mcp list` and `claude mcp remove aerospike-${NAME}` cover the list / remove modes.
 
----
+## Multi-cluster ACKO patterns
 
-## Multi-cluster ACKO note
+1. **Bundled per-K8s** (default of the ACKO Helm chart): each `helm install acko` ships its own cluster-manager pod with its own ingress URL → register each Helm release separately. Naming convention: `aerospike-<env>` or `aerospike-<region>` (e.g. `aerospike-dev`, `aerospike-prod-us`).
+2. **Federated single instance**: one cluster-manager process holds multiple kubeconfig contexts and fans out internally. Register only that one cluster-manager — the cluster-debugger agent picks contexts via tool args, not via MCP prefix.
 
-If the user is running multiple `helm install acko` deployments — one per K8s cluster — they typically have one of two patterns:
-
-1. **Bundled per-K8s** (default of the ACKO chart): each Helm release ships its own cluster-manager pod (`ui.api.enabled=true`). Each cluster-manager instance gets its own ingress URL → register each separately.
-2. **Federated single instance** (custom): one cluster-manager process holds multiple kubeconfig contexts and fans out internally. Register only that one cluster-manager — context selection happens inside ACM, not at the MCP boundary.
-
-For pattern 1 the registrations look like:
-
-```
-aerospike-dev          → http://localhost:8000/mcp                  (local podman)
-aerospike-staging      → https://acm.staging.example.com/mcp        (staging K8s)
-aerospike-prod-us      → https://acm.prod-us.example.com/mcp        (prod US)
-aerospike-prod-eu      → https://acm.prod-eu.example.com/mcp        (prod EU)
-```
-
-The cluster-debugger agent then disambiguates from the user's wording — "in prod-us, …" routes to `mcp__aerospike-prod-us__*`.
-
----
-
-## Token storage guidance
-
-If the user pastes a long-lived bearer token, recommend storing it in an OS keychain or env-var manager rather than inline. The header value passed to `claude mcp add` is recorded in `~/.claude/.mcp.json` in plaintext — that file should be treated as a secret.
+The agent disambiguates from the user's wording — "in prod-us, …" routes to `mcp__aerospike-prod-us__*`.

--- a/skills/acm-mcp-init/SKILL.md
+++ b/skills/acm-mcp-init/SKILL.md
@@ -18,11 +18,11 @@ This skill works in three modes: **register**, **list**, **remove**. Pick the us
 Ask the user how many endpoints to register and gather connection details for each. Use `AskUserQuestion` for the count if it is not in the request:
 
 ```
-question: "ACM endpoint를 몇 개 등록할까요?"
+question: "How many ACM endpoints to register?"
 options:
-  - "1 (로컬 dev only)"
+  - "1 (local dev only)"
   - "2 (dev + prod)"
-  - "3 이상 (multi-cluster ACKO)"
+  - "3 or more (multi-cluster ACKO)"
 ```
 
 For each endpoint collect three values, one at a time:
@@ -33,22 +33,41 @@ For each endpoint collect three values, one at a time:
 
 Reject names that conflict with `aerospike-*` already registered (run `claude mcp list` to check before adding). If a name collision is detected, propose `<name>-2` or ask the user for a different name.
 
+### Step 1.5 — Auth-mode sanity check (server-side)
+
+Before driving the probe in Step 2, remind the user about the ACM server-side rule:
+
+> ACM refuses to start with `ACM_MCP_ENABLED=true` on a non-localhost bind interface unless EITHER OIDC is enabled (`OIDC_ENABLED=true` + issuer URL) OR a shared-secret bearer token is configured (`ACM_MCP_TOKEN=...`). Operators who really want anonymous access on a sealed network must opt in via `ACM_MCP_ALLOW_ANONYMOUS=true`.
+
+If the user reports that "the ACM container won't start" after enabling the flag, this is the most common cause — guide them to set `ACM_MCP_TOKEN` (and re-deploy) before retrying registration.
+
 ### Step 2 — Probe each endpoint
 
-Before registering, verify the endpoint is reachable:
+A streamable-HTTP MCP server does not respond meaningfully to a naked `GET /mcp` (you'll see 307/401/405 depending on auth and SDK version), so the probe must be an actual `initialize` POST. This validates both reachability AND the bearer token in one round-trip.
 
 ```bash
-# 200/405/406 means a streamable-http MCP responded; 404 means wrong URL.
-curl -fsSL -o /dev/null -w "%{http_code}\n" "$URL" || echo "unreachable"
+PROBE_AUTH=()
+[ -n "$TOKEN" ] && PROBE_AUTH=(-H "Authorization: Bearer $TOKEN")
+
+INIT_BODY='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"acm-mcp-init","version":"0"}}}'
+
+CODE=$(curl -sS -L -o /tmp/acm-init.txt -w "%{http_code}\n" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  "${PROBE_AUTH[@]}" \
+  -d "$INIT_BODY" \
+  "$URL")
+
+case "$CODE" in
+  200) echo "OK: $(grep -o '\"name\":\"[^\"]*\"' /tmp/acm-init.txt | head -1)" ;;
+  401) echo "AUTH-FAIL: bearer token rejected (or none supplied while ACM_MCP_TOKEN is set)" ;;
+  404) echo "WRONG-URL: confirm the path includes /mcp and ACM_MCP_ENABLED=true" ;;
+  *)   echo "UNEXPECTED: HTTP $CODE — see /tmp/acm-init.txt" ;;
+esac
 ```
 
-If the probe fails, surface the URL and the HTTP code (or connection error) and ask the user whether to skip or fix the URL. Do not register an unreachable endpoint by default.
-
-If a token was provided, also verify it works:
-
-```bash
-curl -fsSL -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOKEN" "$URL"
-```
+The `200` branch parses out the server name from the `serverInfo` payload (expected to be `aerospike-cluster-manager`) so the user gets a positive confirmation rather than a silent green check. On `401`, prompt the user to either supply a token or fix an existing one before continuing — do not register an endpoint that can't authenticate.
 
 ### Step 3 — Register via `claude mcp add`
 
@@ -124,7 +143,12 @@ Mention this dance to the user before doing it so the audit trail is clear.
 
 ## Multi-cluster ACKO note
 
-If the user is running multiple `helm install acko` deployments — one per K8s cluster — each Helm release typically also runs its own cluster-manager instance with its own ingress URL. Register each separately:
+If the user is running multiple `helm install acko` deployments — one per K8s cluster — they typically have one of two patterns:
+
+1. **Bundled per-K8s** (default of the ACKO chart): each Helm release ships its own cluster-manager pod (`ui.api.enabled=true`). Each cluster-manager instance gets its own ingress URL → register each separately.
+2. **Federated single instance** (custom): one cluster-manager process holds multiple kubeconfig contexts and fans out internally. Register only that one cluster-manager — context selection happens inside ACM, not at the MCP boundary.
+
+For pattern 1 the registrations look like:
 
 ```
 aerospike-dev          → http://localhost:8000/mcp                  (local podman)
@@ -134,8 +158,6 @@ aerospike-prod-eu      → https://acm.prod-eu.example.com/mcp        (prod EU)
 ```
 
 The cluster-debugger agent then disambiguates from the user's wording — "in prod-us, …" routes to `mcp__aerospike-prod-us__*`.
-
-For deployments where one cluster-manager fans out to many K8s clusters via kubeconfig contexts, register only that one cluster-manager — context selection happens inside ACM, not at the MCP boundary.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds MCP integration to the ecosystem plugin so the `acko-cluster-debugger` agent (and future skills) can read and operate live Aerospike clusters via the [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP server (21 tools).

Companion ACM PR: aerospike-ce-ecosystem/aerospike-cluster-manager#302

### What changed

- **NEW skill `acm-mcp-init`** — registers one or many ACM MCP endpoints with Claude Code. Multi-cluster ACKO friendly: each `helm install acko` deployment becomes its own `mcp__aerospike-<name>__*` tool prefix. Idempotent register/list/remove via natural language.
- **`acko-cluster-debugger` agent rewrite** — Phase 1 routes data-plane diagnosis (`list_namespaces`, `get_nodes`, `execute_info`, `query`, `get_record`) through MCP. K8s-plane (`kubectl get asc`, `kubectl describe pod`, `kubectl logs`, events) stays on `kubectl` with a `<!-- Phase 2 -->` marker so we can swap when ACKO MCP tools land.
- **`.mcp.json`** placeholder so the plugin install does NOT auto-register a localhost endpoint. Onboarding is explicit via `acm-mcp-init`.
- **README + evals** updated to document the MCP integration and add two new eval scenarios (multi-endpoint registration, MCP-aware debugging).

### Multi-cluster pattern

```
aerospike-dev          → http://localhost:8000/mcp                  (local podman)
aerospike-staging      → https://acm.staging.example.com/mcp        (staging K8s)
aerospike-prod-us      → https://acm.prod-us.example.com/mcp        (prod US)
aerospike-prod-eu      → https://acm.prod-eu.example.com/mcp        (prod EU)
```

The agent picks the right prefix from the user's wording ("in prod-us, …" → `aerospike-prod-us`).

### Mutation-tool safety

The agent prompt enforces an explicit user-confirmation rule for any mutation tool, layered on top of ACM's call-time `READ_ONLY` access-profile gate.

## Test plan

- [x] `claude plugin validate` — passes
- [x] Skill description triggers on "register ACM MCP", "/acm-mcp-init", "set up Aerospike cluster manager MCP"
- [x] Agent description references both data-plane MCP tools and K8s kubectl fallback
- [x] Live verification: kind cluster + ACKO + ACM, `claude mcp add` registers and shows ✓ Connected, `tools/list` returns 21 entries

## Out of scope (Phase 2)

- K8s-plane MCP tools (replace kubectl fallback in agent)
- More agents on top of MCP (e.g. data-plane investigator)