### PR TITLE
docs(skills): document aerospike-py exception .result_code (ADR-0027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 ### Changed
 
+- `aerospike-py-api` skill — documented the new `.result_code: int` attribute on Aerospike exceptions (server errors carry the real wire code, e.g. `FailForbidden`=22; client-side errors carry the `-1` `CLIENT_SIDE_RESULT_CODE` sentinel) as the structured way to branch on failures instead of parsing message strings (aerospike-py ADR-0027, PR #413).
 - Plugin manifest (`plugin.json`) and `marketplace.json` descriptions rewritten to cover all 9 current skills.
 - CI workflow prompts (`issue-planner`, `agent-implement`, `pr-reviewer`) updated from the obsolete "5 skills + 1 agent" structure to the current 9-skill layout.
 - `README.md` — added the missing `acko-e2e-test` and `bug-reporter` skills to the Skills table.

--- a/skills/aerospike-py-api/SKILL.md
+++ b/skills/aerospike-py-api/SKILL.md
@@ -37,7 +37,7 @@ client.append(key, "name", "_sfx"); client.increment(key, "counter", 1)  # offse
 
 ## 3. Error Handling
 
-Catch specifics (`RecordNotFound`, `BackpressureError` = `max_concurrent_operations` exceeded, `AerospikeTimeoutError`) before the `AerospikeError` catch-all. Hierarchy: `AerospikeError` > `ClientError(BackpressureError)`, `ClusterError`, `InvalidArgError`, `AerospikeTimeoutError`, `RecordError(RecordNotFound, RecordExistsError, RecordGenerationError, FilteredOut, ...)`, `ServerError(AerospikeIndexError, QueryError, AdminError, UDFError)`. `aerospike_py.exception.TimeoutError`/`IndexError` are **deprecated aliases** (DeprecationWarning). Result-code table + batch error mapping: `./reference/admin.md`
+Catch specifics (`RecordNotFound`, `BackpressureError` = `max_concurrent_operations` exceeded, `AerospikeTimeoutError`) before the `AerospikeError` catch-all. Hierarchy: `AerospikeError` > `ClientError(BackpressureError)`, `ClusterError`, `InvalidArgError`, `AerospikeTimeoutError`, `RecordError(RecordNotFound, RecordExistsError, RecordGenerationError, FilteredOut, ...)`, `ServerError(AerospikeIndexError, QueryError, AdminError, UDFError)`. `aerospike_py.exception.TimeoutError`/`IndexError` are **deprecated aliases** (DeprecationWarning). Every exception exposes `.result_code: int` (server errors = real wire code, client-side = `-1`) — branch on it, don't parse messages. Result-code table + batch error mapping + `.result_code`: `./reference/admin.md`
 
 ## 4. Batch Operations
 

--- a/skills/aerospike-py-api/reference/admin.md
+++ b/skills/aerospike-py-api/reference/admin.md
@@ -247,6 +247,25 @@ Query timeouts also raise `AerospikeTimeoutError` (wire code **212**, no exporte
 
 Every server result code maps to its real proto.h wire code (there is no `-1` catch-all), so `BatchRecord.result` and error messages always carry the actual code. All security/ACL/quota codes (53–83 range, e.g. `InvalidPassword`=62, `InvalidCredential`=65, `InvalidRole`=70, `QuotaExceeded`=83) raise **`AdminError`**; unlisted codes (e.g. index 202–206, query 211/213–215) raise the generic `ServerError` with the correct code in the message.
 
+### Structured error codes — `exc.result_code`
+
+Every Aerospike exception carries an integer **`.result_code`** attribute (base `AerospikeError` and every subclass) — branch on it instead of parsing the `AEROSPIKE_ERR (<code>)` message string. Server errors (`ServerError`, and batch `BatchError` / `BatchLastError`) carry the real wire result code on the instance (e.g. `FailForbidden`=22, `RecordNotFound`=2, `RecordExistsError`=5 — the same codes as the table above). Client-side errors — `ClusterError` (connection / invalid node / no-more-connections), `AerospikeTimeoutError`, `InvalidArgError`, and the `ClientError` catch-all — carry the sentinel **`-1`** (`CLIENT_SIDE_RESULT_CODE`, mirroring the C client's `AEROSPIKE_ERR_CLIENT`); the class-level default is also `-1`. The message string still embeds `AEROSPIKE_ERR (<code>)` as before. (ADR-0027)
+
+```python
+from aerospike_py import ServerError, AerospikeError
+
+try:
+    client.put(key, {"n": 1})
+except ServerError as e:
+    if e.result_code == 22:      # FailForbidden — e.g. forbidden/read-only namespace
+        handle_forbidden()
+    else:
+        raise
+except AerospikeError as e:
+    log.warning("aerospike op failed (code=%s)", e.result_code)  # -1 == client-side
+    raise
+```
+
 ---
 
 ## Exception Hierarchy


### PR DESCRIPTION
## Summary

aerospike-py **PR #413 / ADR-0027** adds a structured integer `.result_code` attribute to every Aerospike exception. This documents it in the **`aerospike-py-api`** skill so generated code branches on `.result_code` instead of parsing the `AEROSPIKE_ERR (<code>)` message string.

### What `.result_code` does (verified against aerospike-py `rust/src/errors.rs`)
- Base `AerospikeError` and **all** subclasses expose `.result_code: int` (class default `-1`).
- **Server errors** (`ServerError`, and batch `BatchError` / `BatchLastError`) carry the real Aerospike wire result code on the instance — e.g. `FailForbidden`=22, `RecordNotFound`=2, `RecordExistsError`=5.
- **Client-side errors** (`ClusterError` from connection / invalid-node / no-more-connections, `AerospikeTimeoutError`, `InvalidArgError`, and the `ClientError` catch-all) carry the `-1` sentinel `CLIENT_SIDE_RESULT_CODE`, mirroring the C client's `AEROSPIKE_ERR_CLIENT`.
- The message string still embeds `AEROSPIKE_ERR (<code>)` as before.

## Changes
- **`skills/aerospike-py-api/reference/admin.md`** — new *"Structured error codes — `exc.result_code`"* subsection under Error Handling, extending the existing result-code coverage (not duplicating it), with a `try/except ServerError` example (`if e.result_code == 22`).
- **`skills/aerospike-py-api/SKILL.md`** — one concise pointer clause in the Error Handling section; the body stays lean per its recent compression.
- **`CHANGELOG.md`** — `Unreleased > Changed` entry. No version fields touched.

## Not changed
- **`skills/acko-debugging`** — intentionally untouched. It routes diagnosis through `ackoctl` / `kubectl` / `asinfo` and does not interpret aerospike-py Python exceptions, so `.result_code` is out of scope there.

## Stale text
Grepped both target skills for "no result_code" / "must parse strings" / TODO wording — none found; nothing to correct.

## Verification
- Markdown link check: edits add prose + a Python code block, no new markdown links; existing relative links still resolve.
- `.claude-plugin/plugin.json` and `marketplace.json` — untouched; confirmed still valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)