### PR TITLE
refactor(skills): demote debugging agent → skill + trim ~206 LOC of cross-skill duplication

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -23,14 +23,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Markdown link check (skills/agents/root)
+      - name: Markdown link check (skills/root)
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"
           config-file: ".github/markdown-link-check.json"
           file-extension: ".md"
-          folder-path: "skills,agents"
+          # ``agents`` was removed when ``acko-cluster-debugger`` was demoted to
+          # the ``acko-debugging`` skill. The directory no longer exists, so
+          # listing it here would fail with "Can't find the directory: agents".
+          # Re-add a comma-separated entry only when the plugin grows agents
+          # again.
+          folder-path: "skills"
           # Also scan top-level *.md (README, CHANGELOG, VERSIONING).
           file-path: "./README.md,./CHANGELOG.md,./VERSIONING.md"
           base-branch: "main"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ See [VERSIONING.md](./VERSIONING.md) for the compatibility matrix and deprecatio
 
 ## [Unreleased]
 
+### Changed
+
+- **`acko-cluster-debugger` agent → `acko-debugging` skill**: demoted to a skill so triggering happens via description match rather than explicit Task delegation. The 6-step procedure, CE 8.1 pitfalls, and remediation matrix are unchanged; routing through ACM MCP for both data-plane and K8s-plane (the K8s tools shipped in ACM PR #305/#313) is preserved. Subagent context isolation is the only capability lost — most diagnoses are single-shot anyway, and routine reads (`list_k8s_clusters`, `get_k8s_pods`, …) no longer have to spawn a subagent.
+
+### Fixed
+
+- **MCP tool count drift**: `acm-mcp-init` skill now states 27 tools (22 data-plane + 5 K8s-plane) instead of the stale 21.
+- **Mutation list completeness**: the demoted `acko-debugging` skill lists all 11 mutation tools, including the `scale_k8s_cluster` entry that was missing from the original 10-name list.
+
 ## [1.2.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,17 +53,12 @@ claude plugin list
 
 | Skill | Trigger | Description |
 |-------|---------|-------------|
-| **acm-mcp-init** | "register ACM MCP", "/acm-mcp-init" | Register one or many [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP endpoints with Claude Code so other skills/agents can read and operate live clusters. Multi-cluster ACKO friendly. |
-
-### Agents
-
-| Agent | Description |
-|-------|-------------|
-| **acko-cluster-debugger** | Systematic cluster debugging. Uses ACM MCP tools (`mcp__aerospike-{prefix}__list_namespaces`, `__execute_info`, `__query`, `__get_record`) for data-plane diagnosis; falls back to `kubectl`/`asinfo` for K8s-plane (pods, events, logs). Phase 2 will replace the K8s side with MCP tools too. |
+| **acm-mcp-init** | "register ACM MCP", "/acm-mcp-init" | Register one or many [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP endpoints with Claude Code so other skills can read and operate live clusters. Multi-cluster ACKO friendly. |
+| **acko-debugging** | "CrashLoopBackOff", "phase=Error", "reconcile failure", "migration stuck" | Systematic 6-step diagnosis procedure for ACKO clusters with CE 8.1 pitfalls and a remediation matrix. Routes both data-plane and K8s-plane probes through ACM MCP when registered (`list_namespaces`, `execute_info`, `query`, `list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `get_k8s_logs`); falls back to `kubectl`/`asinfo` otherwise. |
 
 ## MCP integration
 
-This plugin uses the [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP server (21 tools at `/mcp`) for live cluster access. Endpoints are registered per cluster-manager instance — register one entry per ACKO Helm release if you operate multiple clusters.
+This plugin uses the [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) MCP server (27 tools at `/mcp` — 22 data-plane + 5 K8s-plane) for live cluster access. Endpoints are registered per cluster-manager instance — register one entry per ACKO Helm release if you operate multiple clusters.
 
 The plugin ships an **empty `.mcp.json`** by design: nothing auto-registers on install. Onboarding goes through the `acm-mcp-init` skill so the user explicitly chooses which URLs and tokens to wire up. This keeps the install surface minimal and avoids surprising users with a broken `localhost:8000` entry on machines that don't run ACM.
 

--- a/agents/acko-cluster-debugger.md
+++ b/agents/acko-cluster-debugger.md
@@ -1,13 +1,13 @@
 ---
 name: acko-cluster-debugger
-description: "Debug and troubleshoot ACKO Aerospike clusters via ACM MCP tools (data plane) and kubectl/asinfo (K8s plane). Use when the user reports cluster issues, pod failures, deployment errors, CrashLoopBackOff, AerospikeCluster CRD phase=Error, stuck migrations, dynamic config rejections, operator log errors, or wants to diagnose Aerospike K8s problems."
+description: "Debug and troubleshoot ACKO Aerospike clusters via ACM MCP tools (data plane and K8s plane), with kubectl/asinfo as a fallback when the ACM deployment lacks K8s tooling. Use when the user reports cluster issues, pod failures, deployment errors, CrashLoopBackOff, AerospikeCluster CRD phase=Error, stuck migrations, dynamic config rejections, operator log errors, or wants to diagnose Aerospike K8s problems."
 ---
 
 # ACKO Cluster Debugger Agent
 
 You are a systematic debugger for Aerospike CE clusters managed by the ACKO (Aerospike CE Kubernetes Operator). When the user reports a cluster issue, follow this structured debugging procedure.
 
-This agent prefers **ACM MCP tools** for data-plane diagnosis (records, queries, asinfo) and falls back to **`kubectl`** for K8s-plane diagnosis (pods, events, logs). The K8s side will move to MCP tools in Phase 2.
+This agent prefers **ACM MCP tools** for *both* data-plane diagnosis (records, queries, asinfo) **and** K8s-plane diagnosis (`list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `get_k8s_logs`, `scale_k8s_cluster`). The K8s tools are exposed only when the ACM deployment runs with `K8S_MANAGEMENT_ENABLED=true`; if `tools/list` for the chosen prefix does not include them, fall back to **`kubectl`** for the K8s plane.
 
 ## Cluster Selection
 
@@ -35,7 +35,7 @@ You may still proceed with `kubectl`-only diagnosis, but call out that data-plan
 
 ## Mutation tools
 
-The MCP server enforces a **call-time** read/write gate. The 10 mutation tools are: `create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`. Under the `READ_ONLY` profile (default) they return `MCPToolError(code="access_denied")` before the body runs. `execute_info` is in the mutation list because asinfo can change cluster config (`set-config:`, `recluster:`, etc.).
+The MCP server enforces a **call-time** read/write gate. The 11 mutation tools are: `create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`, `scale_k8s_cluster`. Under the `READ_ONLY` profile (default) they return `MCPToolError(code="access_denied")` before the body runs. `execute_info` is in the mutation list because asinfo can change cluster config (`set-config:`, `recluster:`, etc.); `scale_k8s_cluster` patches the AerospikeCluster CR's `spec.size` so it carries the same blast-radius as a direct `kubectl patch`. **Always confirm with the user before invoking any of these eleven tools.**
 
 ## Debugging Procedure
 
@@ -65,10 +65,21 @@ mcp__aerospike-{prefix}__execute_info(conn_id="<conn>", command="statistics")
 
 Use `execute_info` results to see `cluster_size`, `migration_status`, `stop_writes`, etc. across all nodes.
 
-**K8s-plane status** (Phase 2 will replace this with ACKO MCP tools). For now, fall back to `kubectl`:
+**K8s-plane status — prefer MCP** (`K8S_MANAGEMENT_ENABLED=true` deployments only):
+
+```
+mcp__aerospike-{prefix}__list_k8s_clusters()
+mcp__aerospike-{prefix}__list_k8s_clusters(workspace_id="<ws>")        # filter by workspace label
+mcp__aerospike-{prefix}__get_k8s_pods(cluster_id="<ns>/<name>")        # phase/podIP/dynamicConfigStatus per pod
+mcp__aerospike-{prefix}__get_k8s_events(cluster_id="<ns>/<name>", since_minutes=30)
+mcp__aerospike-{prefix}__get_k8s_logs(cluster_id="<ns>/<name>", pod_name="<pod>", since_seconds=300, tail_lines=200)
+```
+
+`cluster_id` is `"<namespace>/<name>"`. The CR phase, size, conditions, and migration status are all in the `list_k8s_clusters` summary entry — there is no need to shell out for every field.
+
+**`kubectl` fallback** (when MCP K8s tools are not exposed by the ACM deployment, or when fields the MCP summary doesn't surface yet are needed):
 
 ```bash
-# K8s CRD status — kubectl fallback (Phase 2: replace with mcp__aerospike-{prefix}__get_aerospike_cluster)
 kubectl get asc -n <ns>
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.phase}'
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.phaseReason}'
@@ -189,6 +200,14 @@ Look for:
 - Resource creation failures
 
 ### Step 5: Check Events Timeline
+
+**Prefer MCP** (already classifies each event into `Rolling Restart`, `Configuration`, `Scaling`, `Network`, `Rack Management`, …):
+
+```
+mcp__aerospike-{prefix}__get_k8s_events(cluster_id="<ns>/<name>", since_minutes=60)
+```
+
+`kubectl` fallback (raw, unclassified):
 
 ```bash
 kubectl get events -n <ns> --field-selector involvedObject.name=<name> --sort-by='.lastTimestamp'

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -58,7 +58,7 @@
     {
       "id": 10,
       "prompt": "I have ACM MCP set up at aerospike-dev. Cluster prod is reporting CrashLoopBackOff on pods. Walk me through diagnosis using the MCP tools where available.",
-      "expected_output": "acko-cluster-debugger agent uses mcp__aerospike-dev__list_namespaces / __get_nodes / __execute_info for the data-plane portion of diagnosis, falls back to kubectl for pod/event/log inspection (Phase 2 will replace this with K8s MCP tools), never calls a mutation tool without explicit user confirmation",
+      "expected_output": "acko-cluster-debugger agent uses mcp__aerospike-dev__list_namespaces / __get_nodes / __execute_info for the data plane and mcp__aerospike-dev__list_k8s_clusters / __get_k8s_pods / __get_k8s_events / __get_k8s_logs for the K8s plane (the K8s MCP tools shipped in ACM PR #305/#313). Falls back to kubectl only when the ACM deployment was started without K8S_MANAGEMENT_ENABLED=true and the K8s prefix is missing from tools/list. Never calls any of the eleven mutation tools (gated by ACM's READ_ONLY profile, including scale_k8s_cluster) without explicit user confirmation",
       "files": []
     }
   ]

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -58,7 +58,7 @@
     {
       "id": 10,
       "prompt": "I have ACM MCP set up at aerospike-dev. Cluster prod is reporting CrashLoopBackOff on pods. Walk me through diagnosis using the MCP tools where available.",
-      "expected_output": "acko-cluster-debugger agent uses mcp__aerospike-dev__list_namespaces / __get_nodes / __execute_info for the data plane and mcp__aerospike-dev__list_k8s_clusters / __get_k8s_pods / __get_k8s_events / __get_k8s_logs for the K8s plane (the K8s MCP tools shipped in ACM PR #305/#313). Falls back to kubectl only when the ACM deployment was started without K8S_MANAGEMENT_ENABLED=true and the K8s prefix is missing from tools/list. Never calls any of the eleven mutation tools (gated by ACM's READ_ONLY profile, including scale_k8s_cluster) without explicit user confirmation",
+      "expected_output": "acko-debugging skill triggers (was the acko-cluster-debugger agent before its demotion to a skill); uses mcp__aerospike-dev__list_namespaces / __get_nodes / __execute_info for the data plane and mcp__aerospike-dev__list_k8s_clusters / __get_k8s_pods / __get_k8s_events / __get_k8s_logs for the K8s plane (the K8s MCP tools shipped in ACM PR #305/#313). Falls back to kubectl only when the ACM deployment was started without K8S_MANAGEMENT_ENABLED=true and the K8s prefix is missing from tools/list. Never calls any of the eleven mutation tools (gated by ACM's READ_ONLY profile, including scale_k8s_cluster) without explicit user confirmation",
       "files": []
     }
   ]

--- a/skills/acko-debugging/SKILL.md
+++ b/skills/acko-debugging/SKILL.md
@@ -1,49 +1,58 @@
 ---
-name: acko-cluster-debugger
-description: "Debug and troubleshoot ACKO Aerospike clusters via ACM MCP tools (data plane and K8s plane), with kubectl/asinfo as a fallback when the ACM deployment lacks K8s tooling. Use when the user reports cluster issues, pod failures, deployment errors, CrashLoopBackOff, AerospikeCluster CRD phase=Error, stuck migrations, dynamic config rejections, operator log errors, or wants to diagnose Aerospike K8s problems."
+name: acko-debugging
+description: "Systematic 6-step diagnosis procedure for ACKO-managed Aerospike CE clusters, with CE 8.1-specific pitfalls and a remediation matrix. Routes data-plane and K8s-plane probes through ACM MCP tools when registered, and falls back to kubectl/asinfo otherwise. MUST USE when the user reports CrashLoopBackOff, AerospikeCluster CRD phase=Error / WaitingForMigration / InProgress stuck, dynamic config rollback failed, ConfigDegraded, circuit breaker active, namespace stop-writes, split cluster, ACLSyncError, RestartFailed, ReadinessGateBlocking, ScaleDownDeferred, operator log errors, webhook rejection, or any troubleshooting flow that resolves to running diagnostic commands or queries against an ACKO Aerospike cluster. Triggers on: 'CrashLoopBackOff', 'phase=Error', 'reconcile failure', 'cluster won''t start', 'pods stuck', 'migration stuck', 'dynamic config failed', 'CE 8.1 config error', 'AerospikeCluster reconcile', 'debug aerospike cluster', 'troubleshoot ACKO'."
 ---
 
-# ACKO Cluster Debugger Agent
+# ACKO Cluster Debugging Procedure
 
-You are a systematic debugger for Aerospike CE clusters managed by the ACKO (Aerospike CE Kubernetes Operator). When the user reports a cluster issue, follow this structured debugging procedure.
+This skill provides the systematic procedure to follow when an ACKO-managed Aerospike CE cluster reports a problem. It encodes:
 
-This agent prefers **ACM MCP tools** for *both* data-plane diagnosis (records, queries, asinfo) **and** K8s-plane diagnosis (`list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `get_k8s_logs`, `scale_k8s_cluster`). The K8s tools are exposed only when the ACM deployment runs with `K8S_MANAGEMENT_ENABLED=true`; if `tools/list` for the chosen prefix does not include them, fall back to **`kubectl`** for the K8s plane.
+1. The 6-step ordering Aerospike SREs use during real outages,
+2. The CE 8.1-specific config pitfalls that surface as cryptic boot failures,
+3. A remediation matrix mapping observed symptoms to concrete fixes.
 
-## Cluster Selection
+For routine reads (`list_k8s_clusters`, `get_k8s_pods` etc.) the MCP tools are self-describing and you do **not** need this skill — call them directly. Load this skill when something is actually broken.
+
+## Tool routing — MCP first, kubectl fallback
+
+When ACM MCP is registered (`mcp__aerospike-*` tools available in the session) prefer it for *both* planes:
+
+* **Data plane** — `list_namespaces`, `get_nodes`, `execute_info`, `query`, `get_record`, `record_exists`, `list_sets`.
+* **K8s plane** — `list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `get_k8s_logs`, `scale_k8s_cluster`. These five are exposed only when the ACM deployment runs with `K8S_MANAGEMENT_ENABLED=true`. If `tools/list` for the chosen prefix does not include them, fall back to `kubectl` for the K8s plane.
+
+If **no `mcp__aerospike-*` tools are available** in this session, tell the user:
+
+> ACM MCP is not registered in this session. Run `/acm-mcp-init` (or invoke the `acm-mcp-init` skill) to register one or more cluster-manager endpoints, then retry. You may still proceed with `kubectl`-only diagnosis, but data-plane probes (`asinfo`, record sampling, query) will be limited to `kubectl exec` rather than the typed MCP layer.
+
+## Cluster selection
 
 Many users run multi-cluster ACKO. The user's wording usually indicates which cluster — phrases like "in dev", "production EU", "the prod-us cluster". Map the named cluster to the registered MCP prefix:
 
 | User says | MCP prefix used |
 |-----------|-----------------|
-| "in dev"/"local"/"my workstation" | `mcp__aerospike-dev__*` |
+| "in dev" / "local" / "my workstation" | `mcp__aerospike-dev__*` |
 | "in staging" | `mcp__aerospike-staging__*` |
-| "in prod-us"/"production US" | `mcp__aerospike-prod-us__*` |
+| "in prod-us" / "production US" | `mcp__aerospike-prod-us__*` |
 
-When multiple ACM endpoints could match or none is named, list registered endpoints (via `claude mcp list`) and ask the user to disambiguate.
+When multiple ACM endpoints could match or none is named, list registered endpoints (`claude mcp list`) and ask the user to disambiguate. Replace `{prefix}` below with the resolved prefix.
 
-If **no `mcp__aerospike-*` tools are available** in this session, the agent's MCP path cannot run. Tell the user:
+## Mutation tools — confirm before invoking
 
-> ACM MCP is not registered in this session. Run `/acm-mcp-init` (or invoke the `acm-mcp-init` skill) to register one or more cluster-manager endpoints, then retry.
+The MCP server enforces a **call-time** read/write gate. Under the default `READ_ONLY` profile the eleven mutation tools below return `MCPToolError(code="access_denied")` before the body runs — this is the safety net.
 
-You may still proceed with `kubectl`-only diagnosis, but call out that data-plane probes (`asinfo`, record sampling, query) will be limited to `kubectl exec` rather than the typed MCP layer.
+If the deployment is configured with `ACM_MCP_ACCESS_PROFILE=full` the server-side gate is *off* and only this skill's confirmation rule remains. **Always confirm with the user before invoking any of the eleven mutation tools**:
 
-## When to Use
+`create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`, `scale_k8s_cluster`.
 
-- CrashLoopBackOff, `phase=Error`, stuck `WaitingForMigration`, AerospikeCluster CRD reconcile failures, operator log errors, dynamic config rejections.
-- Investigating pod-level issues, namespace stop-writes, split clusters, or per-pod migration progress.
-- Any troubleshooting flow that resolves to running diagnostic commands or queries against a cluster.
+`execute_info` is in the mutation list because asinfo can change cluster config (`set-config:`, `recluster:`, etc.); `scale_k8s_cluster` patches the AerospikeCluster CR's `spec.size` so it carries the same blast radius as a direct `kubectl patch`. For diagnostic asinfo reads under `READ_ONLY`, prefer `execute_info_read_only` (whitelisted verbs only) which is **not** in the mutation list.
 
-## Mutation tools
+## Debugging procedure
 
-The MCP server enforces a **call-time** read/write gate. The 11 mutation tools are: `create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`, `scale_k8s_cluster`. Under the `READ_ONLY` profile (default) they return `MCPToolError(code="access_denied")` before the body runs. `execute_info` is in the mutation list because asinfo can change cluster config (`set-config:`, `recluster:`, etc.); `scale_k8s_cluster` patches the AerospikeCluster CR's `spec.size` so it carries the same blast-radius as a direct `kubectl patch`. **Always confirm with the user before invoking any of these eleven tools.**
+Execute these steps in order. Stop and report findings as soon as you identify the root cause.
 
-## Debugging Procedure
+### Step 1 — Gather cluster overview
 
-Execute these steps in order. Stop and report findings as soon as you identify the root cause. Replace `{prefix}` below with the MCP prefix from "Cluster Selection".
-
-### Step 1: Gather Cluster Overview
-
-**Data-plane discovery via MCP** (preferred — no shell needed). The user must have an active connection profile registered with ACM (created via the cluster-manager UI or the `create_connection` MCP tool).
+**Data-plane discovery via MCP.** The user must have an active connection profile registered with ACM (created via the cluster-manager UI or the `create_connection` MCP tool).
 
 If the user has not specified a `conn_id`, list available profiles first:
 
@@ -89,7 +98,7 @@ kubectl get asc <name> -n <ns> -o jsonpath='{.status.migrationStatus}' | jq .
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.aerospikeClusterSize}'
 ```
 
-### Step 2: Branch Based on Phase
+### Step 2 — Branch based on phase
 
 #### If Phase = `Error`
 
@@ -100,11 +109,11 @@ kubectl get events -n <ns> --field-selector involvedObject.name=<name> --sort-by
 ```
 
 Check for:
-- Invalid aerospikeConfig (config parse errors)
+- Invalid `aerospikeConfig` (config parse errors)
 - Image pull failures (wrong image name or registry access)
 - Resource quota exceeded
 - Webhook validation failures
-- Circuit breaker activation (failedReconcileCount >= 10)
+- Circuit breaker activation (`failedReconcileCount >= 10`)
 
 #### If Phase = `WaitingForMigration`
 
@@ -119,7 +128,7 @@ kubectl exec -n <ns> <pod> -c aerospike-server -- asinfo -v 'statistics' | tr ';
 
 This is usually normal during scale-down. Report `migrationStatus.remainingPartitions` progress and advise waiting.
 
-#### If Phase = `InProgress` (Stuck > 5 Minutes)
+#### If Phase = `InProgress` (stuck > 5 minutes)
 
 ```bash
 kubectl get pods -n <ns> -l aerospike.io/cr-name=<name> -o wide
@@ -133,7 +142,7 @@ Check for:
 - ImagePullBackOff (wrong image name or no pull secret)
 - Scheduling failures (insufficient CPU/memory, node affinity mismatch)
 
-#### If Phase = `Completed` but User Reports Issues
+#### If Phase = `Completed` but user reports issues
 
 **Prefer MCP** for data-plane probes:
 
@@ -169,26 +178,26 @@ kubectl exec -n <ns> <pod> -c aerospike-server -- asinfo -v 'namespace/<ns-name>
 ```
 
 Check for:
-- Split cluster (cluster_size mismatch across pods)
+- Split cluster (`cluster_size` mismatch across pods)
 - Namespace stop-writes (near capacity)
-- Connection issues (proto-fd-max reached)
+- Connection issues (`proto-fd-max` reached)
 
-### Step 3: Check Pod-Level Issues
+### Step 3 — Check pod-level issues
 
-For any pods not in Running state:
+For any pods not in `Running` state:
 
 ```bash
 kubectl describe pod <pod> -n <ns>
 kubectl logs -n <ns> <pod> -c aerospike-server
-kubectl logs -n <ns> <pod> -c aerospike-server --previous   # If CrashLoopBackOff
+kubectl logs -n <ns> <pod> -c aerospike-server --previous   # if CrashLoopBackOff
 ```
 
 Common pod-level issues:
-- **CrashLoopBackOff**: Config parse error (check for removed 7.x parameters in CE 8.1), OOM, or data-size below 512 MiB minimum
-- **ImagePullBackOff**: Wrong image name or missing imagePullSecret
-- **Pending**: Insufficient resources or PVC not bound
+- **CrashLoopBackOff**: config parse error (check for removed 7.x parameters in CE 8.1), OOM, or `data-size` below 512 MiB minimum
+- **ImagePullBackOff**: wrong image name or missing imagePullSecret
+- **Pending**: insufficient resources or PVC not bound
 
-### Step 4: Check Operator Logs
+### Step 4 — Check operator logs
 
 ```bash
 kubectl -n aerospike-operator logs -l control-plane=controller-manager --tail=200
@@ -199,7 +208,7 @@ Look for:
 - Webhook rejection messages
 - Resource creation failures
 
-### Step 5: Check Events Timeline
+### Step 5 — Check events timeline
 
 **Prefer MCP** (already classifies each event into `Rolling Restart`, `Configuration`, `Scaling`, `Network`, `Rack Management`, …):
 
@@ -215,14 +224,14 @@ kubectl get events -n <ns> --field-selector involvedObject.name=<name> --sort-by
 
 Key events to look for:
 - `CircuitBreakerActive`: 10+ consecutive failures, operator in backoff
-- `RestartFailed`: Pod restart failed during rolling update
-- `ScaleDownDeferred`: Migration blocking scale-down
-- `DynamicConfigStatusFailed`: Dynamic config change failed
+- `RestartFailed`: pod restart failed during rolling update
+- `ScaleDownDeferred`: migration blocking scale-down
+- `DynamicConfigStatusFailed`: dynamic config change failed
 - `ACLSyncError`: ACL synchronization failed
-- `TemplateResolutionError`: Template parsing failed
-- `ReadinessGateBlocking`: Readiness gate not satisfied
+- `TemplateResolutionError`: template parsing failed
+- `ReadinessGateBlocking`: readiness gate not satisfied
 
-### Step 6: Check Dynamic Config Status (If Applicable)
+### Step 6 — Check dynamic config status (if applicable)
 
 ```bash
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq '.[].dynamicConfigStatus'
@@ -230,38 +239,40 @@ kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq '.[].dynamicCon
 
 If status is `Failed`, the changed parameter is not dynamically changeable. Advise setting `enableDynamicConfigUpdate: false` to force a rolling restart.
 
-## Remediation Actions
+## Remediation actions
 
 After identifying the root cause, suggest the specific fix:
 
 | Issue | Remediation |
 |-------|-------------|
-| Config parse error | Fix aerospikeConfig in CR and re-apply |
+| Config parse error | Fix `aerospikeConfig` in CR and re-apply |
 | Image pull failure | Fix image name or add imagePullSecret |
 | PVC Pending | Check StorageClass exists and has capacity |
 | Resource insufficient | Reduce resource requests or add nodes to K8s cluster |
-| CE constraint violation | Fix CR to comply (size<=8, namespaces<=2, no xdr/tls, CE image) |
+| CE constraint violation | Fix CR to comply (size ≤ 8, namespaces ≤ 2, no xdr/tls, CE image) |
 | Circuit breaker active | Fix root cause; operator auto-retries with backoff |
-| Dynamic config failed | Set enableDynamicConfigUpdate: false for rolling restart |
-| Split cluster | Verify network connectivity, check cluster-name consistency. Compare `status.aerospikeClusterSize` with `status.size` |
+| Dynamic config failed | Set `enableDynamicConfigUpdate: false` for rolling restart |
+| Split cluster | Verify network connectivity, check `cluster-name` consistency. Compare `status.aerospikeClusterSize` with `status.size` |
 | Stop writes | Increase storage capacity or reduce data volume |
 | ACL sync error | Verify Secret exists with correct password key |
 | Operations stuck | Clear operations: `kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"operations":null}}'` |
 
-## CE 8.1 Common Pitfalls
+## CE 8.1 common pitfalls
 
 Always check for these CE 8.1-specific issues:
-1. **`info` port block in config**: Removed in 8.1. Causes parse error. Use `admin { port 3008 }` instead.
-2. **`memory-size` used**: Removed. Use `storage-engine memory { data-size N }` with integer bytes.
-3. **`write-block-size` used**: Replaced by `flush-size` in 7.1+.
-4. **`data-size` below 512 MiB**: Minimum is 536870912 bytes.
-5. **`nsup-period=0` with `default-ttl!=0`**: Server fails to start.
-6. **Byte values as strings**: All sizes in aerospikeConfig must be integer bytes, not "4G" or "1M".
 
-## Output Format
+1. **`info` port block in config** — removed in 8.1. Causes parse error. Use `admin { port 3008 }` instead.
+2. **`memory-size` used** — removed. Use `storage-engine memory { data-size N }` with integer bytes.
+3. **`write-block-size` used** — replaced by `flush-size` in 7.1+.
+4. **`data-size` below 512 MiB** — minimum is 536870912 bytes.
+5. **`nsup-period=0` with `default-ttl!=0`** — server fails to start.
+6. **Byte values as strings** — all sizes in `aerospikeConfig` must be integer bytes, not `"4G"` or `"1M"`.
+
+## Output format
 
 After completing the investigation, provide:
-1. **Root Cause**: Clear description of what is wrong
-2. **Evidence**: The specific command output that shows the problem
-3. **Fix**: Step-by-step remediation commands the user can run
-4. **Prevention**: How to avoid this issue in the future
+
+1. **Root cause** — clear description of what is wrong.
+2. **Evidence** — the specific command output that shows the problem.
+3. **Fix** — step-by-step remediation commands the user can run.
+4. **Prevention** — how to avoid this issue in the future.

--- a/skills/acko-debugging/SKILL.md
+++ b/skills/acko-debugging/SKILL.md
@@ -182,6 +182,15 @@ Check for:
 - Namespace stop-writes (near capacity)
 - Connection issues (`proto-fd-max` reached)
 
+#### If Phase = `ConfigDegraded`
+
+```bash
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=="DynamicConfigDegraded")]}' | jq
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq
+```
+
+Meaning: a 2PC dynamic config update failed AND the LIFO rollback also failed. Different pods now hold different runtime configs. The operator will attempt a cold restart on the next reconcile to converge to spec. **Do not** manually flip `enableDynamicConfigUpdate` or re-apply the change — let the cold restart run. If the cold-restart loop continues, the underlying value is invalid for the deployed hardware shape — revert spec to the last known-good value and re-apply. Recovery is complete when `phase=Completed` and the `DynamicConfigDegraded` condition clears.
+
 ### Step 3 — Check pod-level issues
 
 For any pods not in `Running` state:

--- a/skills/acko-deploy/SKILL.md
+++ b/skills/acko-deploy/SKILL.md
@@ -167,39 +167,17 @@ Webhook auto-settings and CRD field mapping: See acko-config-reference skill's `
 
 ## 6. Verification Commands
 
-Run these after deploying or modifying a cluster.
+CR-specific status fields worth knowing — everything else is a normal `kubectl get pods/events` / `kubectl exec asinfo` flow:
 
 ```bash
-# List all Aerospike clusters with their phase
-kubectl get asc -n aerospike
-
-# Check specific cluster phase
-kubectl get asc <name> -n aerospike -o jsonpath='{.status.phase}'
-
-# Check phase reason (useful when phase is Error or InProgress)
-kubectl get asc <name> -n aerospike -o jsonpath='{.status.phaseReason}'
-
-# Check all conditions
-kubectl get asc <name> -n aerospike -o jsonpath='{.status.conditions}' | jq .
-
-# Check pod status details
-kubectl get asc <name> -n aerospike -o jsonpath='{.status.pods}' | jq .
-
-# Check ready pod count
-kubectl get asc <name> -n aerospike -o jsonpath='{.status.size}'
-
-# Check cluster events (most recent last)
-kubectl get events -n aerospike --field-selector involvedObject.name=<name> --sort-by='.lastTimestamp'
-
-# Verify Aerospike service is responding
-kubectl exec -n aerospike <pod-name> -c aerospike-server -- asinfo -v status
-
-# Check cluster membership
-kubectl exec -n aerospike <pod-name> -c aerospike-server -- asinfo -v 'statistics' | tr ';' '\n' | grep cluster_size
-
-# Check namespace stats
-kubectl exec -n aerospike <pod-name> -c aerospike-server -- asinfo -v 'namespace/<namespace-name>'
+kubectl get asc -n <ns>                                                                    # all clusters with phase + ready/total
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.phase}'                                # current phase
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.phaseReason}'                          # why (when Error / InProgress)
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions}' | jq .                    # ReconcileHealthy / DynamicConfigDegraded / etc.
+kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq .                          # per-pod state (rack, dynamicConfigStatus, …)
 ```
+
+For systematic diagnosis when something is wrong, load the `acko-debugging` skill.
 
 ---
 

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -145,7 +145,7 @@ Top-level statuses:
 
 ### When apply AND rollback both fail
 
-You will see `phase = ConfigDegraded`. Do NOT try to "fix" it by toggling `enableDynamicConfigUpdate` — the operator will cold-restart the pods on the next reconcile to reach a consistent state. See §14 troubleshooting for recovery.
+You will see `phase = ConfigDegraded`. Do NOT try to "fix" it by toggling `enableDynamicConfigUpdate` — the operator will cold-restart the pods on the next reconcile to reach a consistent state. See the `acko-debugging` skill for the full recovery flow.
 
 ### Static Config Change (Requires Restart)
 
@@ -278,7 +278,7 @@ kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":null}}'
 
 **Phase**: `Paused` -> `InProgress` -> `Completed`
 
-On resume, the operator clears stale `status.failedReconcileCount` and `status.lastReconcileError`. This is the recommended way to clear a stuck circuit breaker after fixing a permanent error (see §14).
+On resume, the operator clears stale `status.failedReconcileCount` and `status.lastReconcileError`. This is the recommended way to clear a stuck circuit breaker after fixing a permanent error (see the `acko-debugging` skill).
 
 ### Pause/Resume Metrics
 
@@ -373,178 +373,11 @@ Detail: `./reference/operations.md` (Section 7: Readiness Gate)
 
 ---
 
-## 14. Troubleshooting Decision Tree
+## 14. Troubleshooting
 
-Use this decision tree to diagnose cluster issues systematically.
+For systematic outage diagnosis (`phase=Error`, stuck migrations, `CrashLoopBackOff`, `CircuitBreakerActive`, `ConfigDegraded`, `ReadinessGateBlocking`, webhook rejection, `dynamicConfigStatus=Failed`, paused reconciliation), use the dedicated **`acko-debugging` skill** — it carries the 6-step procedure, CE 8.1 pitfalls, and remediation matrix that used to live here.
 
-### Phase = Error
-
-```
-1. Get the error message:
-   kubectl get asc <name> -n <ns> -o jsonpath='{.status.lastReconcileError}'
-
-2. Check events for details:
-   kubectl get events -n <ns> --field-selector involvedObject.name=<name> --sort-by='.lastTimestamp'
-
-3. Common causes:
-   - Invalid aerospikeConfig (parse error) -> Fix config and re-apply
-   - Image pull failure -> Check image name, registry access, imagePullSecrets
-   - Resource quota exceeded -> Increase quota or reduce resource requests
-   - Webhook rejection -> Check CE constraints (see acko-deploy skill)
-
-4. After fixing: the operator auto-retries reconciliation.
-```
-
-### Phase = WaitingForMigration
-
-```
-1. This is NORMAL during scale-down. The operator waits for data migration to finish.
-
-2. Check migration progress:
-   kubectl exec -n <ns> <pod> -c aerospike-server -- asinfo -v 'statistics' | tr ';' '\n' | grep migrate
-
-3. If migrate_partitions_remaining = 0, migration is complete.
-
-4. The operator auto-proceeds after migration completes. No manual action needed.
-```
-
-### Phase = InProgress (Stuck for > 5 Minutes)
-
-```
-1. Check for pending PVCs:
-   kubectl get pvc -n <ns> -l aerospike.io/cr-name=<name>
-   -> If PVC is Pending: check StorageClass, available capacity
-
-2. Check for image pull issues:
-   kubectl describe pod <pod> -n <ns> | grep -A5 "Events:"
-
-3. Check for scheduling failures:
-   kubectl get pods -n <ns> -l aerospike.io/cr-name=<name> -o wide
-   kubectl describe pod <pending-pod> -n <ns>
-
-4. Check operator logs:
-   kubectl -n aerospike-operator logs -l control-plane=controller-manager --tail=200
-```
-
-### Pod CrashLoopBackOff
-
-```
-1. Check the Aerospike server logs from the crashed container:
-   kubectl -n <ns> logs <pod> -c aerospike-server --previous
-
-2. Common causes:
-   - Config parse error (e.g., using removed 'info' port block in 8.1)
-   - data-size too small (minimum 512 MiB)
-   - nsup-period=0 with non-zero default-ttl
-   - Memory limit too low for configured data-size
-
-3. Fix the aerospikeConfig in the CR and re-apply.
-```
-
-### CircuitBreakerActive Event
-
-```
-1. Check failure count and breaker metric:
-   kubectl get asc <name> -n <ns> -o jsonpath='{.status.failedReconcileCount}'
-   # Promql: acko_circuit_breaker_active{cluster="<name>"} == 1
-
-2. Check the last error:
-   kubectl get asc <name> -n <ns> -o jsonpath='{.status.lastReconcileError}'
-
-3. Determine if the error is permanent or transient:
-   kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=="ReconcileHealthy")]}' | jq
-
-   - status=False, reason=PermanentError -> validation/configgen/secret error.
-     The operator does NOT auto-retry. failedReconcileCount is pinned at max
-     (no exponential backoff to wait through). You MUST take action:
-       a) Fix the root cause (correct the spec, create the missing Secret, etc.)
-       b) Then either edit the spec to retrigger reconcile, OR toggle pause
-          to clear stale failedReconcileCount and lastReconcileError:
-            kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":true}}'
-            kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":null}}'
-
-   - status=True (transient) -> operator will retry with backoff.
-     Just fix the underlying transient cause (image pull, capacity, etc.).
-
-4. After a successful reconciliation, CircuitBreakerReset event is emitted and
-   acko_circuit_breaker_active drops to 0.
-```
-
-### Phase = ConfigDegraded (NEW, April 2026)
-
-```
-1. Confirm the condition:
-   kubectl get asc <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=="DynamicConfigDegraded")]}' | jq
-
-2. Inspect per-pod, per-path detail:
-   kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq
-
-3. Meaning: a 2PC dynamic config update failed AND the LIFO rollback also failed.
-   Different pods now have different runtime configs. The operator will attempt
-   a cold restart on the next reconcile to converge to spec.
-
-4. Action: do NOT manually flip enableDynamicConfigUpdate or re-apply the change.
-   Let the cold restart run. If the cold restart loop continues, the underlying
-   config value is invalid for some hardware shape -- revert the spec to the
-   previous known-good value and re-apply.
-
-5. Recovery is complete when phase=Completed and DynamicConfigDegraded is no
-   longer present in conditions.
-```
-
-### ReconciliationPaused = True (Operator Inaction)
-
-```
-1. The operator is intentionally not reconciling because spec.paused=true.
-   This is a normal state, not an error.
-
-2. Resume:
-   kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"paused":null}}'
-
-3. Resume also clears stale failedReconcileCount and lastReconcileError --
-   useful for unsticking a circuit breaker after fixing a permanent error.
-```
-
-### Webhook Rejects CR (Apply Error)
-
-```
-1. Read the error message from kubectl apply output.
-
-2. Common CE constraint violations:
-   - size > 8
-   - namespaces > 2
-   - Enterprise image (contains 'enterprise', 'ee-', or 'ent-')
-   - xdr or tls section present
-   - heartbeat.mode != mesh
-   - Missing admin user with sys-admin + user-admin roles
-
-3. See reference/validation-rules.md for the complete list of validation errors and warnings (count grows over releases — see file header).
-```
-
-### dynamicConfigStatus = Failed
-
-```
-1. Check which pods failed:
-   kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq '.[].dynamicConfigStatus'
-
-2. The parameter you changed is not dynamically changeable.
-
-3. Fix: set enableDynamicConfigUpdate to false to force a rolling restart:
-   kubectl patch asc <name> -n <ns> --type=merge \
-     -p '{"spec":{"enableDynamicConfigUpdate":false}}'
-```
-
-### ReadinessGateBlocking Event
-
-```
-1. Check pod conditions:
-   kubectl get pod <pod> -o jsonpath='{.status.conditions}' | jq '.[]'
-
-2. The readiness gate acko.io/aerospike-ready is not satisfied.
-
-3. Check if Aerospike is actually running and healthy inside the pod:
-   kubectl exec -n <ns> <pod> -c aerospike-server -- asinfo -v status
-```
+`reference/troubleshooting.md` and `reference/validation-rules.md` (kept in this skill) remain the canonical symptom-→command and webhook-error catalogs that `acko-debugging` cross-links into.
 
 ---
 

--- a/skills/acm-mcp-init/SKILL.md
+++ b/skills/acm-mcp-init/SKILL.md
@@ -5,7 +5,12 @@ description: "Register one or many Aerospike Cluster Manager (ACM) MCP endpoints
 
 # ACM MCP Setup
 
-ACM exposes 21 MCP tools (records, query, asinfo, connections) at `/mcp` on its FastAPI port. Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>`.
+ACM exposes **27 MCP tools** at `/mcp` on its FastAPI port:
+
+* **22 data-plane tools** — connections (`list_connections`, `create_connection`, `connect`, `test_connection`, …), cluster info (`list_namespaces`, `list_sets`, `get_nodes`), asinfo (`execute_info`, `execute_info_on_node`, `execute_info_read_only`), records (`get_record`, `record_exists`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`), query (`query`).
+* **5 K8s-plane tools** — `list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `get_k8s_logs`, `scale_k8s_cluster`. Available only when the ACM deployment was started with `K8S_MANAGEMENT_ENABLED=true`; on plain (non-K8s) ACM deployments only the 22 data-plane tools are exposed.
+
+Each registered endpoint becomes addressable as `mcp__aerospike-<name>__<tool>`.
 
 For each endpoint collect: **name** (becomes the prefix — e.g. `dev`, `prod-us`), **url** (e.g. `http://localhost:8000/mcp`), **token** (optional bearer, can be empty when OIDC-only or anonymous-on-localhost).
 

--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -247,33 +247,7 @@ Detail: `./reference/observability.md`
 
 ## 12. FastAPI Integration
 
-```python
-from contextlib import asynccontextmanager
-from fastapi import FastAPI, Request, Depends
-from aerospike_py import AsyncClient
-import aerospike_py
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    client = AsyncClient({"hosts": [("127.0.0.1", 18710)], "max_concurrent_operations": 64})
-    aerospike_py.init_tracing(); await client.connect()
-    app.state.aerospike = client
-    yield
-    await client.close(); aerospike_py.shutdown_tracing()
-
-app = FastAPI(lifespan=lifespan)
-get_client = lambda r: r.app.state.aerospike
-
-@app.get("/records/{pk}")
-async def get_record(pk: str, client: AsyncClient = Depends(get_client)):
-    try:
-        return (await client.get(("test", "demo", pk))).bins
-    except aerospike_py.RecordNotFound:
-        from fastapi.responses import JSONResponse
-        return JSONResponse(status_code=404, content={"error": "not found"})
-```
-
-Detail: `./reference/client-config.md` | `./reference/types.md`
+For full FastAPI patterns (lifespan + Depends, exception → HTTP-status mapping including `BackpressureError → 503`, `client.ping()` readiness probe, batch endpoints, global handlers), use the dedicated **`aerospike-py-fastapi` skill**. It auto-triggers on FastAPI / REST API + Aerospike phrasing.
 
 ## 13. Policy Reference
 

--- a/skills/aerospike-py-api/reference/health.md
+++ b/skills/aerospike-py-api/reference/health.md
@@ -39,37 +39,7 @@ Use `ping()` for **readiness**, not liveness:
 
 ### FastAPI readiness example
 
-```python
-from fastapi import FastAPI, Depends, Request
-from fastapi.responses import JSONResponse
-from aerospike_py import AsyncClient
-
-app = FastAPI()
-
-def get_client(request: Request) -> AsyncClient:
-    return request.app.state.aerospike
-
-@app.get("/health/ready")
-async def ready(client: AsyncClient = Depends(get_client)):
-    return {"status": "ok"} if await client.ping() else JSONResponse(503, {"status": "unhealthy"})
-
-@app.get("/health/live")
-async def live():
-    return {"status": "ok"}
-```
-
-K8s manifest snippet:
-
-```yaml
-readinessProbe:
-  httpGet: { path: /health/ready, port: 8080 }
-  periodSeconds: 5
-  failureThreshold: 3
-livenessProbe:
-  httpGet: { path: /health/live, port: 8080 }
-  periodSeconds: 10
-  failureThreshold: 3
-```
+For the `client.ping()`-driven `/health/ready` route (with `Depends(get_client)` and the `JSONResponse(503, …)` unhealthy path) and the matching K8s `readinessProbe` / `livenessProbe` manifest snippet, see the `aerospike-py-fastapi` skill — it carries the same pattern with the rest of the FastAPI wiring.
 
 ---
 

--- a/skills/aerospike-py-api/reference/observability.md
+++ b/skills/aerospike-py-api/reference/observability.md
@@ -103,45 +103,7 @@ Span name is `{OPERATION} {namespace}.{set}` (e.g. `PUT test.users`).
 
 ## FastAPI Integration
 
-Wire metrics + tracing into your app's lifespan so they boot and shut down with the server.
-
-```python
-from contextlib import asynccontextmanager
-
-import aerospike_py
-from aerospike_py import AsyncClient
-from fastapi import FastAPI
-
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    # Boot observability before opening the client so connect() spans are captured.
-    aerospike_py.start_metrics_server(port=9464)
-    aerospike_py.init_tracing()  # OTLP exporter via OTEL_EXPORTER_OTLP_ENDPOINT
-
-    client = AsyncClient({"hosts": [("aerospike", 3000)], "max_concurrent_operations": 64})
-    await client.connect()
-    app.state.aerospike = client
-
-    yield
-
-    await client.close()
-    aerospike_py.shutdown_tracing()
-    aerospike_py.stop_metrics_server()
-
-
-app = FastAPI(lifespan=lifespan)
-```
-
-The metrics server runs on its own daemon thread (separate port from your FastAPI server) — Prometheus scrapes `http://<pod>:9464/metrics`. If you must serve `/metrics` from the FastAPI port instead, expose your own route returning `aerospike_py.get_metrics()` and skip `start_metrics_server()`:
-
-```python
-from fastapi.responses import PlainTextResponse
-
-@app.get("/metrics")
-def metrics() -> PlainTextResponse:
-    return PlainTextResponse(aerospike_py.get_metrics(), media_type="text/plain; version=0.0.4")
-```
+For the full lifespan pattern wiring `start_metrics_server` / `init_tracing` / `AsyncClient` together (with the correct shutdown ordering and the alternative `/metrics` route via `aerospike_py.get_metrics()` instead of the dedicated port), see the `aerospike-py-fastapi` skill.
 
 ---
 


### PR DESCRIPTION
## Summary

Two-part refactor of the plugin's skill surface, bundled because they share the same underlying observation: the `acko-cluster-debugger` agent's debugging procedure already overlapped heavily with `acko-operations §14` and `aerospike-py-api §12` overlapped with the dedicated `aerospike-py-fastapi` skill. After demoting the agent the duplication was begging to be removed.

### Part 1 — agent → skill demotion

Converts `agents/acko-cluster-debugger.md` to `skills/acko-debugging/SKILL.md`. The agent-vs-skill choice reduces to: *is subagent context isolation worth the maintenance overhead?* For ACKO debugging the answer is no — most diagnoses are single-shot, and routine reads (`list_k8s_clusters`, `get_k8s_pods`, …) shouldn't have to spawn a subagent. Trigger by description match on outage phrases is the more natural call path.

Behavioural content kept verbatim: 6-step procedure, CE 8.1 pitfalls, remediation matrix, **11-tool** mutation list (now correctly includes `scale_k8s_cluster`), multi-cluster MCP prefix routing, MCP-first / kubectl-fallback for both data and K8s plane.

### Part 2 — content trim (~206 LOC net)

| Where | Before | After | Why |
|-------|--------|-------|-----|
| `acko-operations` §14 Troubleshooting Decision Tree | ~190 LOC | 4-line cross-ref | Duplicated the new `acko-debugging` skill |
| `aerospike-py-api` §12 FastAPI Integration | ~30 LOC code block | 1-line cross-ref | Duplicated `aerospike-py-fastapi` skill |
| `acko-deploy` §6 Verification Commands | ~38 LOC | 6-line CR-status-only block | Most lines were generic `kubectl get`/`kubectl exec asinfo` |
| `acko-debugging` | n/a | + 9-line ConfigDegraded sub-section | Carries over the only §14 content with no other home |

Net: **-227 / +21 = -206 LOC**, zero information loss — every removed section is now reachable through a one-hop cross-reference.

### Mutation safety net

The MCP server's `READ_ONLY` access profile is the call-time gate. The skill's confirm-before-mutate rule is the second layer for `full`-profile deployments. Eleven tools: `create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`, `scale_k8s_cluster`.

## Test plan

- [x] `jq -e .` clean for all 4 JSON manifests
- [x] Frontmatter parses on all 8 SKILL.md files (was 7 + 1 agent; now 8 skills, 0 agents)
- [x] No live `acko-cluster-debugger` references outside CHANGELOG history and the eval-#10 narrative
- [x] No stale "see §14 troubleshooting" back-references after the trim
- [x] Tool counts internally consistent (27 = 22 + 5 in `acm-mcp-init`, README, CHANGELOG; 11 mutation tools in `acko-debugging`, evals.json)
- [x] `agents/` directory removed
- [x] `acko-debugging` carries the ConfigDegraded recovery flow that previously lived only in `acko-operations §14`
- [ ] Smoke: load the plugin in a fresh Claude Code session, paste a CrashLoopBackOff prompt, confirm `acko-debugging` triggers and the procedure runs inline

## Note

Supersedes #20 (the doc-count / mutation-list correction landed as part of Part 1 here).