### PR TITLE
fix: correct acko-e2e-test skill drift against operator main (chart 0.4.0 ui.enabled + OTel)

### DIFF
--- a/skills/acko-e2e-test/SKILL.md
+++ b/skills/acko-e2e-test/SKILL.md
@@ -99,7 +99,7 @@ PASS when **`tests/chart/test_helm_matrix.py`** verifies the matrix:
 
 | Mode | Contract |
 |------|----------|
-| **operator-only** (`--set ui.enabled=false`) | Operator Deployment present; NO ui-api/ui-web; NO ServiceMonitor |
+| **operator-only** (`--set ui.api.enabled=false --set ui.web.enabled=false`) | Operator Deployment present; NO ui-api/ui-web; NO ServiceMonitor |
 | **UI full** (api + web) | api + web Deployments; NetworkPolicy with both `:8000` and `:3100`; helm-test pod present |
 | **UI api-only** | api only; NetworkPolicy with ONLY `:8000`; helm-test pod present |
 | **UI web-only** | web only; NetworkPolicy with ONLY `:3100`; web pod has `automountServiceAccountToken=false`; NO helm-test pod |
@@ -109,7 +109,7 @@ PASS when **`tests/chart/test_helm_matrix.py`** verifies the matrix:
 
 Plus **`tests/chart/test_helm_lint.py`** — `helm lint` reports no `[ERROR]` entries.
 
-> ⚠️ **Drift note**: The chart's current default is `ui.enabled=true`. The "operator-only" row uses `--set ui.enabled=false` explicitly. If the default flips, update the parametrize entry.
+> ⚠️ **Drift note**: Chart 0.4.0 removed the legacy `ui.enabled` master switch. The UI is controlled by the independent `ui.api.enabled` / `ui.web.enabled` toggles (both default `true`); the "operator-only" row opts out by setting BOTH to `false`. If a future chart re-introduces a master switch, update the parametrize entries.
 
 ### Helm chart — real install + helm test
 

--- a/skills/acko-e2e-test/e2e_pytest/conftest.py
+++ b/skills/acko-e2e-test/e2e_pytest/conftest.py
@@ -223,7 +223,7 @@ def ui_api_pf(helm_release: dict) -> Iterator[str]:
         ]
     )
     if not svc:
