### PR TITLE
docs: fix plugin marketplace and e2e workspace metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "aerospike-ce-ecosystem",
+  "description": "Aerospike CE ecosystem tools for Kubernetes operator deployment, operations, end-to-end testing, and Python application development.",
   "owner": {
     "name": "Aerospike CE Ecosystem",
     "email": "kimsoungryoul@gmail.com"

--- a/skills/acko-e2e-test/SKILL.md
+++ b/skills/acko-e2e-test/SKILL.md
@@ -26,7 +26,7 @@ bash scripts/bootstrap.sh --check   # status only — install nothing
 bash scripts/bootstrap.sh --no-operator   # don't auto-clone the operator repo
 ```
 
-The operator repo is discovered automatically — `helpers/env.py` tries (in order): `$OPERATOR_REPO`, the workspace-sibling layout (`asc-workspace/aerospike-ce-kubernetes-operator`), `$CWD/aerospike-ce-kubernetes-operator`, `~/aerospike-ce-kubernetes-operator`, `~/github/aerospike-ce-kubernetes-operator`, `/workspace/aerospike-ce-kubernetes-operator`. If none exist, fixtures `pytest.skip()` with a clear message — no hard import-time failure.
+The operator repo is discovered automatically — `helpers/env.py` tries (in order): `$OPERATOR_REPO`, the workspace-sibling layout (`<workspace>/aerospike-ce-kubernetes-operator`), `$CWD/aerospike-ce-kubernetes-operator`, `~/aerospike-ce-kubernetes-operator`, `~/github/aerospike-ce-kubernetes-operator`, `/workspace/aerospike-ce-kubernetes-operator`. If none exist, fixtures `pytest.skip()` with a clear message — no hard import-time failure.
 
 ## How to run
 

--- a/skills/acko-e2e-test/e2e_pytest/helpers/env.py
+++ b/skills/acko-e2e-test/e2e_pytest/helpers/env.py
@@ -41,7 +41,7 @@ CERT_MANAGER_VERSION = _env("CERT_MANAGER_VERSION", "v1.19.3")
 # Paths — operator repo and chart.
 # Discovery order (first existing dir wins):
 #   1. $OPERATOR_REPO env var
-#   2. asc-workspace sibling layout (this plugin under asc-workspace/aerospike-ce-ecosystem-plugins)
+#   2. workspace sibling layout (this plugin under a shared workspace directory)
 #   3. CWD/aerospike-ce-kubernetes-operator (run from a parent dir that holds both)
 #   4. ~/aerospike-ce-kubernetes-operator (cloned to home)
 #   5. ~/github/aerospike-ce-kubernetes-operator (the default ~/github/<repo> layout)
@@ -55,7 +55,7 @@ def _discover_operator_repo() -> Path:
         return Path(explicit).expanduser()
 
     here = Path(__file__).resolve()
-    # parents: helpers, e2e_pytest, acko-e2e-test, skills, aerospike-ce-ecosystem-plugins, asc-workspace
+    # parents: helpers, e2e_pytest, acko-e2e-test, skills, plugin repo, shared workspace
     workspace_sibling = here.parents[5] / "aerospike-ce-kubernetes-operator"
 
     candidates = [


### PR DESCRIPTION
## Summary
- Add the missing marketplace description so plugin validation is warning-free.
- Replace stale `asc-workspace` e2e wording/comments with generic workspace-sibling terminology.

## Testing
- `claude plugin validate .`
- `rg -n 'asc-workspace' skills/acko-e2e-test` returned no matches.
- `git diff --check`