### PR TITLE
docs(skills): trim redundant and generic content from 4 skills

### DIFF
--- a/skills/acko-debugging/SKILL.md
+++ b/skills/acko-debugging/SKILL.md
@@ -286,11 +286,4 @@ Always check for these CE 8.1-specific issues:
 5. **`nsup-period=0` with `default-ttl!=0`** — server fails to start.
 6. **Byte values as strings** — all sizes in `aerospikeConfig` must be integer bytes, not `"4G"` or `"1M"`.
 
-## Output format
-
-After completing the investigation, provide:
-
-1. **Root cause** — clear description of what is wrong.
-2. **Evidence** — the specific command output that shows the problem.
-3. **Fix** — step-by-step remediation commands the user can run.
-4. **Prevention** — how to avoid this issue in the future.
+Report the root cause with the command output that proves it, then the remediation commands.

--- a/skills/acko-deploy/SKILL.md
+++ b/skills/acko-deploy/SKILL.md
@@ -13,20 +13,11 @@ Deploy Aerospike Community Edition clusters on Kubernetes using the ACKO operato
 
 ### Step 1: Check Prerequisites
 
-Run these commands to verify your environment is ready:
+The operator must be running and the CRD installed:
 
 ```bash
-# Verify kubectl is connected to a cluster
-kubectl cluster-info
-
-# Verify the ACKO operator is running
 kubectl get pods -n aerospike-operator -l control-plane=controller-manager
-
-# Verify the AerospikeCluster CRD is installed
 kubectl api-resources | grep aerospikeclusters
-
-# Create the target namespace (if it does not exist)
-kubectl create namespace aerospike --dry-run=client -o yaml | kubectl apply -f -
 ```
 
 If the operator is not running, install it first:
@@ -65,18 +56,10 @@ kubectl apply -f aerospike-basic.yaml
 ### Step 3: Verify Deployment
 
 ```bash
-# Wait for phase=Completed (typically 30-90 seconds)
+# phase=Completed typically takes 30-90s; pod naming is <cr-name>-<rack>-<idx>
 kubectl wait --for=jsonpath='{.status.phase}'=Completed asc/aerospike-basic -n aerospike --timeout=120s
-
-# Check cluster status (should show PHASE=Completed, HEALTH=1/1)
 kubectl get asc aerospike-basic -n aerospike
-
-# Check pod status (should show 1/1 Running)
-kubectl get pods -n aerospike
-
-# Verify Aerospike is responding
 kubectl exec -n aerospike aerospike-basic-0-0 -c aerospike-server -- asinfo -v status
-# Expected output: ok
 ```
 
 ---
@@ -149,7 +132,7 @@ Choose the scenario that matches your needs. Each links to a ready-to-use YAML e
 - **Use when**: You need to manually restart pods (warm via SIGUSR1, or full pod recreate) without changing spec
 - **Key features**: `spec.operations[]` with `WarmRestart` (SIGUSR1) or `PodRestart` (delete+recreate); optional `podList` to target specific pods; webhook prevents modifying the operations list while one is `InProgress`
 
-> **Monitoring sample note (`04-monitoring.yaml`)**: Recent fix — `metricLabels` values are TOML-escaped (double-quote-wrapped, backslash-escaped, control chars rejected) and the demo `emptyDir` mount points to `/opt/aerospike/work` instead of accidentally overlaying `/opt/aerospike`. If you cloned this example before April 2026, verify both.
+> **Monitoring sample note (`04-monitoring.yaml`)**: `metricLabels` values are TOML-escaped (double-quote-wrapped, backslash-escaped, control chars rejected); the demo `emptyDir` mounts at `/opt/aerospike/work`, not `/opt/aerospike`.
 
 ---
 
@@ -193,6 +176,6 @@ CE 8.1 notes: See acko-config-reference skill
 
 ---
 
-## 9. Template Fix Notice (April 2026)
+## 9. Template Notes
 
-A recent operator fix re-applies the resolved template to the in-memory cluster spec **after** every `Status().Update`/`Patch`, so template-derived fields (`PodSpec.PodAntiAffinity`, `Resources`, `Storage`) now reach the StatefulSet and persist across reconciles. If you previously worked around this by inlining template values into `spec.overrides`, you can drop those workarounds. `VolumeClaimTemplate` updates remain immutable — VCTs are only set at StatefulSet creation time inside `buildStatefulSet`.
+Template-derived fields (`PodSpec.PodAntiAffinity`, `Resources`, `Storage`) reach the StatefulSet and persist across reconciles — no need to inline template values into `spec.overrides`. `VolumeClaimTemplate` updates remain immutable (VCTs are set only at StatefulSet creation time).

