### PR TITLE
fix(skills): correct stale ackoctl flag names and 'aliases removed' claim

### DIFF
--- a/skills/ackoctl/reference/commands.md
+++ b/skills/ackoctl/reference/commands.md
@@ -18,18 +18,18 @@ Read-only. **Run `guide get` before any mutating command** and follow the policy
 | `config view` | Print the merged config (~/.ackoctl/config.yaml). |
 | `config current-context` | Print only the current context name. |
 | `config use-context NAME` | Switch the current context. |
-| `config set-context NAME --server URL --token TOKEN [--workspace WS]` | Create/update a context entry. |
+| `config set-context NAME --server URL --token TOKEN [--workspace-id WS]` | Create/update a context entry. |
 | `config delete-context NAME` | Remove a context entry. |
 
 ## `connection` — cluster-manager connection profiles
 
-`--host` is repeatable (one flag per seed host); `--user`/`--pass` carry auth.
+`--host` is repeatable (one flag per seed host); `--user` + `--password` (or `--password-stdin`) carry auth. `--password` and `--password-stdin` are mutually exclusive.
 
 | Verb | One-liner |
 |------|-----------|
 | `connection list` | List connection profiles in the current workspace. |
 | `connection get ID` | Show a single profile (no password). |
-| `connection create --name N --host H1 [--host H2] --port 3000 [--user U --pass P]` | Create a profile. |
+| `connection create --name N --host H1 [--host H2] --port 3000 [--user U (--password P \| --password-stdin)]` | Create a profile. |
 | `connection update ID [--name ... --host ... --color ... --note ...]` | Patch fields. |
 | `connection delete ID --yes` | Delete a profile. |
 | `connection health ID` | Probe an existing profile's cluster: connected, build, edition, node/namespace counts, memory/disk usage. |

--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -75,7 +75,7 @@ except aerospike_py.AerospikeError as e: ...  # catch-all
 
 Hierarchy: `AerospikeError` > `ClientError(BackpressureError)`, `ClusterError`, `AerospikeTimeoutError`, `RecordError(RecordNotFound, RecordExistsError, RecordGenerationError, FilteredOut, ...)`, `ServerError(AerospikeIndexError, QueryError, AdminError, UDFError)`
 
-`TimeoutError`/`IndexError` aliases are removed -- use `AerospikeTimeoutError`/`AerospikeIndexError`.
+`aerospike_py.exception.TimeoutError`/`IndexError` remain as **deprecated aliases** for `AerospikeTimeoutError`/`AerospikeIndexError` and emit a `DeprecationWarning` when accessed — prefer the canonical names in new code.
 
 Detail: `./reference/admin.md`
 

--- a/skills/aerospike-py-fastapi/SKILL.md
+++ b/skills/aerospike-py-fastapi/SKILL.md
@@ -152,7 +152,7 @@ async def aerospike_error_handler(request, exc):
 | `RecordExistsError` | 409 | Record already exists (CREATE_ONLY) |
 | `RecordGenerationError` | 409 | Optimistic lock conflict |
 | `BackpressureError` | 503 | Too many concurrent operations |
-| `AerospikeTimeoutError` | 504 | Operation timed out (canonical name; `TimeoutError` alias removed) |
+| `AerospikeTimeoutError` | 504 | Operation timed out (canonical name; `aerospike_py.exception.TimeoutError` is a deprecated alias) |
 | `AerospikeIndexError` | 400/500 | Secondary index error (400 if user supplied bad query, else 500) |
 | `AerospikeError` | 500 | Catch-all server error |
 


### PR DESCRIPTION
## Summary

Three small body-text fixes across two skills; no frontmatter/triggers touched.

### `aerospike-py-api/SKILL.md` (body)
The Exception Hierarchy paragraph said *\"TimeoutError/IndexError aliases are removed\"*. This contradicts:
- the same SKILL's frontmatter (corrected in #61),
- the canonical aerospike-py docs (`docs/docs/api/exceptions.md`),
- the `aerospike_py.exception.__getattr__` implementation that still resolves them and emits `DeprecationWarning`.

Rewritten to describe them accurately as **deprecated aliases** with the canonical replacement.

### `aerospike-py-fastapi/SKILL.md` (exception-status table)
Same false claim in the `AerospikeTimeoutError` row. Fixed in the same direction (the alias remains as `aerospike_py.exception.TimeoutError`, deprecated).

### `ackoctl/reference/commands.md` (commands table)
Two stale flag names that don't exist in the binary today:
- `connection create … --user U --pass P` → the real flag is `--password` (with `--password-stdin` mutually exclusive — see ackoctl #57).
- `config set-context … --workspace WS` → the config command's own flag is `--workspace-id`. (`--workspace` exists only as a global persistent flag.)

Both reference/commands rows now match the binary; `SKILL.md` §2 and §7 were already correct.

## Test plan

- [x] `rg \"--pass \" skills/ackoctl/` returns no matches (no other stale `--pass`).
- [x] `rg \"aliases.*removed|alias.*removed\" skills/` returns no matches.
- [x] Diff is body-only across all three files; frontmatter `description:` is byte-identical → no trigger change.

No version bump (auto-release handles it from the Conventional Commits header).