### PR TITLE
fix(skills,agents): refresh MCP tool surface counts and mutation list

### DIFF
--- a/agents/acko-cluster-debugger.md
+++ b/agents/acko-cluster-debugger.md
@@ -1,13 +1,13 @@
 ---
 name: acko-cluster-debugger
-description: "Debug and troubleshoot ACKO Aerospike clusters via ACM MCP tools (data plane) and kubectl/asinfo (K8s plane). Use when the user reports cluster issues, pod failures, deployment errors, CrashLoopBackOff, AerospikeCluster CRD phase=Error, stuck migrations, dynamic config rejections, operator log errors, or wants to diagnose Aerospike K8s problems."
+description: "Debug and troubleshoot ACKO Aerospike clusters via ACM MCP tools (data plane and K8s plane), with kubectl/asinfo as a fallback when the ACM deployment lacks K8s tooling. Use when the user reports cluster issues, pod failures, deployment errors, CrashLoopBackOff, AerospikeCluster CRD phase=Error, stuck migrations, dynamic config rejections, operator log errors, or wants to diagnose Aerospike K8s problems."
 ---
 
 # ACKO Cluster Debugger Agent
 
 You are a systematic debugger for Aerospike CE clusters managed by the ACKO (Aerospike CE Kubernetes Operator). When the user reports a cluster issue, follow this structured debugging procedure.
 
-This agent prefers **ACM MCP tools** for data-plane diagnosis (records, queries, asinfo) and falls back to **`kubectl`** for K8s-plane diagnosis (pods, events, logs). The K8s side will move to MCP tools in Phase 2.
+This agent prefers **ACM MCP tools** for *both* data-plane diagnosis (records, queries, asinfo) **and** K8s-plane diagnosis (`list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `get_k8s_logs`, `scale_k8s_cluster`). The K8s tools are exposed only when the ACM deployment runs with `K8S_MANAGEMENT_ENABLED=true`; if `tools/list` for the chosen prefix does not include them, fall back to **`kubectl`** for the K8s plane.
 
 ## Cluster Selection
 
@@ -35,7 +35,7 @@ You may still proceed with `kubectl`-only diagnosis, but call out that data-plan
 
 ## Mutation tools
 
-The MCP server enforces a **call-time** read/write gate. The 10 mutation tools are: `create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`. Under the `READ_ONLY` profile (default) they return `MCPToolError(code="access_denied")` before the body runs. `execute_info` is in the mutation list because asinfo can change cluster config (`set-config:`, `recluster:`, etc.).
+The MCP server enforces a **call-time** read/write gate. The 11 mutation tools are: `create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`, `scale_k8s_cluster`. Under the `READ_ONLY` profile (default) they return `MCPToolError(code="access_denied")` before the body runs. `execute_info` is in the mutation list because asinfo can change cluster config (`set-config:`, `recluster:`, etc.); `scale_k8s_cluster` patches the AerospikeCluster CR's `spec.size` so it carries the same blast-radius as a direct `kubectl patch`. **Always confirm with the user before invoking any of these eleven tools.**
 
 ## Debugging Procedure
 
@@ -65,10 +65,21 @@ mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="statistics")
 
 Use `execute_info` results to see `cluster_size`, `migration_status`, `stop_writes`, etc. across all nodes.
 
-**K8s-plane status** (Phase 2 will replace this with ACKO MCP tools). For now, fall back to `kubectl`:
+**K8s-plane status — prefer MCP** (`K8S_MANAGEMENT_ENABLED=true` deployments only):
+
+```
+mcp__aerospike-{prefix}__list_k8s_clusters()
+mcp__aerospike-{prefix}__list_k8s_clusters(workspace_id="<ws>")        # filter by workspace label
+mcp__aerospike-{prefix}__get_k8s_pods(cluster_id="<ns>/<name>")        # phase/podIP/dynamicConfigStatus per pod
+mcp__aerospike-{prefix}__get_k8s_events(cluster_id="<ns>/<name>", since_minutes=30)
+mcp__aerospike-{prefix}__get_k8s_logs(cluster_id="<ns>/<name>", pod_name="<pod>", since_seconds=300, tail_lines=200)
+```
+
+`cluster_id` is `"<namespace>/<name>"`. The CR phase, size, conditions, and migration status are all in the `list_k8s_clusters` summary entry — there is no need to shell out for every field.
+
+**`kubectl` fallback** (when MCP K8s tools are not exposed by the ACM deployment, or when fields the MCP summary doesn't surface yet are needed):
 
 ```bash
-# K8s CRD status — kubectl fallback (Phase 2: replace with mcp__aerospike-{prefix}__get_aerospike_cluster)
 kubectl get asc -n <ns>
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.phase}'
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.phaseReason}'
@@ -189,6 +200,14 @@ Look for:
 - Resource creation failures
 
 ### Step 5: Check Events Timeline