--- a/skills/ackoctl/SKILL.md
+++ b/skills/ackoctl/SKILL.md
@@ -238,21 +238,7 @@ UDF registration is cluster-wide; the operator note (`ackoctl note record update
 - Auth is **bearer token only**. There is no `ackoctl login`; users bring their own OIDC JWT (Keycloak CLI, browser device flow, …) and store it in the context or pass it per-call via `--token` / `ACKOCTL_TOKEN`.
 - For multi-cluster ACKO, register one context per cluster-manager instance (`kind-local`, `prod-us`, `prod-eu`) and switch with `ackoctl config use-context <name>` or per-call `--context`.
 
-## 6. Differences vs the prior MCP integration
-
-| Concern | Old (ACM MCP) | New (ackoctl) |
-|---------|---------------|---------------|
-| Bootstrap | `claude mcp add --transport http aerospike-<name> <url>` per cluster | `ackoctl config set-context <name>` per cluster |
-| Auth | bearer in `~/.claude/.mcp.json` (plaintext) | bearer in `~/.ackoctl/config.yaml` per context |
-| Server bind rules | DNS-rebinding allowlist, Origin allowlist, anonymous-on-localhost flag on the MCP HTTP server | none — there is no MCP HTTP server in cluster-manager any more |
-| Tool routing | `mcp__aerospike-<name>__<tool>` | `ackoctl --context=<name> <noun> <verb>` |
-| Mutation gating | server-side `READ_ONLY` profile blocks 11 tool names at call time | server-side workspace ACL + `--yes` confirmation flag on destructive verbs |
-| Tool count drift | session-bound, varied per ACM version (22 vs 27) | one CLI binary, version-pinned via `ackoctl version` |
-| Discovery | `tools/list` per prefix | `ackoctl --help`, `ackoctl <noun> --help` |
-
-The MCP HTTP server is gone, so the matching security surface (`ACM_MCP_*` env vars, allowlists, OIDC integration on the MCP path) is gone too. Authentication and ACL live entirely on the existing FastAPI surface that ackoctl talks to.
-
-## 7. Links
+## 6. Links
 
 - **ackoctl repo** — https://github.com/aerospike-ce-ecosystem/ackoctl
 - **ackoctl usage cheat sheet** — https://github.com/aerospike-ce-ecosystem/ackoctl/blob/main/docs/usage.md

--- a/skills/aerospike-py-fastapi/SKILL.md
+++ b/skills/aerospike-py-fastapi/SKILL.md
@@ -166,16 +166,6 @@ async def metrics():
 
 Or use the built-in server: `aerospike_py.start_metrics_server(port=9464)` in lifespan.
 
-## 7. Key Patterns
-
-- **Lifespan**: Create `AsyncClient` in lifespan, store on `app.state`, close on shutdown
-- **DI**: Use `Depends(get_client)` for every endpoint — never create client per-request
-- **Exceptions on module**: `aerospike_py.RecordNotFound` (NOT `aerospike_py.exception.RecordNotFound`)
-- **NamedTuple returns**: `record.bins`, `record.meta.gen` (NOT tuple unpacking)
-- **batch_read**: returns `dict[UserKey, AerospikeRecord]` — iterate with `.items()`, missing keys are absent
-- **batch_write**: inspect `BatchRecord.in_doubt` before retrying non-idempotent writes
-- **Health probe**: `await client.ping()` for readiness; trivial 200 OK for liveness
-- **Backpressure**: Set `max_concurrent_operations` to prevent connection pool exhaustion
-- **Exception name**: `AerospikeTimeoutError` (legacy `TimeoutError` alias removed)
+## 7. Reference
 
 Detail: `../aerospike-py-api/reference/client-config.md` | `../aerospike-py-api/reference/admin.md` | `../aerospike-py-api/reference/health.md` | `../aerospike-py-api/reference/write.md`


### PR DESCRIPTION
## Summary

Cleanup pass over the 9 plugin skills, removing ~56 lines that added no signal:

- **aerospike-py-fastapi** — dropped §7 "Key Patterns"; every bullet restated a pattern already demonstrated in the code examples above it
- **ackoctl** — dropped §6 "Differences vs the prior MCP integration"; a 12-row comparison table to an already-retired MCP server, irrelevant to actually using the CLI
- **acko-debugging** — dropped the generic "Output format" reporting checklist
- **acko-deploy** — stripped generic `kubectl` explainer comments from §1, condensed §9 changelog prose and the monitoring sample note

## What was deliberately kept

`acko-config-reference`, `aerospike-py-api`, `acko-operations`, `acko-e2e-test`, and `bug-reporter` were left untouched — their content is project-specific, non-obvious, and load-bearing (CE 8.1 constraints, unconventional PyO3 patterns, CR-shaped patch commands, e2e contracts, repo-routing table).

## Test plan

- [ ] No dangling cross-references to removed sections (verified via grep — only unrelated "Output format" flag-doc matches remain)
- [ ] Skill frontmatter (`name`, `description`, triggers) unchanged — only body prose trimmed
- [ ] `plugin.json` skill list unaffected (no files added/removed)