### PR TITLE
fix(skills): sync aerospike-py skills with merged core PRs #361–#405

### DIFF
--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aerospike-py-api
-description: "MUST USE when writing any Python code with aerospike-py or aerospike_py. Rust/PyO3 library with UNCONVENTIONAL patterns — exceptions are importable both from the top-level module (aerospike_py.RecordNotFound) and from aerospike_py.exception (with TimeoutError/IndexError being deprecated aliases there), return types are NamedTuples (record.bins, record.meta.gen, NOT tuple unpacking), batch_read returns a LazyBatchRecords handle (.to_dict() for dict[UserKey, AerospikeRecord], .to_numpy(np.dtype([...])) for a zero-copy structured array; handle.items()/handle[\"k\"] still work via Mapping backward-compat; the legacy _dtype= kwarg is removed), policies use module-level constants (aerospike_py.POLICY_EXISTS_CREATE_ONLY). Without this skill, code uses wrong import paths/return types and misses expression filters (exp), batch_write in_doubt retry, CDT list/map/bit/hll, ping(), backpressure, Prometheus metrics, OpenTelemetry, NumPy, and admin APIs. Triggers on: aerospike-py, aerospike_py, AsyncClient, client.ping(), batch_write, Python + Aerospike, put/get/query/batch with Aerospike."
+description: "MUST USE when writing any Python code with aerospike-py or aerospike_py. Rust/PyO3 library with UNCONVENTIONAL patterns — exceptions are importable both from the top-level module (aerospike_py.RecordNotFound) and from aerospike_py.exception (with TimeoutError/IndexError being deprecated aliases there), return types are NamedTuples (record.bins, record.meta.gen, NOT tuple unpacking), batch_read returns a LazyBatchRecords handle (.to_dict() for dict[UserKey, AerospikeRecord], .to_list() for request-order positional list[bins | None] collision-safe across sets, .to_numpy(np.dtype([...])) for a zero-copy structured array; handle.items()/handle[\"k\"] still work via Mapping backward-compat; the legacy _dtype= kwarg is removed), policies use module-level constants (aerospike_py.POLICY_EXISTS_CREATE_ONLY). Without this skill, code uses wrong import paths/return types and misses expression filters (exp), batch_write in_doubt retry, CDT list/map/bit/hll, ping(), backpressure, Prometheus metrics, OpenTelemetry, NumPy, and admin APIs. Triggers on: aerospike-py, aerospike_py, AsyncClient, client.ping(), batch_write, Python + Aerospike, put/get/query/batch with Aerospike."
 ---
 
 ## Installation
@@ -11,7 +11,7 @@ pip install aerospike-py[numpy]  # NumPy batch integration
 pip install aerospike-py[otel]   # OpenTelemetry context propagation
 ```
 
-Wheels include Python 3.14 and 3.14t (free-threaded, `gil_used=true`).
+Wheels include Python 3.14 and 3.14t (free-threaded, `gil_used=false` — importing on 3.14t keeps the GIL disabled, so threaded workloads scale).
 
 **Import note**: Rust/PyO3 extension. All exceptions are importable from `aerospike_py` directly (preferred) or from `aerospike_py.exception` (e.g., `from aerospike_py.exception import RecordNotFound`). Constants live on `aerospike_py` module directly (e.g., `aerospike_py.POLICY_EXISTS_CREATE_ONLY`). Return types are NamedTuples — use `record.bins`, `record.meta.gen`. Type stubs: `src/aerospike_py/__init__.pyi`
 
@@ -85,7 +85,7 @@ Detail: `./reference/admin.md`
 keys = [("test", "demo", f"user_{i}") for i in range(10)]
 
 # batch_read -> LazyBatchRecords (deferred-conversion handle, NOT a dict). Materialise
-# via .to_dict() / .to_numpy(dtype), or use it dict-like (Mapping over cached to_dict()):
+# via .to_dict() / .to_list() (request-order list[bins|None], multi-set collision-safe) / .to_numpy(dtype), or use it dict-like (Mapping over cached to_dict()):
 lazy = client.batch_read(keys)                      # or batch_read(keys, bins=["name"])
 for user_key, bins in lazy.items(): ...             # dict-like; missing keys absent
 if "user_3" in lazy: print(lazy["user_3"]["name"])

--- a/skills/aerospike-py-api/reference/admin.md
+++ b/skills/aerospike-py-api/reference/admin.md
@@ -100,6 +100,7 @@ client.admin_drop_role("data_reader")
 {"code": aerospike.PRIV_READ}                              # Global
 {"code": aerospike.PRIV_READ, "ns": "test"}                # Namespace-scoped
 {"code": aerospike.PRIV_READ, "ns": "test", "set": "demo"} # Namespace + set-scoped
+{"code": "read", "ns": "test", "set": "demo"}              # Canonical name also accepted (handy for JSON/HTTP)
 ```
 
 ### RoleInfo dict
