### PR TITLE
docs: correct stale ackoctl commands and refresh project metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "aerospike-ce-ecosystem",
-      "description": "Aerospike CE ecosystem tools: deploy clusters on Kubernetes with ACKO, build Python apps with aerospike-py",
+      "description": "Aerospike CE ecosystem tools: deploy, operate, and debug clusters on Kubernetes with ACKO; drive cluster-manager via the ackoctl CLI; build Python apps with aerospike-py.",
       "source": "./",
       "category": "development"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aerospike-ce-ecosystem",
   "version": "1.4.1",
-  "description": "Aerospike CE ecosystem tools: deploy clusters on Kubernetes with ACKO operator, build Python apps with aerospike-py (Rust/PyO3 async client). Skills for deployment, Day-2 operations, troubleshooting, API reference, and FastAPI integration.",
+  "description": "Aerospike CE ecosystem tools for Claude Code: deploy, operate, and debug clusters on Kubernetes with the ACKO operator; drive aerospike-cluster-manager via the ackoctl CLI; and build Python apps with aerospike-py (Rust/PyO3 async client). 9 skills spanning deployment, Day-2 operations, debugging, e2e testing, CLI usage, API reference, FastAPI integration, and bug routing.",
   "author": {
     "name": "Aerospike CE Ecosystem",
     "email": "kimsoungryoul@gmail.com"

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -34,10 +34,9 @@ jobs:
             You are an AI implementation agent for the **aerospike-ce-ecosystem-plugins** project.
 
             ## Project Context
-            - **Structure**: Claude Code plugin with skills and agents
-              - `skills/` — 5 skills (acko-deploy, acko-operations, acko-config-reference, aerospike-py-api, aerospike-py-fastapi)
-              - `agents/` — 1 agent (acko-cluster-debugger)
-              - Each skill has `SKILL.md` (main content) and `reference/` directory (detailed docs)
+            - **Structure**: Claude Code plugin with skills
+              - `skills/` — 9 skills (acko-config-reference, acko-debugging, acko-deploy, acko-e2e-test, acko-operations, ackoctl, aerospike-py-api, aerospike-py-fastapi, bug-reporter)
+              - Each skill has `SKILL.md` (main content); most also have a `reference/` directory (detailed docs)
             - **Content type**: Markdown-based skill files with embedded code examples, API signatures, CRD specs
             - **Core repo references**:
               - aerospike-py: API signatures (`__init__.pyi`), exceptions (`errors.rs`), constants

--- a/.github/workflows/issue-planner.yml
+++ b/.github/workflows/issue-planner.yml
@@ -30,9 +30,8 @@ jobs:
             You are an AI planning agent for the **aerospike-ce-ecosystem-plugins** project.
 
             ## Project Context
-            - **Structure**: Claude Code plugin with skills and agents
-              - `skills/` — 5 skills (acko-deploy, acko-operations, acko-config-reference, aerospike-py-api, aerospike-py-fastapi)
-              - `agents/` — 1 agent (acko-cluster-debugger)
+            - **Structure**: Claude Code plugin with skills
+              - `skills/` — 9 skills (acko-config-reference, acko-debugging, acko-deploy, acko-e2e-test, acko-operations, ackoctl, aerospike-py-api, aerospike-py-fastapi, bug-reporter)
               - `evals/` — evaluation test cases
               - `.claude-plugin/plugin.json` — plugin metadata
             - **Content type**: Markdown-based skill files with reference documents

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -35,7 +35,7 @@ jobs:
             You are an AI code review agent for **aerospike-ce-ecosystem-plugins**.
 
             ## Project Context
-            - Claude Code plugin with 5 skills + 1 agent
+            - Claude Code plugin with 9 skills
             - Skills contain API docs, code examples, CRD specs from core repos
             - Accuracy of skill content is critical — incorrect examples will mislead users
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,0 @@
-{
-  "mcpServers": {}
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,93 @@ All notable changes to the `aerospike-ce-ecosystem` Claude Code plugin are docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 See [VERSIONING.md](./VERSIONING.md) for the compatibility matrix and deprecation policy.
+Per-release notes are also auto-published to [GitHub Releases](https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/releases) by the `daily-release.yml` workflow.
 
 ## [Unreleased]
+
+### Changed
+
+- Plugin manifest (`plugin.json`) and `marketplace.json` descriptions rewritten to cover all 9 current skills.
+- CI workflow prompts (`issue-planner`, `agent-implement`, `pr-reviewer`) updated from the obsolete "5 skills + 1 agent" structure to the current 9-skill layout.
+- `README.md` — added the missing `acko-e2e-test` and `bug-reporter` skills to the Skills table.
+
+### Fixed
+
+- Skill command examples — corrected stale `ackoctl` verbs (`k8s pod logs` → `k8s cluster logs`, `udf register` → `udf upload`) and CE 7.x namespace parameters (`stop-writes-pct` → `stop-writes-sys-memory-pct`, `high-water-*-pct` → `evict-used-pct`) across `acko-debugging`, `ackoctl`, `acko-operations`, and `README.md`.
+
+### Removed
+
+- Deleted the dead `.mcp.json` placeholder left over from the retired `acm-mcp-init` MCP integration.
+
+## [1.4.4] - 2026-05-17
+
+### Fixed
+
+- Skills — corrected `ackoctl` verbs/flags and added an `aerospike-py` import note (#35).
+
+## [1.4.3] - 2026-05-14
+
+### Changed
+
+- Skills — trimmed redundant and generic content from 4 skills (#32).
+
+### CI/CD
+
+- Daily Release — shifted the scheduled run to KST 07:00 (#31).
+
+## [1.4.2] - 2026-05-13
+
+### Changed
+
+- Reverted an erroneous 2.0.0 release — retiring the MCP HTTP server in favour of `ackoctl` is a feature swap, not a breaking major bump (#30).
+
+## [1.4.1] - 2026-05-13
+
+### Fixed
+
+- `ackoctl` skill — aligned the documented commands with the actual `ackoctl` CLI (#29).
+
+## [1.4.0] - 2026-05-13
+
+### Added
+
+- **Skills**:
+  - `ackoctl` — drive `aerospike-cluster-manager` through the `ackoctl` Go CLI (connections, records, queries, indexes, operator notes, K8s `AerospikeCluster` CRs, admin, UDFs) (#27).
+  - `bug-reporter` — routes ACKO / ecosystem bug reports to the correct repo and generates a ready-to-paste GitHub issue body (#28).
+
+### Removed
+
+- Retired the `acm-mcp-init` skill and the cluster-manager MCP HTTP server integration; `ackoctl` provides equivalent coverage (#27).
+
+## [1.3.1] - 2026-05-09
+
+### Changed
+
+- Demoted the `acko-cluster-debugger` agent to the `acko-debugging` skill and trimmed ~206 LOC of cross-skill duplication (#21).
+
+### Removed
+
+- The `agents/` directory — the plugin no longer ships agents (#21).
+
+## [1.3.0] - 2026-05-08
+
+### Added
+
+- **Skills**:
+  - `acm-mcp-init` — cluster-manager MCP server initialisation, plus an MCP-aware `acko-cluster-debugger` (#19). _(Retired in 1.4.0.)_
+
+## [1.2.2] - 2026-05-06
+
+### CI/CD
+
+- Daily Release — restricted automatic version bumps to minor (`feat`) and patch; major bumps are now manual (#18).
+
+## [1.2.1] - 2026-05-06
+
+### Added
+
+- **Tests**:
+  - `e2e` — multi-cluster + Keycloak OIDC pytest scenarios: common-cluster web, dev/prod operator-cluster API, and keycloak realm bootstrap (#17).
 
 ## [1.2.0] - 2026-05-04
 
@@ -46,12 +131,21 @@ Initial public release. Plugin manifest version is `1.0.0` (see `.claude-plugin/
   - `aerospike-py-api` — `aerospike-py` (Rust/PyO3) Python client API reference covering unconventional patterns (module-level exceptions, NamedTuple records, policy constants, expression filters, batch ops, CDT, metrics).
   - `aerospike-py-fastapi` — Production-ready FastAPI patterns for `aerospike-py`: `AsyncClient` lifespan, `Depends` injection, exception-to-HTTP-status mapping, ping health probe, batch endpoints.
 - **Agent**:
-  - `acko-cluster-debugger` — Systematic debugger agent for ACKO Aerospike clusters; runs an ordered triage procedure when the user reports pod failures, deployment errors, or cluster issues.
+  - `acko-cluster-debugger` — Systematic debugger agent for ACKO Aerospike clusters; runs an ordered triage procedure when the user reports pod failures, deployment errors, or cluster issues. _(Demoted to the `acko-debugging` skill in 1.3.1.)_
 - **Plugin manifest**: 1.0.0 release.
   - `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` published for plugin discovery.
   - Repository under `aerospike-ce-ecosystem` GitHub org.
 
-[Unreleased]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.4.4...HEAD
+[1.4.4]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.4.3...v1.4.4
+[1.4.3]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.4.2...v1.4.3
+[1.4.2]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.4.1...v1.4.2
+[1.4.1]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.3.1...v1.4.0
+[1.3.1]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.2.2...v1.3.0
+[1.2.2]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.2.1...v1.2.2
+[1.2.1]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 - Skills — corrected `ackoctl` verbs/flags and added an `aerospike-py` import note (#35).
 
-## [1.4.3] - 2026-05-14
+## [1.4.3] - 2026-05-15
 
 ### Changed
 
@@ -63,7 +63,7 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 - Retired the `acm-mcp-init` skill and the cluster-manager MCP HTTP server integration; `ackoctl` provides equivalent coverage (#27).
 
-## [1.3.1] - 2026-05-09
+## [1.3.1] - 2026-05-08
 
 ### Changed
 
@@ -73,7 +73,7 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 - The `agents/` directory — the plugin no longer ships agents (#21).
 
-## [1.3.0] - 2026-05-08
+## [1.3.0] - 2026-05-07
 
 ### Added
 
@@ -95,10 +95,12 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 ## [1.2.0] - 2026-05-04
 
-### Added
+### Changed
 
 - **Skills**:
   - `acko-e2e-test` — Hybrid pytest rewrite: Python for assertions, bash for CLI orchestration. Tightens release-verification scenarios and reduces flakiness on the CLI orchestration boundary (PR #10).
+- **Skill updates**:
+  - `aerospike-py-api` — added a PK regex filter scan guide and `REGEX_*` constants (PR #11); cross-linked the Secondary Index alternative from the PK regex notes (PR #14).
 
 ### CI/CD
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ claude plugin list
 | **acko-deploy** | "deploy Aerospike on Kubernetes" | Step-by-step guide to deploy CE clusters via AerospikeCluster CR — 8 scenarios from minimal to full-featured |
 | **acko-operations** | "scale Aerospike cluster" | Day-2 operations: scale, upgrade, dynamic config, warm restart, ACL, pause/resume, troubleshooting |
 | **acko-config-reference** | *(background)* | CE 8.1 parameter reference, CRD-to-conf mapping, webhook validation rules |
+| **acko-e2e-test** | "ACKO e2e test", "kind cluster test" | End-to-end test playbook — canonical scenarios, Ginkgo labels, mandatory `helm install` operator setup, release-verification performance checks |
 
 ### aerospike-py (Python Client)
 
@@ -54,7 +55,13 @@ claude plugin list
 | Skill | Trigger | Description |
 |-------|---------|-------------|
 | **ackoctl** | "ackoctl", "manage Aerospike connection", "browse records", "register UDF", "scale cluster" | Drive [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) via the [ackoctl](https://github.com/aerospike-ce-ecosystem/ackoctl) CLI — connections, cluster info, records/sets, queries, secondary indexes, operator notes, raw asinfo, K8s AerospikeCluster CRs, admin (users/roles), and Lua UDF modules. Multi-cluster ACKO friendly via kubeconfig-style contexts. |
-| **acko-debugging** | "CrashLoopBackOff", "phase=Error", "reconcile failure", "migration stuck" | Systematic 6-step diagnosis procedure for ACKO clusters with CE 8.1 pitfalls and a remediation matrix. Routes both data-plane and K8s-plane probes through ackoctl (`ackoctl cluster info`, `ackoctl info exec`, `ackoctl query exec`, `ackoctl k8s cluster get/list`, `ackoctl k8s pod logs`, `ackoctl k8s events list`); falls back to `kubectl`/`asinfo` when ackoctl is unavailable. |
+| **acko-debugging** | "CrashLoopBackOff", "phase=Error", "reconcile failure", "migration stuck" | Systematic 6-step diagnosis procedure for ACKO clusters with CE 8.1 pitfalls and a remediation matrix. Routes both data-plane and K8s-plane probes through ackoctl (`ackoctl cluster info`, `ackoctl info`, `ackoctl query exec`, `ackoctl k8s cluster get/list`, `ackoctl k8s cluster logs`, `ackoctl k8s events list`); falls back to `kubectl`/`asinfo` when ackoctl is unavailable. |
+
+### Ecosystem support
+
+| Skill | Trigger | Description |
+|-------|---------|-------------|
+| **bug-reporter** | "버그 제보", "where do I file this issue", "report this to GitHub" | Routes a bug report to the correct `aerospike-ce-ecosystem` repo by symptom and generates a ready-to-paste GitHub issue body with the required reproduction context |
 
 ## ackoctl integration
 
@@ -70,7 +77,7 @@ ackoctl config set-context kind-local \
   --workspace-id=default
 ackoctl config use-context kind-local
 
-# 3. Use the cluster from any agent / chat
+# 3. Use the cluster from any skill or chat
 #    "in kind-local, list connections and get a sample record from sample_set"
 ackoctl connection list
 ackoctl record list <CONN_ID> --namespace=test --set=sample_set --page-size=5
@@ -86,7 +93,7 @@ ackoctl config set-context prod-us \
 ackoctl --context=prod-us k8s cluster list
 ```
 
-Auth is bearer-token only — users bring their own OIDC JWT (Keycloak CLI, browser device flow, …). The workspace ACL on cluster-manager scopes every call; destructive verbs (`delete`, `remove`, mutation `info exec --allow-write`, `k8s cluster scale`) require `--yes` for non-interactive runs.
+Auth is bearer-token only — users bring their own OIDC JWT (Keycloak CLI, browser device flow, …). The workspace ACL on cluster-manager scopes every call; destructive verbs (`delete`, `remove`, mutation `info --allow-write`, `k8s cluster scale`) require `--yes` for non-interactive runs.
 
 The `ackoctl` skill covers install, configuration, and every command (connection / cluster / set / record / query / index / note / k8s / info / admin / udf). See `skills/ackoctl/reference/commands.md` for a one-line-per-command cheat sheet.
 

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -58,7 +58,7 @@
     {
       "id": 10,
       "prompt": "I have ackoctl set up against my prod cluster (context prod-us). Cluster prod is reporting CrashLoopBackOff on pods. Walk me through diagnosis using ackoctl where available.",
-      "expected_output": "acko-debugging skill triggers (was the acko-cluster-debugger agent before its demotion to a skill); uses ackoctl --context=prod-us cluster info / ackoctl info exec for the data plane and ackoctl --context=prod-us k8s cluster list / k8s cluster get / k8s pod logs / k8s events list for the K8s plane. Falls back to kubectl only when ackoctl is unavailable or cluster-manager was started without K8S_MANAGEMENT_ENABLED=true (ackoctl k8s commands return 404). Never invokes destructive verbs (record put/delete, cluster configure-namespace, info exec --allow-write, index create/delete, k8s cluster scale, k8s cluster reconcile, udf register/remove, admin user/role mutations, connection delete) without explicit user confirmation",
+      "expected_output": "acko-debugging skill triggers (was the acko-cluster-debugger agent before its demotion to a skill); uses ackoctl --context=prod-us cluster info / ackoctl info for the data plane and ackoctl --context=prod-us k8s cluster list / k8s cluster get / k8s cluster logs / k8s events list for the K8s plane. Falls back to kubectl only when ackoctl is unavailable or cluster-manager was started without K8S_MANAGEMENT_ENABLED=true (ackoctl k8s commands return 404). Never invokes destructive verbs (record put/delete, cluster configure-namespace, info --allow-write, index create/delete, k8s cluster scale, k8s cluster reconcile, udf upload/remove, admin user/role mutations, connection delete) without explicit user confirmation",
       "files": []
     },
     {

--- a/skills/acko-debugging/SKILL.md
+++ b/skills/acko-debugging/SKILL.md
@@ -18,7 +18,7 @@ For routine reads (`ackoctl k8s cluster list`, `ackoctl record get`, …) the CL
 Prefer `ackoctl` for **both** planes. It goes through cluster-manager, which is the authoritative source for AerospikeCluster state (it normalises CR status fields, classifies K8s events, and enforces workspace ACL). Fall back to `kubectl` / direct `asinfo` only when `ackoctl` is unavailable, or when a field the cluster-manager summary does not surface yet is needed.
 
 - **Data plane** — `ackoctl cluster info`, `ackoctl info --command=...`, `ackoctl query exec`, `ackoctl record get`, `ackoctl set list`.
-- **K8s plane** — `ackoctl k8s cluster list / get / reconcile / scale`, `ackoctl k8s pod logs`, `ackoctl k8s events list`. Requires cluster-manager started with `K8S_MANAGEMENT_ENABLED=true`; if `ackoctl k8s cluster list` returns a 404, fall back to `kubectl` for the K8s plane.
+- **K8s plane** — `ackoctl k8s cluster list / get / reconcile / scale`, `ackoctl k8s cluster logs`, `ackoctl k8s events list`. Requires cluster-manager started with `K8S_MANAGEMENT_ENABLED=true`; if `ackoctl k8s cluster list` returns a 404, fall back to `kubectl` for the K8s plane.
 
 If `ackoctl` is not installed or no context is configured, tell the user:
 
@@ -50,7 +50,7 @@ These ackoctl invocations mutate cluster state. Always confirm with the user bef
 | `ackoctl index create` / `index delete` | Server-side index DDL |
 | `ackoctl k8s cluster scale` | Patches `spec.size` on the AerospikeCluster CR — same blast radius as `kubectl patch` |
 | `ackoctl k8s cluster reconcile` | Stamps `acko.io/force-reconcile`; triggers operator reconciliation |
-| `ackoctl udf register` / `udf remove` | Cluster-wide UDF module change |
+| `ackoctl udf upload` / `udf remove` | Cluster-wide UDF module change |
 | `ackoctl admin user/role *` | Identity changes (security-enabled clusters only) |
 | `ackoctl connection delete` | Removes the profile **and** cascades all attached notes |
 
@@ -90,7 +90,7 @@ ackoctl --context={ctx} k8s cluster list                                        
 ackoctl --context={ctx} k8s cluster list --workspace=<ws>                           # explicit workspace filter
 ackoctl --context={ctx} k8s cluster get <ns>/<name> -o yaml                         # phase, size, conditions, dynamicConfigStatus
 ackoctl --context={ctx} k8s events list <ns>/<name> --since=30m                     # classified events
-ackoctl --context={ctx} k8s pod logs <ns>/<name> --pod=<pod> --container=aerospike-server --since=5m --tail=200
+ackoctl --context={ctx} k8s cluster logs <ns>/<name> --pod=<pod> --container=aerospike-server --since=5m --tail=200
 ```
 
 The CR phase, size, conditions, and migration status are all in the `k8s cluster get` payload — no need to shell out for every field.
@@ -201,8 +201,8 @@ For any pods not in `Running` state — prefer ackoctl, fall back to kubectl:
 
 ```bash
 # ackoctl path
-ackoctl --context={ctx} k8s pod logs <ns>/<name> --pod=<pod> --container=aerospike-server --since=10m --tail=200
-ackoctl --context={ctx} k8s pod logs <ns>/<name> --pod=<pod> --container=aerospike-server --previous   # if CrashLoopBackOff
+ackoctl --context={ctx} k8s cluster logs <ns>/<name> --pod=<pod> --container=aerospike-server --since=10m --tail=200
+ackoctl --context={ctx} k8s cluster logs <ns>/<name> --pod=<pod> --container=aerospike-server --previous   # if CrashLoopBackOff
 
 # kubectl fallback
 kubectl describe pod <pod> -n <ns>

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -121,7 +121,6 @@ kubectl patch asc <name> -n <ns> --type=merge \
 - `proto-fd-max`
 - `max-record-size`
 - `stop-writes-sys-memory-pct`
-- `high-water-memory-pct` (CE 7.x; replaced in 8.1)
 - `evict-used-pct`
 - `evict-tenths-pct`
 - `nsup-period`

--- a/skills/acko-operations/reference/operations.md
+++ b/skills/acko-operations/reference/operations.md
@@ -64,8 +64,8 @@ spec:
       proto-fd-max: 20000               # Dynamic parameter
     namespaces:
       - name: test
-        high-water-memory-pct: 70       # Dynamic parameter (CE 7.x)
-        stop-writes-pct: 90             # Dynamic parameter (CE 7.x)
+        evict-used-pct: 70              # Dynamic parameter (CE 8.1)
+        stop-writes-sys-memory-pct: 90  # Dynamic parameter (CE 8.1)
 ```
 
 The operator applies dynamic changes via 2-phase commit (April 2026+):

--- a/skills/ackoctl/SKILL.md
+++ b/skills/ackoctl/SKILL.md
@@ -96,8 +96,8 @@ ackoctl connection health <ID>     # live probe — always returns 200; see `con
 ackoctl cluster info <CONN_ID> -o yaml
 ackoctl cluster configure-namespace <CONN_ID> \
   --name=test \
-  --param=high-water-disk-pct=70 \
-  --param=stop-writes-pct=90
+  --param=evict-used-pct=70 \
+  --param=stop-writes-sys-memory-pct=90
 ```
 
 `configure-namespace` issues `asinfo set-config` under the hood — only **runtime-mutable** namespace knobs apply. Aerospike CE cannot create namespaces at runtime: those live in `aerospike.conf` (managed by ACKO).


### PR DESCRIPTION
## Summary

Project-wide review pass fixing documentation accuracy issues found across skills, CI workflows, and plugin metadata. All changes are docs/chore/fix — no `feat`, so this releases as a **patch** bump.

### Skill & eval command accuracy
- Corrected stale `ackoctl` verbs to match the canonical `skills/ackoctl/SKILL.md`:
  - `ackoctl k8s pod logs` → `ackoctl k8s cluster logs` (`acko-debugging`, `README`, `evals`)
  - `ackoctl udf register` → `ackoctl udf upload` (`acko-debugging`, `evals`)
  - `ackoctl info exec` → `ackoctl info` (`README`, `evals`)
- Corrected CE 7.x namespace parameters that were removed in CE 8.1:
  - `stop-writes-pct` → `stop-writes-sys-memory-pct`
  - `high-water-disk-pct` / `high-water-memory-pct` → `evict-used-pct`
  - per `skills/acko-config-reference/reference/breaking-changes-7x-to-8.md`
  - touched `ackoctl/SKILL.md`, `acko-operations/SKILL.md`, `acko-operations/reference/operations.md`

### README
- Added the missing `acko-e2e-test` and `bug-reporter` skills to the Skills table (was listing only 7 of 9).
- Fixed stale `ackoctl info exec` / `k8s pod logs` references and "from any agent / chat" → "from any skill or chat".

### CI workflows
- `issue-planner.yml`, `agent-implement.yml`, `pr-reviewer.yml` prompts described an obsolete "5 skills + 1 agent" structure with a non-existent `agents/` directory. Updated to the current 9-skill layout.

### Plugin metadata
- `plugin.json` / `marketplace.json` descriptions rewritten to cover all 9 current skills (previously omitted ackoctl, debugging, e2e, bug-reporter).
- Deleted the dead `.mcp.json` placeholder (`{"mcpServers": {}}`), left over from the retired `acm-mcp-init` MCP integration.

### CHANGELOG
- Reconstructed the missing `v1.2.1`–`v1.4.4` history (9 releases) from git tags and GitHub Releases — the file had been stale since `v1.2.0`. Fixed the `[Unreleased]` compare link.

## Out of scope / follow-ups for a maintainer
- **`VERSIONING.md` compatibility matrix** still stops at `1.2.0`. Filling rows for `1.2.1`–`1.4.4` needs the authoritative ACKO / aerospike-py / ackoctl versions each plugin release targeted — left untouched rather than guessed.
- **`plugin.json` `version` is `1.4.1`** while the latest tag/release is `v1.4.4`. `daily-release.yml` releases from git tags and never bumps `plugin.json`, so the field drifts permanently. Per repo policy the `version` key is not hand-edited here; worth deciding whether the release workflow should sync it.

## Test plan
- [x] `python3 -c json.load` — `plugin.json`, `marketplace.json`, `evals/evals.json` parse cleanly
- [x] `grep` sweep — no remaining `info exec` / `k8s pod logs` / `udf register` / `5 skills` / `1 agent` refs in `skills/`, `README.md`, `evals/`, `.github/`
- [x] All corrected commands/params verified against `skills/ackoctl/SKILL.md` and `skills/acko-config-reference/reference/`