### PR TITLE
docs(skills): document RollingRestartDeferred event from ACKO #330

### DIFF
--- a/skills/acko-operations/reference/events.md
+++ b/skills/acko-operations/reference/events.md
@@ -9,6 +9,7 @@ Catalog of Kubernetes events emitted by the ACKO operator. Count grows over rele
 | Event Reason | Type | When Emitted |
 |---|---|---|
 | `RollingRestartStarted` | Normal | Rolling restart batch begins |
+| `RollingRestartDeferred` | Warning | Restart batch deferred because data migration is in flight (mirrors `ScaleDownDeferred`) |
 | `RollingRestartCompleted` | Normal | All target pods have been restarted |
 | `RestartFailed` | Warning | A pod restart failed |
 | `PodWarmRestarted` | Normal | SIGUSR1 warm restart completed for a pod |


### PR DESCRIPTION
Adds the new `RollingRestartDeferred` Warning event (introduced in aerospike-ce-kubernetes-operator#330) to the acko-operations events reference. The other #330 changes (second replication-factor string-rejection path, helm probe comments) are already covered by existing skill content.

Closes the review tracked in project-hub#146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)