### PR TITLE
fix: tighten plugin docs and link checks

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -18,7 +18,7 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     # Transient network failures should not block PRs; the weekly run is the source of truth.
-    continue-on-error: true
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ claude plugin list
 
 | Skill | Trigger | Description |
 |-------|---------|-------------|
-| **acko-deploy** | "deploy Aerospike on Kubernetes" | Step-by-step guide to deploy CE clusters via AerospikeCluster CR — 8 scenarios from minimal to full-featured |
+| **acko-deploy** | "deploy Aerospike on Kubernetes" | Step-by-step guide to deploy CE clusters via AerospikeCluster CR — 9 scenarios from minimal to full-featured |
 | **acko-operations** | "scale Aerospike cluster" | Day-2 operations: scale, upgrade, dynamic config, warm restart, ACL, pause/resume, troubleshooting |
 | **acko-config-reference** | *(background)* | CE 8.1 parameter reference, CRD-to-conf mapping, webhook validation rules |
 | **acko-e2e-test** | "ACKO e2e test", "kind cluster test" | End-to-end test playbook — canonical scenarios, Ginkgo labels, mandatory `helm install` operator setup, release-verification performance checks |


### PR DESCRIPTION
## Summary
- correct the acko-deploy README scenario count to match the shipped skill
- make scheduled link checks fail when links regress while keeping PR link checks informational

## Testing
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/link-check.yml")'
- rg -n "9 scenarios" README.md
- actionlint was not installed locally