@@ -122,18 +123,18 @@ client.admin_drop_role("data_reader")
 
 ## Privilege Constants
 
-| Constant | Value | Description |
-|----------|-------|-------------|
-| PRIV_USER_ADMIN | 0 | User management |
-| PRIV_SYS_ADMIN | 1 | System admin |
-| PRIV_DATA_ADMIN | 2 | Data management (truncate, index) |
-| PRIV_UDF_ADMIN | 3 | UDF management |
-| PRIV_SINDEX_ADMIN | 4 | Secondary index management |
-| PRIV_READ | 10 | Read records |
-| PRIV_READ_WRITE | 11 | Read and write |
-| PRIV_READ_WRITE_UDF | 12 | Read, write, and UDF |
-| PRIV_WRITE | 13 | Write records |
-| PRIV_TRUNCATE | 14 | Truncate operations |
+| Constant | Value | Name | Description |
+|----------|-------|------|-------------|
+| PRIV_USER_ADMIN | 0 | user-admin | User management |
+| PRIV_SYS_ADMIN | 1 | sys-admin | System admin |
+| PRIV_DATA_ADMIN | 2 | data-admin | Data management (truncate, index) |
+| PRIV_UDF_ADMIN | 3 | udf-admin | UDF management |
+| PRIV_SINDEX_ADMIN | 4 | sindex-admin | Secondary index management |
+| PRIV_READ | 10 | read | Read records |
+| PRIV_READ_WRITE | 11 | read-write | Read and write |
+| PRIV_READ_WRITE_UDF | 12 | read-write-udf | Read, write, and UDF |
+| PRIV_WRITE | 13 | write | Write records |
+| PRIV_TRUNCATE | 14 | truncate | Truncate operations |
 
 ---
 
