### PR TITLE
chore(ci): bump actions/checkout to v6 in link-check workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -21,7 +21,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Markdown link check (skills/root)
         uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
## Summary
- actions/checkout: v4 → v6 in link-check.yml

All other plugin workflows already use v6. Latest verified via GitHub API: v6.0.2.

## Test plan
- [x] link-check workflow runs on PR