### PR TITLE
docs(skills): correct ackoctl verbs/flags and aerospike-py import note

### DIFF
--- a/skills/acko-debugging/SKILL.md
+++ b/skills/acko-debugging/SKILL.md
@@ -17,7 +17,7 @@ For routine reads (`ackoctl k8s cluster list`, `ackoctl record get`, …) the CL
 
 Prefer `ackoctl` for **both** planes. It goes through cluster-manager, which is the authoritative source for AerospikeCluster state (it normalises CR status fields, classifies K8s events, and enforces workspace ACL). Fall back to `kubectl` / direct `asinfo` only when `ackoctl` is unavailable, or when a field the cluster-manager summary does not surface yet is needed.
 
-- **Data plane** — `ackoctl cluster info`, `ackoctl info exec --command=...`, `ackoctl query exec`, `ackoctl record get`, `ackoctl set list`.
+- **Data plane** — `ackoctl cluster info`, `ackoctl info --command=...`, `ackoctl query exec`, `ackoctl record get`, `ackoctl set list`.
 - **K8s plane** — `ackoctl k8s cluster list / get / reconcile / scale`, `ackoctl k8s pod logs`, `ackoctl k8s events list`. Requires cluster-manager started with `K8S_MANAGEMENT_ENABLED=true`; if `ackoctl k8s cluster list` returns a 404, fall back to `kubectl` for the K8s plane.
 
 If `ackoctl` is not installed or no context is configured, tell the user:
@@ -46,7 +46,7 @@ These ackoctl invocations mutate cluster state. Always confirm with the user bef
 |---------|--------------|
 | `ackoctl record put` / `record delete` | Single-record write/delete |
 | `ackoctl cluster configure-namespace` | Runtime config change on the live cluster (`asinfo set-config`) |
-| `ackoctl info exec --allow-write` | Raw asinfo with mutation verbs (`set-config:`, `recluster:`) |
+| `ackoctl info --allow-write` | Raw asinfo with mutation verbs (`set-config:`, `recluster:`) |
 | `ackoctl index create` / `index delete` | Server-side index DDL |
 | `ackoctl k8s cluster scale` | Patches `spec.size` on the AerospikeCluster CR — same blast radius as `kubectl patch` |
 | `ackoctl k8s cluster reconcile` | Stamps `acko.io/force-reconcile`; triggers operator reconciliation |
@@ -54,7 +54,7 @@ These ackoctl invocations mutate cluster state. Always confirm with the user bef
 | `ackoctl admin user/role *` | Identity changes (security-enabled clusters only) |
 | `ackoctl connection delete` | Removes the profile **and** cascades all attached notes |
 
-For diagnostic reads, prefer the no-side-effect verbs: `ackoctl k8s cluster get`, `ackoctl info exec` without `--allow-write` (whitelisted read verbs only), `ackoctl query exec`, `ackoctl record get`.
+For diagnostic reads, prefer the no-side-effect verbs: `ackoctl k8s cluster get`, `ackoctl info` without `--allow-write` (whitelisted read verbs only), `ackoctl query exec`, `ackoctl record get`.
 
 ## Debugging procedure
 
@@ -77,8 +77,8 @@ Then run discovery against the selected `CONN_ID`:
 
 ```bash
 ackoctl --context={ctx} cluster info <CONN_ID> -o yaml
-ackoctl --context={ctx} info exec  <CONN_ID> --command='statistics'
-ackoctl --context={ctx} info exec  <CONN_ID> --command='status'
+ackoctl --context={ctx} info <CONN_ID> --command='statistics'
+ackoctl --context={ctx} info <CONN_ID> --command='status'
 ```
 
 Use `statistics` output to see `cluster_size`, `migration_status`, `stop_writes`, etc. across all nodes. `cluster info` already aggregates nodes, namespaces, sets and sindex counts.
@@ -132,7 +132,7 @@ kubectl get asc <name> -n <ns> -o jsonpath='{.status.migrationStatus}' | jq .
 # Per-pod migration partitions
 kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods}' | jq 'to_entries[] | {pod: .key, migrating: .value.migratingPartitions}'
 # Direct asinfo check via ackoctl