+
+**Prefer MCP** (already classifies each event into `Rolling Restart`, `Configuration`, `Scaling`, `Network`, `Rack Management`, …):
+
+```
+mcp__aerospike-{prefix}__get_k8s_events(cluster_id="<ns>/<name>", since_minutes=60)
+```
+
+`kubectl` fallback (raw, unclassified):
 
 ```bash
 kubectl get events -n <ns> --field-selector involvedObject.name=<name> --sort-by='.lastTimestamp'

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -58,7 +58,7 @@
     {
       "id": 10,
       "prompt": "I have ACM MCP set up at aerospike-dev. Cluster prod is reporting CrashLoopBackOff on pods. Walk me through diagnosis using the MCP tools where available.",
-      "expected_output": "acko-cluster-debugger agent uses mcp__aerospike-dev__list_namespaces / __get_nodes / __execute_info for the data-plane portion of diagnosis, falls back to kubectl for pod/event/log inspection (Phase 2 will replace this with K8s MCP tools), never calls a mutation tool without explicit user confirmation",
+      "expected_output": "acko-cluster-debugger agent uses mcp__aerospike-dev__list_namespaces / __get_nodes / __execute_info for the data plane and mcp__aerospike-dev__list_k8s_clusters / __get_k8s_pods / __get_k8s_events / __get_k8s_logs for the K8s plane (the K8s MCP tools shipped in ACM PR #305/#313). Falls back to kubectl only when the ACM deployment was started without K8S_MANAGEMENT_ENABLED=true and the K8s prefix is missing from tools/list. Never calls any of the eleven mutation tools (gated by ACM's READ_ONLY profile, including scale_k8s_cluster) without explicit user confirmation",
       "files": []
     }
   ]

--- a/skills/acm-mcp-init/SKILL.md
+++ b/skills/acm-mcp-init/SKILL.md
@@ -5,7 +5,12 @@ description: "Register one or many Aerospike Cluster Manager (ACM) MCP endpoints
 
 # ACM MCP Setup
 
-ACM exposes 21 MCP tools (records, query, asinfo, connections) at `/mcp` on its FastAPI port. Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>`.
+ACM exposes **27 MCP tools** at `/mcp` on its FastAPI port:
+
+* **22 data-plane tools** — connections (`list_connections`, `create_connection`, `connect`, `test_connection`, …), cluster info (`list_namespaces`, `list_sets`, `get_nodes`), asinfo (`execute_info`, `execute_info_on_node`, `execute_info_read_only`), records (`get_record`, `record_exists`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`), query (`query`).
+* **5 K8s-plane tools** — `list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `get_k8s_logs`, `scale_k8s_cluster`. Available only when the ACM deployment was started with `K8S_MANAGEMENT_ENABLED=true`; on plain (non-K8s) ACM deployments only the 22 data-plane tools are exposed.
+
+Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>`.
 
 For each endpoint collect: **name** (becomes the prefix — e.g. `dev`, `prod-us`), **url** (e.g. `http://localhost:8000/mcp`), **token** (optional bearer, can be empty when OIDC-only or anonymous-on-localhost).
 


### PR DESCRIPTION
## Summary
- `skills/acm-mcp-init/SKILL.md`: "21 MCP tools" → "27 MCP tools" with the 22 data-plane / 5 K8s-plane breakdown (the 5 K8s tools require the ACM deployment to run with `K8S_MANAGEMENT_ENABLED=true`).
- `agents/acko-cluster-debugger.md`: mutation list grows from 10 to 11 — adds `scale_k8s_cluster` so the agent's own "always confirm before mutation" guidance fires on a K8s scale. Also rewrites the K8s-plane section to prefer the now-shipped MCP tools (`list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `get_k8s_logs`) with `kubectl` as fallback. Removes stale "Phase 2 pending" wording.
- `evals/evals.json`: eval #10 expected_output rewritten to match the agent's new K8s MCP usage and 11-tool mutation list.

## Test plan
- [x] `jq -e .` passes for plugin.json / marketplace.json / evals.json / .mcp.json
- [x] Frontmatter on every SKILL.md + agent file still parses (`---` open + `name:` + `description:`)
- [x] Numbers internally consistent: 27 = 22 + 5 across the skill; 11 mutation tools across agent line 38 and eval #10
- [x] No stale "Phase 2 will replace" / "K8s tools pending" in the touched files
- [x] Live wire smoke against ACM master at /mcp: `tools/list` returns 27, `WRITE_TOOLS` membership returns `access_denied` for `scale_k8s_cluster` under `ACM_MCP_ACCESS_PROFILE=read_only`
- [ ] Run evals locally once Phase 2 ACM deployment is reachable