### PR TITLE
feat(skills): require reading operational guides before ackoctl use

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -78,6 +78,12 @@
       "prompt": "cluster-manager UI에서 Record browser 페이지가 500을 내는데 어디 repo에 이슈 올려야 돼?",
       "expected_output": "bug-reporter skill triggers; routes to aerospike-cluster-manager repo (https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/issues/new); asks for browser+version, the failing URL path, browser console error, failing Network tab request/response, and screenshot or /api/v1/version output",
       "files": []
+    },
+    {
+      "id": 14,
+      "prompt": "ackoctl로 test 네임스페이스 users set에 임시 레코드 하나 넣어줘.",
+      "expected_output": "ackoctl skill triggers; recognizes a data-plane write; runs ackoctl guide get data-plane FIRST to read the workspace operational policy before any record put; follows the policy it returns (e.g. caps test-data TTL at 7 days, attaches a note using the creator/date template); then runs ackoctl record put with the policy-compliant flags; if the data-plane guide returns 404 it tells the user no guide is registered and proceeds with standard caution rather than inventing a policy",
+      "files": []
     }
   ]
 }

--- a/skills/ackoctl/SKILL.md
+++ b/skills/ackoctl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ackoctl
-description: "MUST USE when the user drives Aerospike clusters via the ackoctl CLI — connections, records/sets/queries, secondary indexes, operator notes, raw asinfo, K8s AerospikeCluster CRs (list/get/scale/logs/events/pods/reconcile), admin users/roles, and Lua UDFs. Triggers on: ackoctl, manage Aerospike connection, browse records, run query, scale cluster, register UDF, create Aerospike user. Replaces the retired ACM MCP server — canonical way to drive cluster-manager from Claude Code."
+description: "MUST USE when the user drives Aerospike clusters via the ackoctl CLI — connections, records/sets/queries, secondary indexes, operator notes, operational guides, raw asinfo, K8s AerospikeCluster CRs (list/get/scale/logs/events/pods/reconcile), admin users/roles, and Lua UDFs. ALWAYS read the workspace's data-plane / control-plane operational guide with `ackoctl guide get` before running any data or cluster operation, and follow the org/team policy it states. Triggers on: ackoctl, ackoctl guide, manage Aerospike connection, browse records, run query, scale cluster, register UDF, create Aerospike user, read operational guide. Replaces the retired ACM MCP server — canonical way to drive cluster-manager from Claude Code."
 ---
 
 # ackoctl — cluster-manager CLI for Claude Code
@@ -10,6 +10,51 @@ description: "MUST USE when the user drives Aerospike clusters via the ackoctl C
 This skill replaces the legacy `acm-mcp-init` skill. The MCP HTTP server inside cluster-manager has been retired in favor of the CLI: there is **no `claude mcp add`**, no DNS-rebinding allowlist, and no Origin allowlist — the security surface shrank because there is no MCP HTTP server. Claude shells out to `ackoctl` like it would to `kubectl` or `gh`.
 
 When in doubt about a specific invocation, consult [`./reference/commands.md`](./reference/commands.md).