-ackoctl --context={ctx} info exec <CONN_ID> --command='statistics' | tr ';' '\n' | grep migrate
+ackoctl --context={ctx} info <CONN_ID> --command='statistics' | tr ';' '\n' | grep migrate
 ```
 
 This is usually normal during scale-down. Report `migrationStatus.remainingPartitions` progress and advise waiting.
@@ -157,9 +157,9 @@ Check for:
 
 ```bash
 # Status, statistics, namespace details — per-node where useful.
-ackoctl --context={ctx} info exec <CONN_ID> --command='status'
-ackoctl --context={ctx} info exec <CONN_ID> --command='statistics'
-ackoctl --context={ctx} info exec <CONN_ID> --command='namespace/<ns-name>'
+ackoctl --context={ctx} info <CONN_ID> --command='status'
+ackoctl --context={ctx} info <CONN_ID> --command='statistics'
+ackoctl --context={ctx} info <CONN_ID> --command='namespace/<ns-name>'
 # Sample-record sanity check
 ackoctl --context={ctx} query exec <CONN_ID> --namespace=<ns-name> --set=<set> --max-records=5
 # Filtered probe — useful for narrowing in on records that match a suspected

--- a/skills/ackoctl/SKILL.md
+++ b/skills/ackoctl/SKILL.md
@@ -179,7 +179,7 @@ ackoctl k8s cluster list                                 # all AerospikeCluster 
 ackoctl k8s cluster get aerospike/sample-cluster         # <namespace>/<name>
 ackoctl k8s cluster reconcile aerospike/sample-cluster   # stamp acko.io/force-reconcile
 ackoctl k8s cluster scale aerospike/sample-cluster --size=5
-ackoctl k8s pod logs aerospike/sample-cluster --pod=sample-cluster-0-0 \
+ackoctl k8s cluster logs aerospike/sample-cluster --pod=sample-cluster-0-0 \
   --container=aerospike-server --since=5m --tail=200
 ackoctl k8s events list aerospike/sample-cluster --since=30m
 ```
@@ -224,10 +224,9 @@ The target cluster must have security enabled in `aerospike.conf`. CE clusters m
 ### udf — Lua UDF module management
 
 ```bash