-        pytest.skip("ui-api Service not found — is ui.enabled=true?")
+        pytest.skip("ui-api Service not found — is ui.api.enabled=true?")
     with port_forward(
         namespace=helm_release["namespace"],
         service=svc,

--- a/skills/acko-e2e-test/e2e_pytest/tests/chart/test_helm_matrix.py
+++ b/skills/acko-e2e-test/e2e_pytest/tests/chart/test_helm_matrix.py
@@ -3,9 +3,11 @@
 Each mode is one parametrize entry. Tests are pure manifest-shape assertions
 that need no Kind cluster, so they run on every PR as a fast gate.
 
-Drift note: the chart currently ships `ui.enabled=true` by default. The
-operator-only mode therefore uses `--set ui.enabled=false` explicitly. If
-the chart default flips, update the parametrize id below.
+Drift note: chart 0.4.0 removed the legacy `ui.enabled` master switch in
+favour of the independent `ui.api.enabled` / `ui.web.enabled` toggles (both
+default `true`). Operator-only mode therefore opts out by setting BOTH to
+`false`. If a future chart re-introduces a master switch, update the
+parametrize entries below.
 """
 
 from __future__ import annotations
@@ -27,11 +29,11 @@ from helpers.chart_yaml import (
 
 
 # ---------------------------------------------------------------------------
-# Operator-only (chart default ships ui.enabled=true → must opt out explicitly)
+# Operator-only (UI on by default → opt out via ui.api + ui.web both false)
 # ---------------------------------------------------------------------------
 @pytest.mark.chart
 def test_operator_only_no_ui(chart_path: Path) -> None:
-    docs = template(chart_path, {"ui.enabled": "false"})
+    docs = template(chart_path, {"ui.api.enabled": "false", "ui.web.enabled": "false"})
     deps = deployment_names(docs)
 
     assert any(name == "foo-aerospike-ce-kubernetes-operator" for name in deps), (
@@ -53,7 +55,6 @@ def test_ui_full_renders_api_web_networkpolicy(chart_path: Path) -> None:
     docs = template(
         chart_path,
         {
-            "ui.enabled": "true",
             "ui.networkPolicy.enabled": "true",
             "ui.tests.enabled": "true",
         },
@@ -78,7 +79,6 @@ def test_ui_api_only_no_web(chart_path: Path) -> None:
     docs = template(
         chart_path,
         {
-            "ui.enabled": "true",
             "ui.web.enabled": "false",
             "ui.ingress.target": "api",
             "ui.networkPolicy.enabled": "true",
@@ -105,7 +105,6 @@ def test_ui_web_only_no_api(chart_path: Path) -> None:
     docs = template(
         chart_path,
         {
-            "ui.enabled": "true",
             "ui.api.enabled": "false",
             "ui.web.env.apiUrl": "http://x",
             "ui.networkPolicy.enabled": "true",
@@ -137,7 +136,7 @@ def test_ui_web_only_no_api(chart_path: Path) -> None:
 # ---------------------------------------------------------------------------
 @pytest.mark.chart
 def test_otel_disabled_by_default(chart_path: Path) -> None:
-    docs = template(chart_path, {"ui.enabled": "true"})
+    docs = template(chart_path, {})
     api = find_named(docs, "Deployment", "foo-aerospike-ce-kubernetes-operator-ui-api")
     assert api is not None
     env_vars = container_env(api, "api")
@@ -158,7 +157,6 @@ def test_otel_enabled_env_wiring(chart_path: Path) -> None:
     docs = template(
         chart_path,
         {
-            "ui.enabled": "true",
             "ui.api.otel.enabled": "true",
             "ui.api.otel.endpoint": "http://col:4317",
         },
@@ -181,7 +179,6 @@ def test_ingress_target_web_with_web_disabled_fails(chart_path: Path) -> None:
     err = template_expect_fail(
         chart_path,
         {
-            "ui.enabled": "true",
             "ui.web.enabled": "false",
             "ui.ingress.enabled": "true",
             # default ingress.target=web → conflicts with web.enabled=false

--- a/skills/acko-e2e-test/e2e_pytest/tests/observability/test_otel_runtime.py
+++ b/skills/acko-e2e-test/e2e_pytest/tests/observability/test_otel_runtime.py
@@ -6,6 +6,11 @@ toggle, deploys an OTel collector with a debug exporter, generates traffic,
 and asserts that **both** instrumentation scopes appear AND that at least
 one trace contains a Server-kind FastAPI span and an asyncpg child span
 sharing the trace ID.
+
+The asyncpg half of the contract only holds against a real PostgreSQL
+backend. The chart default is sqlite (no asyncpg driver, no asyncpg
+spans), so this test switches the release to the chart-managed embedded
+PostgreSQL on the helm upgrade below.
 """
 
 from __future__ import annotations
@@ -28,6 +33,15 @@ COLLECTOR_YAML = Path(__file__).resolve().parents[3] / "reference" / "otel-colle
 
 
 def _ui_api_pod() -> str:
+    """Name of the newest ui-api pod (by creation timestamp).
+
+    A `helm upgrade` rolls the Deployment; during the cutover the old
+    (Terminating) pod and the freshly-rolled pod both match the label
+    selector, and `{.items[0]}` ordering is not deterministic — it can
+    return the stale pod, whose env still reflects the pre-upgrade
+    values. Sorting by creation timestamp and taking the last entry
+    always yields the post-upgrade pod.
+    """
     return run_text(
         [
             "kubectl",
@@ -37,8 +51,9 @@ def _ui_api_pod() -> str:
             env.NS_OPERATOR,
             "-l",
             "app.kubernetes.io/component=ui-api",
+            "--sort-by=.metadata.creationTimestamp",
             "-o",
-            "jsonpath={.items[0].metadata.name}",
+            "jsonpath={.items[-1:].metadata.name}",
         ]
     )
 
@@ -153,11 +168,21 @@ def test_otel_runtime_emits_correlated_traces(
             f"ui.api.otel.endpoint={otel_collector}",
             "--set",
             "ui.api.otel.protocol=grpc",
+            # asyncpg instrumentation only emits spans against a real
+            # PostgreSQL backend. The chart default is sqlite, so the
+            # HTTP->DB correlation contract below requires switching the
+            # release to the chart-managed embedded PostgreSQL. The
+            # upgrade-safety gates do not fire on a fresh sqlite install
+            # (no leftover embedded-mode Secret / StatefulSet).
+            "--set",
+            "ui.database.type=postgresql",
+            "--set",
+            "ui.database.postgresql.deploy=true",
             "--wait",
             "--timeout",
-            "3m",
+            "5m",
         ],
-        timeout=300,
+        timeout=420,
     )
     run(
         [
@@ -167,7 +192,7 @@ def test_otel_runtime_emits_correlated_traces(
             "-n",
             helm_release["namespace"],
             "deploy",
-            "--timeout=2m",
+            "--timeout=3m",
         ]
     )
 

--- a/skills/acko-e2e-test/reference/quick-commands.md
+++ b/skills/acko-e2e-test/reference/quick-commands.md
@@ -83,37 +83,37 @@ kubectl delete ns aerospike-operator
 cd charts/aerospike-ce-kubernetes-operator
 
 # Resource counts (use as a sanity check; exact numbers depend on chart version)
-helm template t . --set ui.enabled=true --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true --set ui.ingress.enabled=true | grep -cE "^kind:"
+helm template t . --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true --set ui.ingress.enabled=true | grep -cE "^kind:"
 # expect: ~33 (full)
 
-helm template t . --set ui.enabled=true --set ui.web.enabled=false --set ui.ingress.target=api --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true --set ui.ingress.enabled=true | grep -cE "^kind:"
+helm template t . --set ui.web.enabled=false --set ui.ingress.target=api --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true --set ui.ingress.enabled=true | grep -cE "^kind:"
 # expect: ~31 (api-only, no web Deployment / Service)
 
-helm template t . --set ui.enabled=true --set ui.api.enabled=false --set ui.web.env.apiUrl=http://x --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true --set ui.ingress.enabled=true | grep -cE "^kind:"
+helm template t . --set ui.api.enabled=false --set ui.web.env.apiUrl=http://x --set ui.networkPolicy.enabled=true --set ui.tests.enabled=true --set ui.ingress.enabled=true | grep -cE "^kind:"
 # expect: ~26 (web-only, no api Deployment / Service / helm-test pod)
 ```
 
 NetworkPolicy port stanza assertions:
 
 ```bash
-helm template t . --set ui.enabled=true --set ui.web.enabled=false --set ui.networkPolicy.enabled=true | awk '/kind: NetworkPolicy/,/---/' | grep "port:"
+helm template t . --set ui.web.enabled=false --set ui.networkPolicy.enabled=true | awk '/kind: NetworkPolicy/,/---/' | grep "port:"
 # expect: only :8000
 
-helm template t . --set ui.enabled=true --set ui.api.enabled=false --set ui.web.env.apiUrl=http://x --set ui.networkPolicy.enabled=true | awk '/kind: NetworkPolicy/,/---/' | grep "port:"
+helm template t . --set ui.api.enabled=false --set ui.web.env.apiUrl=http://x --set ui.networkPolicy.enabled=true | awk '/kind: NetworkPolicy/,/---/' | grep "port:"
 # expect: only :3100
 ```
 
 `automountServiceAccountToken` assertion (web pod):
 
 ```bash
-helm template t . --set ui.enabled=true | awk '/name: web/,/---/' | grep automountServiceAccountToken
+helm template t . | awk '/name: web/,/---/' | grep automountServiceAccountToken
 # expect: false
 ```
 
 ingress.target failfast:
 
 ```bash
-helm template t . --set ui.enabled=true --set ui.web.enabled=false --set ui.ingress.enabled=true 2>&1 | grep -i "ingress.target"
+helm template t . --set ui.web.enabled=false --set ui.ingress.enabled=true 2>&1 | grep -i "ingress.target"
 # expect: explicit error from ingress.yaml:11 telling the user to flip the target
 ```
 


### PR DESCRIPTION
Running the `acko-e2e-test` suite (`uv run pytest -m smoke`) against the operator at `origin/main` surfaced three independent drifts in the skill. All three are fixed here and verified end-to-end on a Kind cluster.

## 1. Chart 0.4.0 removed the `ui.enabled` master switch

Chart 0.4.0 replaced the legacy `ui.enabled` switch with the independent `ui.api.enabled` / `ui.web.enabled` toggles (both default `true`). The skill still referenced `ui.enabled`, which made `test_helm_matrix.py::test_operator_only_no_ui` a **false failure** — `--set ui.enabled=false` is silently ignored, so UI Deployments still render.

- `test_helm_matrix.py` — operator-only mode now sets `ui.api.enabled=false` + `ui.web.enabled=false`; dropped the redundant no-op `ui.enabled=true` from the other entries.
- `SKILL.md`, `reference/quick-commands.md`, `conftest.py` — corrected the matrix row, drift note, helm-template snippets, and skip-message hint.

## 2. OTel runtime test asserted asyncpg spans against a sqlite backend

`test_otel_runtime.py` asserts an `opentelemetry.instrumentation.asyncpg` scope, but the chart default DB is **sqlite** — no asyncpg driver means asyncpg spans can never appear. The HTTP→DB correlation contract only holds against PostgreSQL, so the test now switches the release to the chart-managed embedded PostgreSQL on its helm upgrade.

## 3. `_ui_api_pod()` race picked the stale Terminating pod

`_ui_api_pod()` took `{.items[0]}` of the ui-api selector. During the helm-upgrade rollout the old (Terminating) and new pods both match; non-deterministic ordering intermittently returned the stale pod (`OTEL_SDK_DISABLED=true`), failing the env assertion. Now sorts by creation timestamp and takes the newest pod.

## Verification

- `uv run pytest -m chart` → **8 passed** (was 1 failed).
- `uv run pytest -m smoke` against operator `origin/main` on a 4-node Kind cluster → after these fixes, the OTel test passes with correlated FastAPI + asyncpg traces observed at the collector. The other 20 smoke tests already passed.
- `ruff check` + `ruff format --check` clean on all changed Python files.