### PR TITLE
docs(skills): reflect operator OpenTelemetry export in acko skills

### DIFF
--- a/skills/acko-deploy/SKILL.md
+++ b/skills/acko-deploy/SKILL.md
@@ -47,6 +47,17 @@ Common install variants:
 
 SQLite is single-writer, so the chart pins `ui.replicaCount=1` and **fails the install if you raise it**. For an HA / multi-replica UI, point `ui.database.type=postgresql` at an **external** managed database (RDS / Cloud SQL / AlloyDB) — or supply its URL via `ui.database.postgresql.existingSecret`. The chart does not run PostgreSQL for you. Full value reference: ACKO docs → Reference → Helm Values.
 
+**OpenTelemetry export (operator).** Off by default. To export the operator's reconcile traces, metrics, and logs to an OTLP/gRPC collector, set **both** `observability.otel.enabled=true` and a non-empty `observability.otel.endpoint`:
+
+```bash
+helm upgrade --install acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  -n aerospike-operator --create-namespace \
+  --set observability.otel.enabled=true \
+  --set observability.otel.endpoint=otel-collector.observability.svc.cluster.local:4317
+```
+
+`endpoint` alone does nothing (telemetry stays off); `enabled=true` without an `endpoint` fails chart rendering. The operator exports **OTLP/gRPC only** — a scheme-less `host:port` is normalized to `http://`, so pass `https://` explicitly for a TLS collector. When `networkPolicy.enabled` / `cilium.enabled` is set, the chart **auto-adds** the collector egress rule (`observability.otel.collectorPort`, default `4317`) — without it the locked-down egress silently drops all telemetry. The chart never deploys a collector itself. See **acko-operations** for enabling/verifying OTel on a running cluster.
+
 ### Step 2: Apply the Minimal CR
 
 ```yaml

--- a/skills/acko-e2e-test/SKILL.md
+++ b/skills/acko-e2e-test/SKILL.md
@@ -105,6 +105,7 @@ PASS when **`tests/chart/test_helm_matrix.py`** verifies the matrix:
 | **UI web-only** | web only; NetworkPolicy with ONLY `:3100`; web pod has `automountServiceAccountToken=false`; NO helm-test pod |
 | **OTel disabled (default)** | `OTEL_SDK_DISABLED=true` in api env; no OTLP endpoint |
 | **OTel enabled** | `OTEL_SDK_DISABLED=false`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`, `OTEL_SERVICE_NAME` all set |
+| **Operator OTel enabled** | `observability.otel.enabled=true` → operator Deployment env has `OTEL_SDK_DISABLED=false` + `OTEL_EXPORTER_OTLP_ENDPOINT`; NetworkPolicy / CiliumNetworkPolicy gain an OTLP egress rule on `observability.otel.collectorPort` |
 | **`ingress.target` failfast** | `helm template` MUST fail with an error mentioning `ui.ingress.target` |
 
 Plus **`tests/chart/test_helm_lint.py`** — `helm lint` reports no `[ERROR]` entries.