+
+## 0. Read the operational guides first — mandatory
+
+Operational guides are workspace-scoped Markdown policy documents that acko
+administrators register in cluster-manager. They are the **authoritative
+org/team policy** for what may be done with Aerospike data and clusters —
+TTL ceilings for throwaway data, required `note` templates, which environments
+may be created and how, approval gates, and so on.
+
+**Before running any mutating `ackoctl` command, read the relevant guide and
+follow it.** This is not optional — the guides exist so an administrator can
+control data and cluster operations dynamically, server-side, without changing
+this skill.
+
+| Before you run … | First read |
+|---|---|
+| `record put/delete`, `set truncate`, `index create/delete`, `note …`, `cluster configure-namespace`, mutating `query` | `ackoctl guide get data-plane` |
+| `connection create/update/delete`, `k8s cluster create/scale/delete/reconcile`, `info … --allow-write`, `admin user/role …` | `ackoctl guide get control-plane` |
+
+```bash
+ackoctl guide list                # which guides the workspace has registered
+ackoctl guide get data-plane      # policy for Aerospike data CRUD
+ackoctl guide get control-plane   # policy for Aerospike cluster lifecycle
+```
+
+Workflow every time:
+
+1. Decide whether the task touches the **data plane** (records / sets /
+   indexes / notes) or the **control plane** (connections / clusters / admin).
+2. Run `ackoctl guide get <data-plane|control-plane>` for the active workspace
+   and read the returned Markdown **in full**.
+3. Apply every policy it states. Example data-plane policy: "temporary test
+   data must set TTL ≤ 7 days and carry a `note` using the template
+   `creator: … / date: …`". Example control-plane policy: "test clusters must
+   be created in-memory only; stage uses the `soft-rack` template; prod is not
+   created directly — get approval first".
+4. Only then run the ackoctl command(s). If the guide forbids or constrains the
+   request, surface that to the user before acting.
+
+If `ackoctl guide get …` returns **404** the guide is not registered yet — tell
+the user, proceed with standard caution, and do **not** invent a policy.
+
+Guides are authored and edited by administrators in the cluster-manager web UI
+under **Operational guides** (`/guides`). See [§4 `guide`](#guide--operational-guides-orgteam-policy)
+for the read-only CLI surface.
 
 ## 1. Install
 
@@ -74,6 +119,27 @@ gh / aws / kubectl style: `ackoctl connection list`, not `ackoctl get connection
 For lists and gets, default to `-o table` for human consumption and switch to `-o json` / `-o yaml` whenever Claude needs to parse the output downstream.
 
 ## 4. Commands by noun
+
+### guide — operational guides (org/team policy)
+
+Read-only access to the workspace's operational guides. **Run these before any
+data or cluster operation** — see [§0](#0-read-the-operational-guides-first--mandatory).
+
+```bash
+ackoctl guide list                              # guides registered for the workspace (data-plane and/or control-plane)
+ackoctl guide get data-plane                    # prints the Markdown policy body
+ackoctl guide get control-plane
+ackoctl guide get data-plane --workspace=ws-team-a
+ackoctl guide get control-plane -o json         # structured: title, timestamps, author
+```
+
+`guide get` prints the raw Markdown to stdout under the default output (easy to
+read and pipe); `-o json` / `-o yaml` emit the full structured guide. The
+workspace comes from `--workspace` or the current context; **unlike other
+resource commands**, `guide` falls back to the built-in `ws-default` workspace
+when neither is set (it does not error out) — `ws-default` always exists and is
+readable by every authenticated caller. Guides are authored in the
+cluster-manager web UI — there is no `guide create/edit` verb in ackoctl.
 
 ### connection — Aerospike connection profiles
 

--- a/skills/ackoctl/reference/commands.md
+++ b/skills/ackoctl/reference/commands.md
@@ -2,6 +2,15 @@
 
 Compact one-line-per-verb enumeration. Use this when constructing a precise `ackoctl` invocation — the SKILL.md prose covers semantics; this file covers exact verbs and flags. Grammar is uniform: `ackoctl <noun> <verb> [POSITIONAL] [--flag value]`. Default output is `-o table`; `-o json|yaml` is always available.
 
+## `guide` — operational guides (read org/team policy first)
+
+Read-only. **Run `guide get` before any mutating command** and follow the policy it states — data-plane guide before record/set/index/note writes, control-plane guide before connection/cluster/admin operations.
+
+| Verb | One-liner |
+|------|-----------|
+| `guide list` | List the guides registered for the workspace (data-plane, control-plane). |
+| `guide get data-plane\|control-plane [--workspace WS]` | Print one guide; default output is the raw Markdown body, `-o json\|yaml` is structured. |
+
 ## `config` — context management (kubeconfig-style)
 
 | Verb | One-liner |


### PR DESCRIPTION
## Summary

Updates the **`ackoctl` skill** so Claude reads the workspace's
**operational guides** (org/team policy) *before* running any mutating
`ackoctl` command — and follows what they say.

This is the AI-side half of the operational-guides feature: an acko
administrator authors policy in cluster-manager, and this skill change makes
the agent honour it without any further skill edits.

## Changes

- **`SKILL.md` — new mandatory "§0 Read the operational guides first"** section: a table mapping each data-plane / control-plane operation to the guide to read first, a 4-step workflow, and the 404 ("no guide registered") fallback rule.
- **`SKILL.md` — new `### guide` command** subsection (`guide list`, `guide get`).
- **Frontmatter `description`** updated to surface the guide-first rule and add triggers (`ackoctl guide`, `read operational guide`).
- **`reference/commands.md`** — new `guide` command table.
- **`evals/evals.json`** — new eval (#14) asserting the skill runs `ackoctl guide get data-plane` before a record write and handles a missing guide correctly.

## Verification

- `evals.json` validated as well-formed JSON (14 evals).
- Skill frontmatter checked (well-formed, 725 chars — comparable to peer skills).
- Documented `ackoctl guide` commands match the actual CLI (ackoctl PR #40): `guide list`, `guide get data-plane|control-plane`, `-o json|yaml`, `--workspace`, `ws-default` fallback.
- Internal Markdown anchor links verified.

## Related

- ackoctl PR #40 — adds the `ackoctl guide` command this skill instructs Claude to use.
- aerospike-cluster-manager PR #380 — the guides API/UI.

Note: per repo policy the `plugin.json` version is left untouched — the auto-release workflow bumps MINOR from the `feat` commit.