@@ -239,6 +240,8 @@ For `batch_write`, also inspect `br.in_doubt` before retrying (write may have ap
 | 200 | AEROSPIKE_ERR_INDEX_FOUND | IndexFoundError |
 | 201 | AEROSPIKE_ERR_INDEX_NOT_FOUND | IndexNotFound |
 | 210 | AEROSPIKE_ERR_QUERY_ABORTED | QueryAbortedError |
+
+Query timeouts also raise `AerospikeTimeoutError` (wire code **212**, no exported constant; `BatchRecord.result` carries 212).
 
 ---
 

--- a/skills/aerospike-py-api/reference/client-config.md
+++ b/skills/aerospike-py-api/reference/client-config.md
@@ -14,7 +14,7 @@ Import from `aerospike_py.types`. Used by `aerospike.client(config)` and `AsyncC
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | hosts | list[tuple[str, int]] | **required** | Seed host addresses |
-| cluster_name | str | None | Expected cluster name |
+| cluster_name | str \| None | None | Expected cluster name |
 | auth_mode | int | AUTH_INTERNAL (0) | Authentication mode |
 | user | str | None | Username for authentication |
 | password | str | None | Password for authentication |

--- a/skills/aerospike-py-api/reference/constants.md
+++ b/skills/aerospike-py-api/reference/constants.md
@@ -42,7 +42,7 @@ All constants are importable from `aerospike_py`.
 | Constant | Value | Description |
 |----------|-------|-------------|
 | POLICY_EXISTS_IGNORE | 0 | Overwrite if exists, create if not (default) |
-| POLICY_EXISTS_UPDATE | 1 | Update if exists, create if not |
+| POLICY_EXISTS_UPDATE | 1 | Alias of POLICY_EXISTS_UPDATE_ONLY — errors (RecordNotFound) if record absent |
 | POLICY_EXISTS_UPDATE_ONLY | 1 | Error if record does not exist |
 | POLICY_EXISTS_REPLACE | 2 | Replace entire record (deletes other bins) |
 | POLICY_EXISTS_REPLACE_ONLY | 3 | Replace entire record, error if not exists |
@@ -94,7 +94,7 @@ All constants are importable from `aerospike_py`.
 | TTL_NAMESPACE_DEFAULT | 0 | Use namespace default TTL |
 | TTL_NEVER_EXPIRE | -1 | Record never expires |
 | TTL_DONT_UPDATE | -2 | Do not change existing TTL |
-| TTL_CLIENT_DEFAULT | -3 | Use client policy default |
+| TTL_CLIENT_DEFAULT | -3 | Resolves to namespace default — aerospike-py has no client-level default TTL |
 
 ---
 

--- a/skills/aerospike-py-api/reference/policies.md
+++ b/skills/aerospike-py-api/reference/policies.md
@@ -41,6 +41,7 @@ Used by: `put()`, `remove()`, `touch()`, `append()`, `prepend()`, `increment()`,
 | socket_timeout | int | 30000 | Socket timeout (ms) |
 | total_timeout | int | 1000 | Total transaction timeout (ms) |
 | max_retries | int | 0 | Max retry attempts |
+| sleep_between_retries | int | 0 | Sleep between retries (ms) |
 | durable_delete | bool | false | Durable delete (Enterprise) |
 | key | int | POLICY_KEY_DIGEST | Key send policy (`POLICY_KEY_*`) |
 | exists | int | POLICY_EXISTS_IGNORE | Record existence policy (`POLICY_EXISTS_*`) |
@@ -80,6 +81,7 @@ Used by: `batch_read()`, `batch_operate()`, `batch_remove()`
 | socket_timeout | int | 30000 | Socket timeout (ms) |
 | total_timeout | int | 1000 | Total transaction timeout (ms) |
 | max_retries | int | 2 | Max retry attempts |
+| sleep_between_retries | int | 0 | Sleep between retries (ms) |
 | filter_expression | Any | | Expression filter |
 
 ---
@@ -98,6 +100,7 @@ Used by: `Query.results()`, `Query.foreach()`
 | socket_timeout | int | 30000 | Socket timeout (ms) |
 | total_timeout | int | 0 | Total timeout (0 = no limit) |
 | max_retries | int | 2 | Max retry attempts |
+| sleep_between_retries | int | 0 | Sleep between retries (ms) |
 | max_records | int | 0 | Max records to return (0 = all) |
 | records_per_second | int | 0 | Rate limit (0 = unlimited) |
 | filter_expression | Any | | Expression filter |
@@ -134,5 +137,6 @@ Used by: all `admin_*` methods, index operations, `truncate()`
 | `TTL_NAMESPACE_DEFAULT` | 0 | Use namespace default |
 | `TTL_NEVER_EXPIRE` | -1 | Never expire |
 | `TTL_DONT_UPDATE` | -2 | Keep existing TTL |
+| `TTL_CLIENT_DEFAULT` | -3 | Resolves to namespace default (no client-level default TTL) |
 
 Full constants reference: `./constants.md`

--- a/skills/aerospike-py-api/reference/read.md
+++ b/skills/aerospike-py-api/reference/read.md
@@ -66,6 +66,7 @@ Read multiple records in a single network call. **Returns a `LazyBatchRecords` h
 
 - `lazy_records.to_dict()` → `dict[UserKey, AerospikeRecord]` (missing / failed records absent)
 - `lazy_records.to_numpy(dtype)` → `NumpyBatchRecords` (zero-copy structured array — the per-record buffer fill runs with the GIL released via `py.detach`)
+- `lazy_records.to_list()` → `list[bins_dict | None]` in request order (`None` at miss/failure; not cached). Collision-safe across sets, where `to_dict()` keeps only one record per `user_key`.
 - `lazy_records.batch_records` → `list[BatchRecord]` (compat — includes digest-only and failed records)
 
 `LazyBatchRecords` also implements the dict-like Mapping protocol so existing dict-style code keeps working without explicit `.to_dict()`:

--- a/skills/aerospike-py-api/reference/types.md
+++ b/skills/aerospike-py-api/reference/types.md
@@ -83,6 +83,7 @@ Returned by sync **and** async `batch_read()`. A zero-conversion handle that wra
 | Method / Operator | Returns | Description |
 |-------------------|---------|-------------|
 | `lazy_records.to_dict()` | `dict[UserKey, AerospikeRecord]` (`= BatchRecords`) | Materialise as `dict[user_key, bins_dict]`. Excludes digest-only and failed records. |
+| `lazy_records.to_list()` | `list[dict \| None]` | Materialise as `list[bins_dict \| None]` in request-key order; `None` at miss/failure positions (header-only hit = `{}`). Collision-safe across sets, where `to_dict()` keeps only one record per `user_key`. Not cached. |
 | `lazy_records.to_numpy(dtype)` | `NumpyBatchRecords` | Materialise as a structured array. `dtype` **must be a real `np.dtype` object** (e.g. `np.dtype([("score","i4")])`). The per-record fill loop runs with the GIL released (`py.detach`), so sibling work (torch inference, other asyncio tasks) can hold the GIL while the buffer fills. |
 | `lazy_records.batch_records` | `list[BatchRecord]` | Compat path: lazy NamedTuple conversion. Includes digest-only and failed records. |
 | `lazy_records.items()` / `keys()` / `values()` / `get()` | dict views | Dict-style — same semantics as the cached `to_dict()`. |
@@ -173,7 +174,7 @@ Returned by `info_all`. One result per cluster node.
 | `operate()` | `Record` |
 | `operate_ordered()` | `OperateOrderedResult` |
 | `info_all()` | `list[InfoNodeResult]` |
-| `batch_read()` | `LazyBatchRecords` — call `.to_dict()` for `BatchRecords` shape, `.to_numpy(np.dtype([...]))` for `NumpyBatchRecords` |
+| `batch_read()` | `LazyBatchRecords` — call `.to_dict()` for `BatchRecords` shape, `.to_list()` for request-order `list[bins \| None]`, `.to_numpy(np.dtype([...]))` for `NumpyBatchRecords` |
 | `batch_write()`, `batch_operate()`, `batch_remove()`, `batch_write_numpy()` | `BatchWriteResult` (NamedTuple, `.batch_records: list[BatchRecord]`) |
 | `ping()` | `bool` |
 | `Query.results()` | `list[Record]` |
@@ -207,6 +208,7 @@ Used by: `put()`, `remove()`, `touch()`, `append()`, `prepend()`, `increment()`,
 | socket_timeout | int | 30000 | Socket timeout (ms) |
 | total_timeout | int | 1000 | Total transaction timeout (ms) |
 | max_retries | int | 0 | Max retry attempts |
+| sleep_between_retries | int | 0 | Sleep between retries (ms) |
 | durable_delete | bool | false | Durable delete (Enterprise) |
 | key | int | POLICY_KEY_DIGEST | Key send policy (`POLICY_KEY_*`) |
 | exists | int | POLICY_EXISTS_IGNORE | Record exists policy (`POLICY_EXISTS_*`) |
@@ -233,6 +235,7 @@ Used by: `batch_read()`, `batch_operate()`, `batch_remove()`
 | socket_timeout | int | 30000 | Socket timeout (ms) |
 | total_timeout | int | 1000 | Total transaction timeout (ms) |
 | max_retries | int | 2 | Max retry attempts |
+| sleep_between_retries | int | 0 | Sleep between retries (ms) |
 | filter_expression | Any | | Expression filter |
 
 ### QueryPolicy
@@ -244,6 +247,7 @@ Used by: `Query.results()`, `Query.foreach()`
 | socket_timeout | int | 30000 | Socket timeout (ms) |
 | total_timeout | int | 0 | Total timeout (0 = no limit) |
 | max_retries | int | 2 | Max retry attempts |
+| sleep_between_retries | int | 0 | Sleep between retries (ms) |
 | max_records | int | 0 | Max records to return (0 = all) |
 | records_per_second | int | 0 | Rate limit (0 = unlimited) |
 | filter_expression | Any | | Expression filter |
@@ -262,7 +266,7 @@ Used by: `admin_create_role()`, `admin_grant_privileges()`, `admin_revoke_privil
 
 | Field | Type | Description |
 |-------|------|-------------|
-| code | int | Privilege code (`PRIV_*`) |
+| code | int \| str | `PRIV_*` constant or canonical name (`"read"`, `"read-write"`, ...). Reads back as the name in `RoleInfo.privileges`. |
 | ns | str | Namespace scope (empty = global) |
 | set | str | Set scope (empty = namespace-wide) |
 

--- a/skills/aerospike-py-api/reference/write.md
+++ b/skills/aerospike-py-api/reference/write.md
@@ -88,6 +88,8 @@ client.increment(key, "age", 1)
 client.increment(key, "score", 0.5)  # float increment
 ```
 
+> `offset` must be `int`/`float` — other types raise `TypeError` client-side (same guard as `OPERATOR_INCR`).
+
 ### remove_bin(key, bin_names, meta=None, policy=None)
 
 Remove specific bins from a record.
@@ -184,6 +186,7 @@ except RecordGenerationError:
 | `socket_timeout` | int | Socket idle timeout (ms) |
 | `total_timeout` | int | Total transaction timeout (ms) |
 | `max_retries` | int | Maximum retry attempts |
+| `sleep_between_retries` | int | Sleep between retries (ms) |
 | `durable_delete` | bool | Durable delete (requires Enterprise) |
 | `key` | int | Key send policy |
 | `exists` | int | Record existence policy |
@@ -575,6 +578,7 @@ Import: `from aerospike_py import bit_operations as bit_ops`
 #### Notes
 - The `policy` parameter for bit operations is an `int` (`BIT_WRITE_*` constant), not a TypedDict.
 - `bit_add` / `bit_subtract`: `bit_size` must be <= 64. `action` must be `BIT_OVERFLOW_FAIL` (0), `BIT_OVERFLOW_SATURATE` (2), or `BIT_OVERFLOW_WRAP` (4) — any other int raises `ValueError` (no longer silently coerced to FAIL).
+- `bit_resize`: `resize_flags` must be exactly one of `BIT_RESIZE_DEFAULT` (0), `BIT_RESIZE_FROM_FRONT` (1), `BIT_RESIZE_GROW_ONLY` (2), `BIT_RESIZE_SHRINK_ONLY` (4) — composed values (e.g. `GROW_ONLY | FROM_FRONT`) raise `ValueError`, not combinable.
 - `value` for `bit_set`, `bit_or`, `bit_xor`, `bit_and` must be `bytes` or `bytearray`.
 - `value` for `bit_lscan`, `bit_rscan` is `bool` (`True` for 1, `False` for 0).
 

--- a/skills/aerospike-py-fastapi/SKILL.md
+++ b/skills/aerospike-py-fastapi/SKILL.md
@@ -61,7 +61,7 @@ async def read(pk: str, client: AsyncClient = Depends(get_client)):
 
 ## 2b. Batch Endpoints
 
-`batch_read` returns a `LazyBatchRecords` handle (NOT a dict). Materialise via `.to_dict()` for the JSON response, or use the dict-like Mapping dunders directly (`handle.items()`, `handle["k"]`, `"k" in handle`). For inference handlers feeding torch, use `.to_numpy(np.dtype([...]))` — the per-record fill runs with the GIL released, so other request handlers keep making progress while the structured array is built. Missing keys are absent from the dict view.
+`batch_read` returns a `LazyBatchRecords` handle (NOT a dict). Materialise via `.to_dict()` for the JSON response (or `.to_list()` for a request-order `list[bins | None]`, collision-safe across sets), or use the dict-like Mapping dunders directly (`handle.items()`, `handle["k"]`, `"k" in handle`). For inference handlers feeding torch, use `.to_numpy(np.dtype([...]))` — the per-record fill runs with the GIL released, so other request handlers keep making progress while the structured array is built. Missing keys are absent from the dict view.
 
 ```python
 from pydantic import BaseModel


### PR DESCRIPTION
## What

Resolves the backlog of **open `skill-followup` issues** in this repo. Each issue tracks an `aerospike-py` PR; I triaged all 27 open ones against the actual PR diffs (not titles) and the current skill content at `main`, then verified each verdict with an independent adversarial pass.

### Triage outcome (30 open issues → 0 open follow-ups)

| Disposition | Count | Issues |
|---|---|---|
| **Doc fix (this PR)** | 7 | #72, #66, #51, #46, #43, #40, #37 |
| **Closed — already covered** | 9 | #70, #69, #68, #67, #65, #62, #48, #34, #15, #47 |
| **Closed — not skill-facing** | 11 | #73, #64, #60, #59, #55, #54, #53, #33, #23, #22 |
| **Closed — source PR never merged** | 3 | #24, #25, #26 (PRs #352/#353/#354 closed in the 2026-05-13 cleanup; symbols absent from `main`) |

Closed issues each got a comment citing the evidence (plugins PR #71 / commit `a6ef877` coverage, or why the upstream change has no Python-visible surface).

## Changes in this PR (7 verified deltas)

All edits are in `skills/aerospike-py-api/` (+ one line in `aerospike-py-fastapi`). Verified against each PR's diff via `gh`.

- **`to_list()` (PR #405)** — document `LazyBatchRecords.to_list()` request-order positional materialisation in `types.md` / `read.md` / `SKILL.md`. The multi-set **collision-safe** alternative to `to_dict()` (which keys by `user_key` and silently drops cross-set collisions). _Closes #72_
- **`TTL_CLIENT_DEFAULT` (PR #390)** — `-3` resolves to the **namespace default**; aerospike-py exposes no client-level default TTL. Corrects the old "use client policy default" wording in `constants.md` + adds the sentinel to `policies.md`. _Closes #66_
- **`gil_used=false` (PR #375)** — the module no longer re-enables the GIL when imported on 3.14t (`sys._is_gil_enabled()` stays `False`). _Closes #51_
- **`sleep_between_retries` (PR #364)** — now actually honored in Write/Batch/Query policies (previously read-only). Added the field to those policy tables in `policies.md` / `types.md` / `write.md`. _Closes #43_
- **`bit_resize` / `increment` / query timeout (PR #368)** — composed `resize_flags` now raise `ValueError` (data-truncation footgun); `increment()` `offset` must be `int`/`float`; server-side query timeout surfaces as wire code **212** → `AerospikeTimeoutError`. _Closes #46_
- **`Privilege.code` (PR #361)** — accepts an `int` constant **or** a canonical string name (`"read"`, `"read-write"`, ...); `RoleInfo.privileges` come back as canonical strings; added a `Name` column to the privilege table and typed `cluster_name` as `str | None`. _Closes #40_
- **`POLICY_EXISTS_UPDATE` (PR #360)** — corrected the description: it is an **alias of `POLICY_EXISTS_UPDATE_ONLY`** (errors with `RecordNotFound` if the record is absent), **not** a create-or-update upsert. _Closes #37_

## Verification

- All markdown tables keep their column counts; the one `|`-in-cell case (`list[bins \| None]` in `types.md`) is escaped.
- No new/changed relative links.
- No `version` / `plugin.json` edits. The frontmatter `description:` was touched only to add the `to_list()` trigger phrase.

Closes #72
Closes #66
Closes #51
Closes #46
Closes #43
Closes #40
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)