### PR TITLE
fix(ackoctl): align skill docs with the actual ackoctl CLI

### DIFF
--- a/skills/ackoctl/SKILL.md
+++ b/skills/ackoctl/SKILL.md
@@ -190,34 +190,36 @@ Cluster identifiers use the `"<namespace>/<name>"` form — always quote them in
 
 ```bash
 # Whitelisted read verbs (status, statistics, namespace/<ns>, ...) — safe by default
-ackoctl info exec <CONN_ID> --command='statistics'
-ackoctl info exec <CONN_ID> --command='namespace/test'
-ackoctl info exec <CONN_ID> --command='status' --node=BB9020014270008
+ackoctl info <CONN_ID> --command='statistics'
+ackoctl info <CONN_ID> --command='namespace/test'
+ackoctl info <CONN_ID> --command='status' --node=BB9020014270008
 
-# Mutation verbs (set-config:, recluster:, ...) require --allow-write and confirmation
-ackoctl info exec <CONN_ID> --command='set-config:context=service;proto-fd-max=20000' --allow-write --yes
+# Multiple verbs in one call: --command is repeatable
+ackoctl info <CONN_ID> --command=build --command=version
+
+# Mutation verbs (set-config:, recluster:, ...) require --allow-write
+ackoctl info <CONN_ID> --command='set-config:context=service;proto-fd-max=20000' --allow-write
 ```
 
-`ackoctl info exec` always reaches cluster-manager; it never bypasses the workspace ACL. For diagnostic reads under restricted profiles, the whitelisted-verbs path is the default; mutation verbs are an explicit opt-in.
+`ackoctl info` always reaches cluster-manager; it never bypasses the workspace ACL. For diagnostic reads under restricted profiles, the whitelisted-verbs path is the default; mutation verbs are an explicit opt-in via `--allow-write`.
 
 ### admin — users and roles (security-enabled clusters)
 
 ```bash
-# Users
-ackoctl admin user list    <CONN_ID>
-ackoctl admin user create  <CONN_ID> --name=alice --password=*** --role=read-write
-ackoctl admin user grant   <CONN_ID> --name=alice --role=sys-admin
-ackoctl admin user revoke  <CONN_ID> --name=alice --role=read-write
-ackoctl admin user passwd  <CONN_ID> --name=alice --password=***
-ackoctl admin user delete  <CONN_ID> --name=alice --yes
+# Users — --username and --roles (comma-separated; repeatable on cli).
+# --password-stdin avoids shell-history disclosure of the plaintext password.
+ackoctl admin user list   <CONN_ID>
+ackoctl admin user create <CONN_ID> --username=alice --password-stdin --roles=read-write,data-admin
+ackoctl admin user passwd <CONN_ID> --username=alice --password-stdin
+ackoctl admin user delete <CONN_ID> --username=alice --yes
 
-# Roles
-ackoctl admin role list    <CONN_ID>
-ackoctl admin role create  <CONN_ID> --name=ops-readonly --privilege=read
-ackoctl admin role delete  <CONN_ID> --name=ops-readonly --yes
+# Roles — --privilege is CODE[:NS[/SET]], repeatable.
+ackoctl admin role list   <CONN_ID>
+ackoctl admin role create <CONN_ID> --name=ops-readonly --privilege=read --privilege=read:test/users
+ackoctl admin role delete <CONN_ID> --name=ops-readonly --yes
 ```
 
-The target cluster must have security enabled in `aerospike.conf`. CE clusters managed by ACKO do **not** have enterprise security; these commands only apply when ackoctl is pointed at an Aerospike Enterprise cluster (a supported cluster-manager mode, but out of the CE happy path).
+The target cluster must have security enabled in `aerospike.conf`. CE clusters managed by ACKO do **not** have enterprise security; these commands return HTTP 403 (`Security is not enabled. Add a 'security { }' block to aerospike.conf …`) when ackoctl is pointed at a CE cluster. They only apply when ackoctl is pointed at an Aerospike Enterprise cluster (a supported cluster-manager mode, but out of the CE happy path). The user role mutation path is **create / delete only** — there is no `grant`/`revoke` verb; change a user's roles by deleting and recreating.
 
 ### udf — Lua UDF module management
 