@@ -165,6 +166,8 @@ PASS when **`tests/observability/test_otel_runtime.py`** (regression_guard for c
 - A deployed OpenTelemetry collector (`reference/otel-collector.yaml`) receives traces with `service.name: aerospike-cluster-manager-api`.
 - **Both** `opentelemetry.instrumentation.fastapi` and `opentelemetry.instrumentation.asyncpg` instrumentation scopes appear at the collector. Before #265 only asyncpg spans showed up, parent-less.
 - At least one trace contains a Server-kind FastAPI span (HTTP request) **and** an asyncpg child span sharing the same trace ID — proving HTTP→DB context propagation.
+
+**Operator side** (`observability.otel.*`) follows the same pattern: `helm upgrade --set observability.otel.enabled=true --set observability.otel.endpoint=<host:4317>` sets `OTEL_SDK_DISABLED=false` on the operator Deployment, and when `networkPolicy.enabled` / `cilium.enabled` is set the chart auto-adds the OTLP egress rule (`observability.otel.collectorPort`). Verified end-to-end on a Calico kind cluster (acko #281): operator reconcile spans, `acko_*` + controller-runtime metrics, and operator logs reach the collector — and removing the egress rule blocks export (negative control). A scheme-less endpoint is normalized to `http://`; the chart never deploys a collector.
 
 ### Performance / soak (release-tag only)
 

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -386,6 +386,29 @@ Detail: `./reference/diagnostic-commands.md`
 
 ---
 
+## 16. OpenTelemetry Observability
+
+The operator can export its **reconcile traces, metrics, and logs** to an OTLP/gRPC collector — off by default. Enable it on a running cluster with a Helm upgrade (no CR change):
+
+```bash
+helm upgrade acko oci://ghcr.io/aerospike-ce-ecosystem/charts/aerospike-ce-kubernetes-operator \
+  -n aerospike-operator --reuse-values \
+  --set observability.otel.enabled=true \
+  --set observability.otel.endpoint=otel-collector.observability.svc.cluster.local:4317
+```
+
+The Deployment rolls; the new pod logs `OpenTelemetry export enabled`. Confirm export is flowing — a blocked egress instead logs `missing address` / `context deadline exceeded`:
+
+```bash
+kubectl -n aerospike-operator logs -l control-plane=controller-manager --tail=50 | grep -iE 'otel|export'
+```
+
+The collector then receives reconcile spans (`Reconcile` → `reconcileCluster` → `reconcileRacks`), the `acko_*` + controller-runtime metrics, and operator logs. Disable again with `--set observability.otel.enabled=false`.
+
+Config rules — `enabled` + `endpoint` both required, OTLP/gRPC endpoint scheme, the auto-added NetworkPolicy egress (`observability.otel.collectorPort`) — are covered in **acko-deploy**.
+
+---
+
 ## Reference Documents
 
 - [Operations Reference](./reference/operations.md) -- Detailed Day-2 operations with all kubectl commands

--- a/skills/acko-operations/reference/metrics.md
+++ b/skills/acko-operations/reference/metrics.md
@@ -4,6 +4,8 @@ Prometheus metrics emitted by the ACKO controller process (not the Aerospike ser
 
 The operator exposes metrics on the standard `controller-runtime` `/metrics` endpoint (default `:8080/metrics` in the `aerospike-operator` namespace).
 
+When `observability.otel.enabled` is set on the Helm chart, this same registry is **also** pushed to an OTLP collector (bridged from Prometheus) — `/metrics` scraping and OTLP push run side by side. See acko-operations §16.
+
 > Catalog verified against `aerospike-ce-kubernetes-operator/internal/metrics/metrics.go`. Every metric below is registered with the listed labels.
 
 ---


### PR DESCRIPTION
## Summary

The ACKO operator now exports traces/metrics/logs to an OTLP collector via the `observability.otel.*` Helm values (`acko` #279, #281). This reflects that into the affected skills:

- **acko-deploy** — a new "OpenTelemetry export (operator)" block in the install section: how to enable it at `helm install` time, the `enabled` + `endpoint` both-required rule, OTLP/gRPC endpoint scheme normalization, and the automatic NetworkPolicy egress.
- **acko-operations** — new **§16 OpenTelemetry Observability**: enabling / verifying / disabling OTel on a running cluster via `helm upgrade`, what flows to the collector, and the gotchas (collector port, endpoint scheme, no bundled collector). `reference/metrics.md` now notes the OTLP push path alongside `/metrics` scraping.
- **acko-e2e-test** — an "Operator OTel enabled" row in the Helm chart matrix and an operator-side contract in the OTel runtime-export section (verified end-to-end on a Calico kind cluster).

Skills that already cover client-side observability (`aerospike-py-api`, `aerospike-py-fastapi`) needed no change.

## Notes

Docs-only; no skill frontmatter / trigger changes.