-ackoctl udf list     <CONN_ID>
-ackoctl udf register <CONN_ID> --file=./examples/sum.lua --name=sum.lua
-ackoctl udf get      <CONN_ID> --name=sum.lua -o yaml          # source + metadata
-ackoctl udf remove   <CONN_ID> --name=sum.lua --yes
+ackoctl udf list   <CONN_ID>
+ackoctl udf upload <CONN_ID> --file=./examples/sum.lua
+ackoctl udf remove <CONN_ID> --filename=sum.lua --yes
 ```
 
 UDF registration is cluster-wide; the operator note (`ackoctl note record update`) is the right place to record provenance / ticket links for the module.

--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -13,7 +13,7 @@ pip install aerospike-py[otel]   # OpenTelemetry context propagation
 
 Wheels include Python 3.14 and 3.14t (free-threaded, `gil_used=true`).
 
-**Import note**: Rust/PyO3 extension. All exceptions and constants live on `aerospike_py` module directly (e.g., `aerospike_py.RecordNotFound`). No `aerospike_py.exception` submodule. Return types are NamedTuples — use `record.bins`, `record.meta.gen`. Type stubs: `src/aerospike_py/__init__.pyi`
+**Import note**: Rust/PyO3 extension. All exceptions are importable from `aerospike_py` directly (preferred) or from `aerospike_py.exception` (e.g., `from aerospike_py.exception import RecordNotFound`). Constants live on `aerospike_py` module directly (e.g., `aerospike_py.POLICY_EXISTS_CREATE_ONLY`). Return types are NamedTuples — use `record.bins`, `record.meta.gen`. Type stubs: `src/aerospike_py/__init__.pyi`
 
 ## 1. Client Setup
 


### PR DESCRIPTION
## Summary

5 documentation corrections across 3 skill files. All are content-only fixes (no logic, no skill removals, no frontmatter changes, no `plugin.json` bump). Each correction is anchored to the upstream `ackoctl` source files in `aerospike-ce-ecosystem/ackoctl`.

## Corrections

### Fix #1 (P0) — `skills/ackoctl/SKILL.md:228`
- Was: `ackoctl udf register <CONN_ID> --file=./examples/sum.lua --name=sum.lua`
- Now: `ackoctl udf upload <CONN_ID> --file=./examples/sum.lua`
- Evidence: [`internal/cli/udf.go:74`](https://github.com/aerospike-ce-ecosystem/ackoctl/blob/main/internal/cli/udf.go#L74) registers the verb as `upload CONN_ID`, not `register`. When `--filename` is omitted the basename of `--file` is used as the module name ([line 78](https://github.com/aerospike-ce-ecosystem/ackoctl/blob/main/internal/cli/udf.go#L78)).

### Fix #2 (P0) — `skills/ackoctl/SKILL.md:229-230`
- Removed: `ackoctl udf get <CONN_ID> --name=sum.lua -o yaml` line — no such subcommand exists in ackoctl source.
- Changed `udf remove --name=sum.lua` to `udf remove --filename=sum.lua`.
- Evidence: [`internal/cli/udf.go:151-153`](https://github.com/aerospike-ce-ecosystem/ackoctl/blob/main/internal/cli/udf.go#L151) — flag is `--filename` (required); only `list`, `upload`, `remove` subcommands exist.

### Fix #3 (P0) — `skills/aerospike-py-api/SKILL.md:16`
- Was: "No `aerospike_py.exception` submodule."
- Now: "All exceptions are importable from `aerospike_py` directly (preferred) or from `aerospike_py.exception` (e.g., `from aerospike_py.exception import RecordNotFound`)."
- Rationale: the `aerospike_py.exception` submodule ships in the package and is a valid import path. The previous wording told users (incorrectly) that the import would fail.

### Fix #4 (P1) — `skills/acko-debugging/SKILL.md` (7 occurrences)
- Replaced every `ackoctl info exec <CONN_ID>` with `ackoctl info <CONN_ID>` (lines 20, 49, 57, 80, 81, 135, 160, 161, 162).
- Evidence: [`internal/cli/info.go:23`](https://github.com/aerospike-ce-ecosystem/ackoctl/blob/main/internal/cli/info.go#L23) — the command is `Use: "info CONN_ID"` with no `exec` subverb.

### Fix #5 (P1) — `skills/ackoctl/SKILL.md:182`
- Was: `ackoctl k8s pod logs aerospike/sample-cluster --pod=sample-cluster-0-0`
- Now: `ackoctl k8s cluster logs aerospike/sample-cluster --pod=sample-cluster-0-0`
- Evidence: [`internal/cli/k8s.go:340-354`](https://github.com/aerospike-ce-ecosystem/ackoctl/blob/main/internal/cli/k8s.go#L340) wires `newK8sClusterLogsCmd` under `newK8sClusterCmd`; there is no `k8s pod` command group.

## Out-of-scope findings (not fixed in this PR)

`skills/acko-debugging/SKILL.md` still contains the following bad patterns that fall outside the 5 enumerated fixes for this PR:

- `ackoctl k8s pod logs` on lines 21, 93, 204, 205 — same root cause as Fix #5; should be `ackoctl k8s cluster logs`.
- `ackoctl udf register` / `udf remove` on line 53 (mutation-table reference) — same root cause as Fix #1/#2; should be `udf upload` / `udf remove`.

Filing as a follow-up rather than expanding this PR's scope.

## Verification

- `grep -rn "udf register\|udf get .*--name\|info exec\|k8s pod logs\|No .aerospike_py.exception"` against the 3 edited files returns the 5 out-of-scope acko-debugging matches noted above, and zero matches for the patterns inside the lines we corrected.
- `python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"` — manifest valid.
- Diff: 3 files, +14/-15 LOC.

## Test plan
- [ ] Skim diff to confirm only content corrections, no frontmatter/version touches
- [ ] CI link-check / pr-reviewer passes