--- a/skills/ackoctl/reference/commands.md
+++ b/skills/ackoctl/reference/commands.md
@@ -7,22 +7,23 @@ Compact one-line-per-verb enumeration. Use this when constructing a precise `ack
 | Verb | One-liner |
 |------|-----------|
 | `config view` | Print the merged config (~/.ackoctl/config.yaml). |
+| `config current-context` | Print only the current context name. |
 | `config use-context NAME` | Switch the current context. |
 | `config set-context NAME --server URL --token TOKEN [--workspace WS]` | Create/update a context entry. |
 | `config delete-context NAME` | Remove a context entry. |
 
 ## `connection` — cluster-manager connection profiles
 
+`--host` is repeatable (one flag per seed host); `--user`/`--pass` carry auth.
+
 | Verb | One-liner |
 |------|-----------|
 | `connection list` | List connection profiles in the current workspace. |
 | `connection get ID` | Show a single profile (no password). |
-| `connection create --name N --hosts H1,H2 --port 3000 [--username U --password P]` | Create a profile. |
-| `connection update ID [--name ... --hosts ... --color ... --note ...]` | Patch fields. |
+| `connection create --name N --host H1 [--host H2] --port 3000 [--user U --pass P]` | Create a profile. |
+| `connection update ID [--name ... --host ... --color ... --note ...]` | Patch fields. |
 | `connection delete ID --yes` | Delete a profile. |
-| `connection connect ID` | Force the profile to (re)open its aerospike-py client. |
-| `connection disconnect ID` | Close the open client. |
-| `connection test --hosts H1 --port 3000 [--username U --password P]` | Dry-run a connect attempt without persisting. |
+| `connection health ID` | Probe an existing profile's cluster: connected, build, edition, node/namespace counts, memory/disk usage. |
 
 ## `cluster` — runtime cluster inspection
 
@@ -53,7 +54,7 @@ Compact one-line-per-verb enumeration. Use this when constructing a precise `ack
 
 | Verb | One-liner |
 |------|-----------|
-| `query CONN_ID --namespace NS [--set S --filter JSON --page-size N]` | Same shape as `record query` against the explicit query endpoint. |
+| `query exec CONN_ID --namespace NS [--set S] [--bin B --op equals\|between\|contains\|geo_within_region\|geo_contains_point --value JSON [--value2 JSON]] [--expression EXPR] [--primary-key PK --pk-type ...] [--select bin1,bin2] [--max-records N]` | Execute a predicate, primary-key lookup, or full scan against the dedicated query endpoint. |
 
 ## `index` — secondary index management
 
@@ -94,7 +95,7 @@ Compact one-line-per-verb enumeration. Use this when constructing a precise `ack
 
 ## `admin` — Aerospike Enterprise user + role management
 
-CE has no security; admin commands always 5xx against CE targets but the wire is correct for EE.
+CE has no security; admin commands return 403 against CE targets (`Security is not enabled`) but the wire is correct for EE. There is no `grant`/`revoke` — change a user's role set by delete + recreate.
 
 | Verb | One-liner |
 |------|-----------|


### PR DESCRIPTION
## What

Local end-to-end smoke (kind cluster + ACKO operator + cluster-manager) found several `ackoctl` invocations in `skills/ackoctl/` that fail when pasted because the flag names or verb shapes don't match the binary on ackoctl main.

## Concrete mismatches caught

| Section | Was (skill) | Actual CLI |
|---|---|---|
| connection | `--hosts H1,H2 --port` | `--host H1 [--host H2] --port` (repeatable) |
| connection | `--username U --password P` | `--user U --pass P` |
| connection | `connect`, `disconnect`, `test` verbs | none exist; the `health` verb is the actual probe |
| config | `view / use-context / set-context / delete-context` | also has `current-context` |
| query | `query CONN_ID --namespace ...` | `query exec CONN_ID --namespace ...` (exec subcommand) |
| info | `info exec CONN_ID --command ... --yes` | `info CONN_ID --command ... [--allow-write]` (no exec, no --yes) |
| admin user | `--name`, `--role` | `--username`, `--roles` |
| admin user | `grant`/`revoke` verbs | none exist; mutate roles via delete + recreate |

## How I found it

\`\`\`
$ ackoctl connection create --name foo --hosts 127.0.0.1 --port 14790
Error: unknown flag: --hosts

$ ackoctl query conn-1 --namespace test
Error: unknown flag: --namespace
\`\`\`

Refs: ackoctl#5