### PR TITLE
fix(skills): add LazyBatchRecords.to_list() example, trim internal trivia

### DIFF
--- a/skills/aerospike-py-api/reference/read.md
+++ b/skills/aerospike-py-api/reference/read.md
@@ -62,7 +62,7 @@ if result.meta is not None:
 
 ### batch_read(keys, bins=None, policy=None) -> LazyBatchRecords
 
-Read multiple records in a single network call. **Returns a `LazyBatchRecords` handle** that wraps the raw Rust results. The async future itself completes with near-zero GIL cost (`Arc::new` + `Py::new`); materialisation is deferred to explicit method calls on the handle:
+Read multiple records in a single network call. **Returns a `LazyBatchRecords` handle** that wraps the raw Rust results — conversion is deferred to explicit method calls on the handle (the async future itself resolves with near-zero GIL cost):
 
 - `lazy_records.to_dict()` → `dict[UserKey, AerospikeRecord]` (missing / failed records absent)
 - `lazy_records.to_numpy(dtype)` → `NumpyBatchRecords` (zero-copy structured array — the per-record buffer fill runs with the GIL released via `py.detach`)
@@ -87,6 +87,12 @@ lazy_records = client.batch_read(keys, bins=["name", "age"])
 
 # Existence check (empty bins) -- handle is still dict-like; missing keys absent
 lazy_records = client.batch_read(keys, bins=[])
+
+# Positional list -- aligned 1:1 with `keys`; None at miss/failure (collision-safe across sets)
+results = client.batch_read(keys, bins=["name"]).to_list()
+for key, bins in zip(keys, results):
+    if bins is not None:        # bins == {} for a header-only hit, None for miss/failure
+        print(key, bins["name"])
 
 # Async
 lazy_records = await async_client.batch_read(keys, bins=["name", "age"])


### PR DESCRIPTION
## Summary

Addresses the skill-impact review in project-hub#145 (upstream `aerospike-py` #405: `LazyBatchRecords.to_list()` positional bulk conversion).

`to_list()` was already synced into the `aerospike-py-api` skill in #74, and the prose/type-table entries (`read.md:69`, `types.md:86`, `SKILL.md`) are accurate against the upstream `.pyi` docstring. This PR is the focused quality pass requested for the issue:

- **Add the missing `to_list()` usage example.** The `read.md` batch_read code block demonstrated `to_dict` / `to_numpy` / `items` but never `to_list` — the one method this issue is about. The new snippet shows the non-obvious contract: positional 1:1 alignment with the request keys, `None` at miss/failure, and the `{}`-vs-`None` distinction for header-only hits.
- **Trim internal trivia.** Dropped the `Arc::new` + `Py::new` allocation detail from the batch_read prose. It's Rust-implementation trivia that doesn't help write user code; the actionable point (deferred conversion, cheap async future) stays.

## Verification

`to_list()` behavior cross-checked against the upstream `src/aerospike_py/__init__.pyi` docstring (commit `264cbf9` / aerospike-py#405): `None` = failed/not-found, `{}` = found-but-empty (header-only), collision-safe across sets, not cached. Skill docs match.

https://claude.ai/code/session_01CaT2crA6zuNrGeNVoPtbwh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaT2crA6zuNrGeNVoPtbwh)_