### PR TITLE
fix(release): sync plugin.json version with released tag

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aerospike-ce-ecosystem",
-  "version": "1.4.1",
+  "version": "1.6.3",
   "description": "Aerospike CE ecosystem tools for Claude Code: deploy, operate, and debug clusters on Kubernetes with the ACKO operator; drive aerospike-cluster-manager via the ackoctl CLI; and build Python apps with aerospike-py (Rust/PyO3 async client). 9 skills spanning deployment, Day-2 operations, debugging, e2e testing, CLI usage, API reference, FastAPI integration, and bug routing.",
   "author": {
     "name": "Aerospike CE Ecosystem",

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -71,6 +71,32 @@ jobs:
           echo "next_version=${NEXT}" >> "$GITHUB_OUTPUT"
           echo "Bumping ${LATEST_TAG} → ${NEXT}"
 
+      # VERSIONING.md step 1: the manifest version is updated before the tag is
+      # created, so the tag points at a commit whose plugin.json already matches.
+      # Pushing before `gh release create --target main` also keeps this commit
+      # inside the new tag, so it does not trigger another release tomorrow.
+      - name: Sync plugin manifest version
+        if: steps.changes.outputs.skip == 'false'
+        run: |
+          # plugin.json records bare semver; git tags carry the 'v' prefix.
+          MANIFEST_VERSION="${{ steps.version.outputs.next_version }}"
+          MANIFEST_VERSION="${MANIFEST_VERSION#v}"
+
+          jq --arg v "$MANIFEST_VERSION" '.version = $v' .claude-plugin/plugin.json > plugin.json.tmp
+          mv plugin.json.tmp .claude-plugin/plugin.json
+
+          if git diff --quiet .claude-plugin/plugin.json; then
+            echo "plugin.json already at ${MANIFEST_VERSION}. Nothing to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json
+          git commit -m "chore(release): sync plugin.json to ${MANIFEST_VERSION}"
+          git push origin HEAD:main
+          echo "plugin.json → ${MANIFEST_VERSION}"
+
       - name: Generate release notes with Claude
         if: steps.changes.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -71,12 +71,19 @@ jobs:
           echo "next_version=${NEXT}" >> "$GITHUB_OUTPUT"
           echo "Bumping ${LATEST_TAG} → ${NEXT}"
 
-      # VERSIONING.md step 1: the manifest version is updated before the tag is
-      # created, so the tag points at a commit whose plugin.json already matches.
-      # Pushing before `gh release create --target main` also keeps this commit
-      # inside the new tag, so it does not trigger another release tomorrow.
+      # Writes VERSIONING.md step 1 (manifest version) before the tag is created,
+      # so the tag points at a commit whose plugin.json already matches. Pushing
+      # before `gh release create --target main` also keeps this commit inside the
+      # new tag, so it does not trigger another release tomorrow.
+      #
+      # This step must never block the release: releasing with a stale manifest is
+      # a cosmetic defect, releasing nothing is an outage. Every failure path here
+      # warns and returns success, and `continue-on-error` covers the unexpected.
+      # The `github.ref` guard keeps a `workflow_dispatch` from a side branch from
+      # fast-forwarding main onto that branch.
       - name: Sync plugin manifest version
-        if: steps.changes.outputs.skip == 'false'
+        if: steps.changes.outputs.skip == 'false' && github.ref == 'refs/heads/main'
+        continue-on-error: true
         run: |
           # plugin.json records bare semver; git tags carry the 'v' prefix.
           MANIFEST_VERSION="${{ steps.version.outputs.next_version }}"
@@ -94,8 +101,21 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .claude-plugin/plugin.json
           git commit -m "chore(release): sync plugin.json to ${MANIFEST_VERSION}"
-          git push origin HEAD:main
-          echo "plugin.json → ${MANIFEST_VERSION}"
+
+          # main may have moved since checkout. Rebase and retry, then give up
+          # rather than fail: the release matters more than the manifest.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              echo "plugin.json → ${MANIFEST_VERSION}"
+              exit 0
+            fi
+            echo "Push rejected on attempt ${attempt}; rebasing onto origin/main."
+            git fetch origin main || break
+            git rebase origin/main || { git rebase --abort || true; break; }
+          done
+
+          echo "::warning::plugin.json not synced to ${MANIFEST_VERSION} (push to main failed). Releasing anyway; the next run retries."
+          exit 0
 
       - name: Generate release notes with Claude
         if: steps.changes.outputs.skip == 'false'


### PR DESCRIPTION
> **This PR is containment, not the resolution.** It stops the manifest from drifting further and makes the drift impossible to ignore. It does **not** fix the release model that caused it — see [Recommended follow-up](#recommended-follow-up), which is a better design than what is implemented here but changes how this project releases, so it belongs to the owner rather than to a review PR.

## Problem

`.claude-plugin/plugin.json:3` declares:

```json
"version": "1.4.1",
```

…while the latest release is **v1.6.3** (2026-07-17), and repo HEAD `92af016` **is** that release commit (`git tag --points-at HEAD` → `v1.6.3`). The manifest is five releases behind the tag it ships on.

This is the version Claude Code reports, so a user installing at v1.6.3 sees `1.4.1` in `claude plugin list`. It is the only version field in the repo (`marketplace.json` has none), so nothing else masks it.

**Root cause:** `.github/workflows/daily-release.yml` computes `next_version` in *Determine next version* and hands it to `gh release create`, but never writes it back to `plugin.json`. Nothing in the pipeline touches the manifest, so every daily release widened the gap. The manifest last matched at 1.4.1.

## Fix

**1. Reconcile the manifest** — `plugin.json` version → `1.6.3`, the version already released at HEAD. No new version, no new tag, no release created.

**2. Write the version during release** — a `Sync plugin manifest version` step in `daily-release.yml`, between *Determine next version* and the release step. It reuses the existing `steps.version.outputs.next_version`, strips the `v`, writes it with `jq`, and commits/pushes before `gh release create`. The job is otherwise unrestructured and no existing step was modified.

Because the commit is pushed **before** the tag is cut, `gh release create --target main` tags a commit that already contains it, so `git rev-list --count "${LATEST_TAG}..HEAD"` is `0` the next day and the sync commit cannot trigger a release of its own.

**The step cannot block a release.** This is the important property, and the first version of this PR got it wrong: it pushed to `main` with no failure handling, ahead of the release step, so a rejected push aborted the job and cut no release — silently, daily, until someone noticed a missing tag. Branch protection would make that permanent; an unrelated merge landing between checkout and push would make it intermittent. A stale version number is cosmetic; a stopped release pipeline is an outage. So:

- Up to 3 attempts, rebasing onto `origin/main` between them, absorbing a concurrent merge instead of aborting.
- Exhausted retries emit a `::warning::` and exit 0 — the release proceeds unsynced, and the next run retries, since it recomputes from the latest tag.
- `continue-on-error: true` catches anything unexpected earlier in the step that `bash -e` would otherwise escalate to a job failure.

It is also guarded on `github.ref == 'refs/heads/main'`. Without that, a `workflow_dispatch` from a side branch would fast-forward `main` onto that branch's tip, carrying every commit on it. This job made no repo writes at all before this step, so that footgun was newly introduced here.

### Relationship to VERSIONING.md

This implements **step 1 only** of `VERSIONING.md` → *Releasing*. To be explicit about what it does not do, that checklist is:

| Step | Status after this PR |
|---|---|
| 1. Update version in `.claude-plugin/plugin.json` | **automated by this PR** |
| 2. Move `Unreleased` entries into a new `X.Y.Z` section in `CHANGELOG.md` | still manual, and drifted |
| 3. Add a row to the compatibility matrix | still manual, and drifted |
| 4. Tag `vX.Y.Z` and push | already automated |

Steps 2 and 3 are drifted from the same root cause as step 1 — the daily release automates tagging but none of the bookkeeping the policy requires around it. Fixing only step 1 leaves that pattern in place.

## Verification

Version facts, as measured:

```
$ gh release list --limit 5
release v1.6.3	Latest	v1.6.3	2026-07-17T13:10:20Z
release v1.6.2		v1.6.2	2026-07-01T23:06:14Z
release v1.6.1		v1.6.1	2026-06-01T23:22:48Z
release v1.6.0		v1.6.0	2026-05-28T23:09:32Z
release v1.5.2		v1.5.2	2026-05-27T23:12:12Z

$ git tag --sort=-v:refname | head -5
v1.6.3
v1.6.2
v1.6.1
v1.6.0
v1.5.2

$ git rev-parse HEAD
92af016573e0787556dcc80e3b27af90c51d8cea
$ git tag --points-at HEAD
v1.6.3
```

Workflow YAML parses, with the guards attached to the new step:

```
YAML parses OK
name: Sync plugin manifest version
if: steps.changes.outputs.skip == 'false' && github.ref == 'refs/heads/main'
continue-on-error: True
total steps: 5
```

### The sync step, executed against real git repositories

The step body was extracted from the workflow and run against a throwaway bare remote plus clones, one scenario per failure mode. All four exit `0`:

**1. Happy path** — pushes and reports:

```
[main 49aa161] chore(release): sync plugin.json to 1.6.4
To ../remote.git   e4d9097..49aa161  HEAD -> main
plugin.json → 1.6.4
>>> STEP EXIT CODE = 0
remote version now:   "version": "1.6.4"
```

**2. `main` moved after checkout** — a concurrent `feat:` merge is pushed by another clone first, so the push is rejected. The step rebases and retries, and *the concurrent commit survives*:

```
! [rejected]        HEAD -> main (fetch first)
Push rejected on attempt 1; rebasing onto origin/main.
Successfully rebased and updated refs/heads/main.
To ../remote.git   abd31c1..4d0202a  HEAD -> main
plugin.json → 1.6.5
>>> STEP EXIT CODE = 0

$ git log --oneline main
4d0202a chore(release): sync plugin.json to 1.6.5
abd31c1 feat: concurrent merge     <- preserved, not clobbered
49aa161 chore(release): sync plugin.json to 1.6.4
```

**3. Branch protection** — a `pre-receive` hook rejects every push, mimicking `GH006: Protected branch update failed`. This is the scenario that would previously have killed the release:

```
$ NEXT_VERSION=v1.7.0 bash step.sh   # fresh clone, protected remote
>>> STEP EXIT CODE = 0   (0 = release still proceeds)
--- push attempts: 3 ---
::warning::plugin.json not synced to 1.7.0 (push to main failed). Releasing anyway; the next run retries.
--- remote untouched:   "version": "1.6.5" ---
```

**4. Manifest already correct** — no empty commit:

```
plugin.json already at 1.6.5. Nothing to commit.
>>> STEP EXIT CODE = 0
commits added: 0
```

`jq`'s output is **byte-for-byte identical** to the file's existing formatting (verified by diffing against a `sed`-substituted copy), so the automated bump is a clean one-line diff with no reformatting noise, and re-running is idempotent.

### What `claude plugin validate` does and does not prove

`claude plugin validate .` passes on this branch, but **that is only evidence the manifest schema is still valid — it does not check the version against anything.** Proof:

```
$ jq '.version = "0.0.1-WRONG"' .claude-plugin/plugin.json   # then validate
Validating marketplace manifest: .../.claude-plugin/marketplace.json

✔ Validation passed
```

It validates `marketplace.json` against its schema and never compares `plugin.json` to a tag. An earlier revision of this PR cited it as if it confirmed the fix; it does not, and no automated check in this repo currently would.

### CHANGELOG discrepancy (reported, not fixed)

`CHANGELOG.md` has 12 released sections, from `## [1.0.0] - 2026-04-30` up to `## [1.4.4] - 2026-05-17`, and then stops. Checking every tag against it:

```
v1.4.4   in CHANGELOG
v1.4.5   MISSING
v1.4.6   MISSING
v1.5.0   MISSING
v1.5.1   MISSING
v1.5.2   MISSING
v1.6.0   MISSING
v1.6.1   MISSING
v1.6.2   MISSING
v1.6.3   MISSING
tags with no CHANGELOG section: 9
```

So the changelog and the tags disagree: **nine released versions have no CHANGELOG section**, and their content appears to still sit under `## [Unreleased]`. The manifest drift starts at 1.4.2 and the changelog drift at 1.4.5, so these are two independent lapses of the same checklist rather than one event. Per review scope I have **not** tried to reconstruct that history — it needs someone who knows which `Unreleased` entries belong to which release. The compatibility matrix in `VERSIONING.md` likewise stops at 1.2.0.

## Recommended follow-up

**Invert the direction: make `plugin.json` the source of truth instead of a write target.** Have *Determine next version* read the version from the manifest and fail if it disagrees with the computed bump, then tag what is already committed.

That is a better design than what this PR implements, for reasons that are structural rather than stylistic:

- The workflow makes **zero repo writes**, so branch protection stops being a consideration at all — no push, no rebase, no retry, none of the machinery above.
- Version bumps arrive through **reviewed PRs**, where a human sees the version change next to the changes it describes, which is also where `CHANGELOG.md` and the compatibility matrix would naturally be updated — so it addresses steps 2 and 3, not just step 1.
- A CI check comparing manifest to latest tag becomes **real enforcement** rather than a consolation prize, because the manifest is then authoritative and a mismatch is a genuine error.

For the record, a CI check *alone* — failing when `plugin.json` ≠ latest tag, with no automation — is safer than the push implemented here but not strictly better: it never fixes drift, and it reds out every unrelated PR until a human bumps by hand.

I have deliberately not implemented the inversion: it changes this project's release model, which is the owner's call.

## Risk

**Merging this obsoletes the `1.6.3` value within hours, by design.** The merge puts `main` past v1.6.3, so tonight's scheduled run computes v1.6.4, rewrites the manifest to `1.6.4`, and tags it. The hand-edited `1.6.3` matters only for the window between merge and that run; the durable part of this PR is the workflow step, not the number.

Low risk for the manifest change: one JSON string, aligning metadata with a release that already exists. It cannot break plugin loading, and it makes the reported version correct for anyone already running v1.6.3.

The workflow change deserves a maintainer's eye, since it introduces the first `git push` from a plain `run:` step in this repo:

- It pushes to `main` from CI. Permitted today (`contents: write`; `gh api …/branches/main/protection` → 404 *Branch not protected*), and it now degrades to a warning rather than a failure if that stops being true — but under branch protection it becomes dead weight that never succeeds, which is the point at which the inversion above should replace it.
- No workflow in this repo triggers on `push`, so the sync commit starts no other job. That is worth preserving; a future `push`-triggered workflow would fire on it.
- `jq` is preinstalled on GitHub-hosted `ubuntu-latest`.
- Untested against a live release run, since triggering one would cut a real tag. The version arithmetic it consumes is unchanged; only the write-back is new, and each of its failure paths is exercised above against real git.

No tracking issue for this exists in the repo (open issues are all `[skill-followup]` items for aerospike-py PRs), so there is nothing to link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
