### PR TITLE
revert: erase 2.0.0 release history — MCP removal is not a major bump

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aerospike-ce-ecosystem",
-  "version": "2.0.0",
+  "version": "1.4.1",
   "description": "Aerospike CE ecosystem tools: deploy clusters on Kubernetes with ACKO operator, build Python apps with aerospike-py (Rust/PyO3 async client). Skills for deployment, Day-2 operations, troubleshooting, API reference, and FastAPI integration.",
   "author": {
     "name": "Aerospike CE Ecosystem",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,35 +8,6 @@ See [VERSIONING.md](./VERSIONING.md) for the compatibility matrix and deprecatio
 
 ## [Unreleased]
 
-## [2.0.0] - 2026-05-13
-
-### BREAKING
-
-- **Removed `acm-mcp-init` skill**: the ACM MCP HTTP server is retired. Users who depended on `claude mcp add --transport http aerospike-...` to talk to cluster-manager must migrate to the [`ackoctl`](https://github.com/aerospike-ce-ecosystem/ackoctl) CLI. The new `ackoctl` skill in this plugin documents the equivalent commands (`ackoctl config set-context` + `ackoctl <noun> <verb>`).
-
-### Added
-
-- **`ackoctl` skill**: documents the [ackoctl](https://github.com/aerospike-ce-ecosystem/ackoctl) Go CLI for cluster-manager. Covers install, kubeconfig-style multi-context configuration, and every command surface — `connection`, `cluster`, `set`, `record`, `query`, `index`, `note`, `k8s`, `info`, `admin`, `udf`. Ships with a per-command reference at `skills/ackoctl/reference/commands.md`.
-
-### Changed
-
-- **`acko-debugging` skill**: diagnostic routing now prefers ackoctl over MCP. The 6-step procedure, CE 8.1 pitfalls, and remediation matrix are unchanged; data-plane and K8s-plane probes route through `ackoctl cluster info` / `ackoctl info exec` / `ackoctl query exec` / `ackoctl k8s cluster get|list` / `ackoctl k8s pod logs` / `ackoctl k8s events list`, falling back to `kubectl`/`asinfo` when ackoctl is unavailable.
-- **`acko-cluster-debugger` agent → `acko-debugging` skill**: demoted to a skill so triggering happens via description match rather than explicit Task delegation. Subagent context isolation is the only capability lost — most diagnoses are single-shot anyway, and routine reads (`ackoctl k8s cluster list`, `ackoctl k8s pod logs`, …) no longer have to spawn a subagent.
-- **README**: replaced the "MCP integration" section with an "ackoctl integration" section of comparable size. The skills inventory table now lists `ackoctl` in place of `acm-mcp-init`.
-- **Plugin manifest**: bumped to `2.0.0` (MAJOR — breaking removal per `VERSIONING.md`).
-- **Compatibility matrix**: new 2.0.0 row pinning `ackoctl >= v0.2.0`.
-
-### Migration notes
-
-| Old (1.x with ACM MCP) | New (2.x with ackoctl) |
-|------------------------|------------------------|
-| `claude mcp add --transport http aerospike-dev http://localhost:8000/mcp` | `ackoctl config set-context dev --server=http://localhost:8000/api --workspace-id=default` |
-| `mcp__aerospike-dev__list_namespaces` | `ackoctl cluster info <CONN_ID>` |
-| `mcp__aerospike-dev__execute_info` | `ackoctl info exec <CONN_ID> --command='statistics'` |
-| `mcp__aerospike-dev__get_k8s_pods` | `ackoctl k8s cluster get <ns>/<name>` |
-| `mcp__aerospike-dev__get_k8s_logs` | `ackoctl k8s pod logs <ns>/<name> --pod=<pod> ...` |
-| `mcp__aerospike-dev__scale_k8s_cluster` | `ackoctl k8s cluster scale <ns>/<name> --size=N --yes` |
-
 ## [1.2.0] - 2026-05-04
 
 ### Added
@@ -80,8 +51,7 @@ Initial public release. Plugin manifest version is `1.0.0` (see `.claude-plugin/
   - `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` published for plugin discovery.
   - Repository under `aerospike-ce-ecosystem` GitHub org.
 
-[Unreleased]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.2.0...v2.0.0
+[Unreleased]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.2.0...HEAD
 [1.2.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/releases/tag/v1.0.0

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -19,16 +19,12 @@ A plugin version is expected to work with the components below; older or newer c
 | 1.0.0          | v1.0.0 (Helm chart 0.2.0) | 0.7.1 | n/a (ACM MCP)      | 8.1.x (8.x supported) |
 | 1.1.0          | v1.0.0 (Helm chart 0.2.0) | 0.7.1 | n/a (ACM MCP)      | 8.1.x (8.x supported) |
 | 1.2.0          | v1.2.1 | 0.10.0 | n/a (ACM MCP) | 8.1.x (8.x supported) |
-| 2.0.0          | v1.2.1 | 0.10.0 | v0.2.0 (admin/udf/info) | 8.1.x (8.x supported) |
 | Unreleased     | tracks ACKO `main` | tracks aerospike-py `main` | tracks ackoctl `main` | 8.x |
 
 Sources for the 1.0.0 row:
 - ACKO: latest git tag in `aerospike-ce-kubernetes-operator` (`v1.0.0`); Helm chart `charts/aerospike-ce-kubernetes-operator/Chart.yaml` `version: 0.2.0`.
 - aerospike-py: latest git tag in `aerospike-py` (`v0.7.1`).
 - Aerospike CE: skills target CE 8.1 (`acko-config-reference`, `acko-deploy`); 8.x line broadly supported.
-
-Notes for the 2.0.0 row:
-- The `acm-mcp-init` skill is removed in 2.0.0 — the cluster-manager MCP HTTP server is retired. The new `ackoctl` skill replaces it; the matrix pins `ackoctl >= v0.2.0` because that is the first release with `admin`, `udf`, and `info` parity for the surface previously exposed via MCP.
 
 ## Deprecation Policy
 


### PR DESCRIPTION
plugin.json was bumped to 2.0.0 in #27 with "MAJOR — breaking removal" framing, but the daily-release workflow disagreed and auto-tagged v1.4.0 / v1.4.1 instead. ackoctl covers every former MCP entry point, so no trigger becomes unreachable — minor bump is correct.

- plugin.json: 2.0.0 → 1.4.1 (matches latest tag)
- CHANGELOG.md: delete the [2.0.0] section entirely
- VERSIONING.md: delete the 2.0.0 matrix row and notes