### PR TITLE
docs: rewrite plugin guides in plain language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,22 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 ### Changed
 
-- `aerospike-py-api` skill — documented the new `.result_code: int` attribute on Aerospike exceptions (server errors carry the real wire code, e.g. `FailForbidden`=22; client-side errors carry the `-1` `CLIENT_SIDE_RESULT_CODE` sentinel) as the structured way to branch on failures instead of parsing message strings (aerospike-py ADR-0027, PR #413).
-- Plugin manifest (`plugin.json`) and `marketplace.json` descriptions rewritten to cover all 9 current skills.
-- CI workflow prompts (`issue-planner`, `agent-implement`, `pr-reviewer`) updated from the obsolete "5 skills + 1 agent" structure to the current 9-skill layout.
-- `README.md` — added the missing `acko-e2e-test` and `bug-reporter` skills to the Skills table.
+- The `aerospike-py-api` skill now documents the `.result_code: int` attribute on Aerospike exceptions. Server errors carry the actual wire code, such as `FailForbidden`=22, while client-side errors use the `-1` `CLIENT_SIDE_RESULT_CODE` sentinel. Applications can use this structured value instead of parsing error messages (aerospike-py ADR-0027, PR #413).
+- The plugin manifest (`plugin.json`) and `marketplace.json` descriptions now cover all nine current skills.
+- The CI workflow prompts (`issue-planner`, `agent-implement`, `pr-reviewer`) now reflect the current nine-skill layout instead of the obsolete "5 skills + 1 agent" structure.
+- The Skills table in `README.md` now includes the previously missing `acko-e2e-test` and `bug-reporter` skills.
 
 ### Fixed
 
-- Skill command examples — corrected stale `ackoctl` verbs (`k8s pod logs` → `k8s cluster logs`, `udf register` → `udf upload`) and CE 7.x namespace parameters (`stop-writes-pct` → `stop-writes-sys-memory-pct`, `high-water-*-pct` → `evict-used-pct`) across `acko-debugging`, `ackoctl`, `acko-operations`, and `README.md`.
-- `ackoctl k8s events list` → `ackoctl k8s cluster events` — the events verb lives under the `k8s cluster` noun in the actual CLI (`ackoctl/SKILL.md`, `acko-debugging/SKILL.md`, `README.md`).
-- `ackoctl/reference/commands.md` — corrected `cluster configure-namespace` flags from `--namespace`/`--set` to the real `--name`/`--param` (repeatable), matching `ackoctl/SKILL.md` and the CLI.
-- `README.md` — Aerospike-py prerequisite bumped from "Python 3.9+" to "Python 3.10+" (aerospike-py declares `requires-python = ">=3.10"`).
-- `acko-e2e-test` and `acko-debugging` skill `description` frontmatter trimmed below the 1024-character limit so the skills load without truncation.
+- Corrected stale `ackoctl` verbs (`k8s pod logs` → `k8s cluster logs`, `udf register` → `udf upload`) and CE 7.x namespace parameters (`stop-writes-pct` → `stop-writes-sys-memory-pct`, `high-water-*-pct` → `evict-used-pct`) in command examples across `acko-debugging`, `ackoctl`, `acko-operations`, and `README.md`.
+- Replaced `ackoctl k8s events list` with `ackoctl k8s cluster events`, matching the actual location of the events verb under the `k8s cluster` noun (`ackoctl/SKILL.md`, `acko-debugging/SKILL.md`, `README.md`).
+- Corrected the `cluster configure-namespace` flags in `ackoctl/reference/commands.md` from `--namespace`/`--set` to the repeatable `--name`/`--param` flags used by `ackoctl/SKILL.md` and the CLI.
+- Updated the aerospike-py prerequisite in `README.md` from "Python 3.9+" to "Python 3.10+", matching the package declaration `requires-python = ">=3.10"`.
+- Shortened the `description` frontmatter for the `acko-e2e-test` and `acko-debugging` skills to keep it below the 1024-character loading limit.
 
 ### Removed
 
-- Deleted the dead `.mcp.json` placeholder left over from the retired `acm-mcp-init` MCP integration.
+- Deleted the unused `.mcp.json` placeholder left by the retired `acm-mcp-init` MCP integration.
 
 ## [1.4.4] - 2026-05-17
 
@@ -42,13 +42,13 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 ### CI/CD
 
-- Daily Release — shifted the scheduled run to KST 07:00 (#31).
+- Daily Release now runs at KST 07:00 (#31).
 
 ## [1.4.2] - 2026-05-13
 
 ### Changed
 
-- Reverted an erroneous 2.0.0 release — retiring the MCP HTTP server in favour of `ackoctl` is a feature swap, not a breaking major bump (#30).
+- Reverted the erroneous 2.0.0 release because replacing the MCP HTTP server with `ackoctl` is a feature swap, not a breaking major change (#30).
 
 ## [1.4.1] - 2026-05-13
 
@@ -89,7 +89,7 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 ### CI/CD
 
-- Daily Release — restricted automatic version bumps to minor (`feat`) and patch; major bumps are now manual (#18).
+- Daily Release now limits automatic version bumps to minor (`feat`) and patch releases; major bumps remain manual (#18).
 
 ## [1.2.1] - 2026-05-06
 
@@ -103,13 +103,13 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 ### Changed
 
 - **Skills**:
-  - `acko-e2e-test` — Hybrid pytest rewrite: Python for assertions, bash for CLI orchestration. Tightens release-verification scenarios and reduces flakiness on the CLI orchestration boundary (PR #10).
+  - `acko-e2e-test` — rewritten as a hybrid pytest suite, using Python for assertions and bash for CLI orchestration. The change tightens release-verification scenarios and reduces flakiness at the CLI orchestration boundary (PR #10).
 - **Skill updates**:
   - `aerospike-py-api` — added a PK regex filter scan guide and `REGEX_*` constants (PR #11); cross-linked the Secondary Index alternative from the PK regex notes (PR #14).
 
 ### CI/CD
 
-- **Daily Release workflow**: New `daily-release.yml` GitHub Actions workflow that auto-detects unreleased commits, computes the next semver from Conventional Commits, and publishes a GitHub release with Claude-generated notes. Mirrors the pattern already used by `aerospike-py` and `aerospike-cluster-manager` so all four ecosystem repos share the same release cadence.
+- **Daily Release workflow**: Added the `daily-release.yml` GitHub Actions workflow. It detects unreleased commits, calculates the next semver version from Conventional Commits, and publishes a GitHub release with Claude-generated notes. The workflow follows the pattern used by `aerospike-py` and `aerospike-cluster-manager`, giving all four ecosystem repositories the same release cadence.
 
 ## [1.1.0] - 2026-05-02
 
@@ -123,11 +123,11 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 ### Changed
 
-- Plugin manifest bumped to `1.1.0` to invalidate stale local plugin caches and surface the new `acko-e2e-test` skill.
+- Bumped the plugin manifest to `1.1.0` so stale local plugin caches are invalidated and the new `acko-e2e-test` skill becomes visible.
 
 ## [1.0.0] - 2026-04-30
 
-Initial public release. Plugin manifest version is `1.0.0` (see `.claude-plugin/plugin.json`).
+Initial public release. The plugin manifest version is `1.0.0` (see `.claude-plugin/plugin.json`).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # aerospike-ce-ecosystem
 
-Claude Code plugin for the Aerospike CE ecosystem — deploy clusters on Kubernetes with [ACKO](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator) and build Python applications with [aerospike-py](https://github.com/aerospike-ce-ecosystem/aerospike-py).
+This Claude Code plugin helps you work with the Aerospike CE ecosystem. Use it to deploy clusters on Kubernetes with [ACKO](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator) and build Python applications with [aerospike-py](https://github.com/aerospike-ce-ecosystem/aerospike-py).
 
 ## Installation
 
 ### From GitHub (recommended)
 
-Add the repository as a marketplace, then install:
+Register this repository as a marketplace, then install the plugin:
 
 ```bash
 # Step 1: Add as marketplace
@@ -38,34 +38,36 @@ claude plugin list
 
 | Skill | Trigger | Description |
 |-------|---------|-------------|
-| **acko-deploy** | "deploy Aerospike on Kubernetes" | Step-by-step guide to deploy CE clusters via AerospikeCluster CR — 9 scenarios from minimal to full-featured |
-| **acko-operations** | "scale Aerospike cluster" | Day-2 operations: scale, upgrade, dynamic config, warm restart, ACL, pause/resume, troubleshooting |
-| **acko-config-reference** | *(background)* | CE 8.1 parameter reference, CRD-to-conf mapping, webhook validation rules |
-| **acko-e2e-test** | "ACKO e2e test", "kind cluster test" | End-to-end test playbook — canonical scenarios, Ginkgo labels, mandatory `helm install` operator setup, release-verification performance checks |
+| **acko-deploy** | "deploy Aerospike on Kubernetes" | Guides you through nine CE deployment scenarios, from a minimal cluster to a full-featured `AerospikeCluster` CR |
+| **acko-operations** | "scale Aerospike cluster" | Covers Day-2 operations such as scaling, upgrades, dynamic configuration, warm restarts, ACL, pause/resume, and troubleshooting |
+| **acko-config-reference** | *(background)* | Provides the CE 8.1 parameter reference, CRD-to-conf mapping, and webhook validation rules |
+| **acko-e2e-test** | "ACKO e2e test", "kind cluster test" | Provides an end-to-end test playbook with canonical scenarios, Ginkgo labels, the required `helm install` operator setup, and release-verification performance checks |
 
 ### aerospike-py (Python Client)
 
 | Skill | Trigger | Description |
 |-------|---------|-------------|
-| **aerospike-py-api** | "use aerospike-py to ..." | Full API reference — AsyncClient, CRUD, batch, CDT, query, expressions, observe, admin |
-| **aerospike-py-fastapi** | "build FastAPI app with Aerospike" | Production-ready FastAPI patterns — lifespan, DI, CRUD endpoints, error handling, metrics |
+| **aerospike-py-api** | "use aerospike-py to ..." | Documents the full API, including AsyncClient, CRUD, batch, CDT, query, expressions, observe, and admin operations |
+| **aerospike-py-fastapi** | "build FastAPI app with Aerospike" | Shows production FastAPI patterns for lifespan, DI, CRUD endpoints, error handling, and metrics |
 
 ### Cluster Manager CLI (ackoctl)
 
 | Skill | Trigger | Description |
 |-------|---------|-------------|
-| **ackoctl** | "ackoctl", "manage Aerospike connection", "browse records", "register UDF", "scale cluster" | Drive [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) via the [ackoctl](https://github.com/aerospike-ce-ecosystem/ackoctl) CLI — connections, cluster info, records/sets, queries, secondary indexes, operator notes, raw asinfo, K8s AerospikeCluster CRs, admin (users/roles), and Lua UDF modules. Multi-cluster ACKO friendly via kubeconfig-style contexts. |
-| **acko-debugging** | "CrashLoopBackOff", "phase=Error", "reconcile failure", "migration stuck" | Systematic 6-step diagnosis procedure for ACKO clusters with CE 8.1 pitfalls and a remediation matrix. Routes both data-plane and K8s-plane probes through ackoctl (`ackoctl cluster info`, `ackoctl info`, `ackoctl query exec`, `ackoctl k8s cluster get/list`, `ackoctl k8s cluster logs`, `ackoctl k8s cluster events`); falls back to `kubectl`/`asinfo` when ackoctl is unavailable. |
+| **ackoctl** | "ackoctl", "manage Aerospike connection", "browse records", "register UDF", "scale cluster" | Uses [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) through the [ackoctl](https://github.com/aerospike-ce-ecosystem/ackoctl) CLI to manage connections, cluster info, records and sets, queries, secondary indexes, operator notes, raw asinfo, K8s `AerospikeCluster` CRs, users and roles, and Lua UDF modules. Kubeconfig-style contexts support multi-cluster ACKO environments. |
+| **acko-debugging** | "CrashLoopBackOff", "phase=Error", "reconcile failure", "migration stuck" | Provides a systematic six-step diagnostic procedure for ACKO clusters, including CE 8.1 pitfalls and a remediation matrix. It runs data-plane and K8s-plane probes through ackoctl (`ackoctl cluster info`, `ackoctl info`, `ackoctl query exec`, `ackoctl k8s cluster get/list`, `ackoctl k8s cluster logs`, `ackoctl k8s cluster events`) and falls back to `kubectl` or `asinfo` when ackoctl is unavailable. |
 
 ### Ecosystem support
 
 | Skill | Trigger | Description |
 |-------|---------|-------------|
-| **bug-reporter** | "버그 제보", "where do I file this issue", "report this to GitHub" | Routes a bug report to the correct `aerospike-ce-ecosystem` repo by symptom and generates a ready-to-paste GitHub issue body with the required reproduction context |
+| **bug-reporter** | "버그 제보", "where do I file this issue", "report this to GitHub" | Identifies the correct `aerospike-ce-ecosystem` repository from the reported symptoms and prepares a GitHub issue with the required reproduction details |
 
 ## ackoctl integration
 
-Live cluster access goes through the [ackoctl](https://github.com/aerospike-ce-ecosystem/ackoctl) Go CLI, which calls [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager)'s REST API at `/api/v1/*`. There is no MCP HTTP server in the loop, so there is no DNS-rebinding allowlist, no Origin allowlist, and no per-cluster `claude mcp add` step — the security surface is just the existing cluster-manager FastAPI auth (bearer JWT + workspace ACL).
+The plugin accesses live clusters through the [ackoctl](https://github.com/aerospike-ce-ecosystem/ackoctl) Go CLI. The CLI calls the [aerospike-cluster-manager](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager) REST API at `/api/v1/*`.
+
+This path does not use an MCP HTTP server. You therefore do not need a DNS-rebinding allowlist, an Origin allowlist, or a separate `claude mcp add` step for each cluster. Authentication remains within the existing cluster-manager FastAPI security model: bearer JWT plus workspace ACL.
 
 ```bash
 # 1. Install ackoctl
@@ -83,7 +85,7 @@ ackoctl connection list
 ackoctl record list <CONN_ID> --namespace=test --set=sample_set --page-size=5
 ```
 
-For multi-cluster ACKO, register one context per cluster-manager instance — naming convention `<env>` or `<region>`:
+For a multi-cluster ACKO environment, register one context for each cluster-manager instance. Name each context after its environment or region, such as `<env>` or `<region>`:
 
 ```bash
 ackoctl config set-context prod-us \
@@ -93,9 +95,9 @@ ackoctl config set-context prod-us \
 ackoctl --context=prod-us k8s cluster list
 ```
 
-Auth is bearer-token only — users bring their own OIDC JWT (Keycloak CLI, browser device flow, …). The workspace ACL on cluster-manager scopes every call; destructive verbs (`delete`, `remove`, mutation `info --allow-write`, `k8s cluster scale`) require `--yes` for non-interactive runs.
+Authentication uses bearer tokens. Provide an OIDC JWT obtained through a method such as the Keycloak CLI or a browser device flow. The cluster-manager workspace ACL limits the scope of every call. For non-interactive runs, destructive operations (`delete`, `remove`, mutation `info --allow-write`, and `k8s cluster scale`) also require `--yes`.
 
-The `ackoctl` skill covers install, configuration, and every command (connection / cluster / set / record / query / index / note / k8s / info / admin / udf). See `skills/ackoctl/reference/commands.md` for a one-line-per-command cheat sheet.
+The `ackoctl` skill covers installation, configuration, and every command group: connection, cluster, set, record, query, index, note, k8s, info, admin, and udf. See `skills/ackoctl/reference/commands.md` for a concise command reference.
 
 ## Prerequisites
 
@@ -112,7 +114,7 @@ The `ackoctl` skill covers install, configuration, and every command (connection
 
 ## Benchmark Results
 
-Evaluated with Claude Sonnet on real deployment tasks:
+The following results come from evaluating Claude Sonnet on real deployment tasks:
 
 | Metric | with skill | without skill | Improvement |
 |--------|-----------|---------------|-------------|
@@ -122,9 +124,10 @@ Evaluated with Claude Sonnet on real deployment tasks:
 | **Tool Calls** | 8.0 | 30.0 | -73.3% |
 
 Key findings:
-- Skills prevent the #1 CE mistake (enterprise-only config in CE clusters)
-- aerospike-py-specific patterns (NamedTuple access, Depends injection) are taught by skills
-- 7 production bonus features generated with skill vs 0 without
+
+- The skills prevented the most common CE configuration error: using enterprise-only settings in a CE cluster.
+- The skills explained aerospike-py-specific patterns such as NamedTuple access and `Depends` injection.
+- Runs with the skills produced seven additional production-oriented features, compared with none in the baseline runs.
 
 ## Development
 
@@ -144,7 +147,7 @@ claude -p "Deploy a single-node Aerospike cluster for development on a kind clus
 claude -p "Deploy a single-node Aerospike cluster for development on a kind cluster" --model sonnet --disable-plugins
 ```
 
-> The `e2e_pytest/` scenario suite includes a **multi-cluster + Keycloak OIDC** scenario (common-cluster web + dev/prod operator-cluster API + bitnami/keycloak realm bootstrap). See [ACKO multi-cluster docs](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/blob/main/docs/multi-cluster-keycloak.md).
+> The `e2e_pytest/` scenario suite includes a **multi-cluster + Keycloak OIDC** scenario. It covers the common-cluster web application, the dev/prod operator-cluster API, and the bitnami/keycloak realm bootstrap. See the [ACKO multi-cluster docs](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/blob/main/docs/multi-cluster-keycloak.md).
 
 ## License
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,7 +1,6 @@
 # Versioning Policy
 
-The `aerospike-ce-ecosystem` Claude Code plugin uses [Semantic Versioning 2.0.0](https://semver.org/).
-Given a version `MAJOR.MINOR.PATCH`:
+The `aerospike-ce-ecosystem` Claude Code plugin follows [Semantic Versioning 2.0.0](https://semver.org/). For a version in the form `MAJOR.MINOR.PATCH`:
 
 - **MAJOR** — incompatible skill/agent contract changes, removal of skills, or changes that require user action.
 - **MINOR** — new skills/agents/commands, expanded coverage, or backwards-compatible content updates.
@@ -11,8 +10,7 @@ The plugin version is recorded in `.claude-plugin/plugin.json` and tagged in git
 
 ## Compatibility Matrix
 
-Each plugin release is validated against specific upstream versions of the projects it documents.
-A plugin version is expected to work with the components below; older or newer combinations are best-effort.
+Each plugin release is validated against specific versions of the upstream projects it documents. The plugin is expected to work with the combinations below; other combinations are best-effort.
 
 | Plugin Version | ACKO | aerospike-py | ackoctl | Aerospike CE Server |
 |----------------|------|--------------|---------|---------------------|
@@ -21,21 +19,22 @@ A plugin version is expected to work with the components below; older or newer c
 | 1.2.0          | v1.2.1 | 0.10.0 | n/a (ACM MCP) | 8.1.x (8.x supported) |
 | Unreleased     | tracks ACKO `main` | tracks aerospike-py `main` | tracks ackoctl `main` | 8.x |
 
-Sources for the 1.0.0 row:
+The 1.0.0 row is based on these sources:
+
 - ACKO: latest git tag in `aerospike-ce-kubernetes-operator` (`v1.0.0`); Helm chart `charts/aerospike-ce-kubernetes-operator/Chart.yaml` `version: 0.2.0`.
 - aerospike-py: latest git tag in `aerospike-py` (`v0.7.1`).
 - Aerospike CE: skills target CE 8.1 (`acko-config-reference`, `acko-deploy`); 8.x line broadly supported.
 
 ## Deprecation Policy
 
-- **Minor versions warn.** When a skill is scheduled for removal it is marked deprecated in its frontmatter `description` and in CHANGELOG `Deprecated`. The skill keeps working through the remainder of the current major.
-- **Major versions remove.** Deprecated skills/agents/commands are deleted in the next major bump. Renames are handled the same way (old name deprecated for a major, removed at the next).
-- **CE feature flags.** Skills that depend on a specific Aerospike CE feature flag (e.g. an 8.x-only config key) are marked in the skill body with the minimum CE version required. If a future CE release drops that feature, the skill is deprecated in the next minor and removed in the next major.
-- **Upstream breaks.** A breaking change in ACKO or `aerospike-py` (e.g. CRD `apiVersion` bump, `aerospike-py` API rename) triggers a major plugin release; the matrix row above is the contract for what each plugin version targets.
+- **Minor versions warn.** When a skill is scheduled for removal, its frontmatter `description` and the `Deprecated` section of the CHANGELOG mark it as deprecated. The skill continues to work for the rest of the current major version.
+- **Major versions remove.** The next major release removes deprecated skills, agents, and commands. Renames follow the same process: the old name remains deprecated for the current major version and is removed in the next one.
+- **CE feature flags.** A skill that depends on a specific Aerospike CE feature flag, such as an 8.x-only configuration key, states the minimum required CE version in its body. If a future CE release removes that feature, the skill is deprecated in the next minor release and removed in the next major release.
+- **Upstream breaks.** A breaking change in ACKO or `aerospike-py`, such as a CRD `apiVersion` bump or an `aerospike-py` API rename, triggers a major plugin release. Each compatibility-matrix row defines the upstream versions targeted by that plugin release.
 
 ## Releasing
 
-1. Update `.claude-plugin/plugin.json` version.
+1. Update the version in `.claude-plugin/plugin.json`.
 2. Move `Unreleased` entries into a new `X.Y.Z` section in `CHANGELOG.md`.
 3. Add a new row to the compatibility matrix above.
 4. Tag `vX.Y.Z` and push.


### PR DESCRIPTION
## Summary

- rewrite the authored README, versioning policy, and changelog prose in clear, natural English
- split dense authentication, security, compatibility, and deprecation explanations into readable sentences
- preserve skill names, commands, version contracts, benchmark values, headings, code blocks, and link destinations
- leave internal SKILL.md instructions and generated content unchanged

## Validation

- git diff --check
- heading sequence comparison against main
- fenced-code-block comparison against main
- Markdown link destination comparison against main
- claude plugin validate .

Documentation-only change; no skill contract, manifest, command, or version changes.