### PR TITLE
fix(skills): anchor acko-e2e-test paths with ${CLAUDE_PLUGIN_ROOT}

### DIFF
--- a/skills/acko-e2e-test/SKILL.md
+++ b/skills/acko-e2e-test/SKILL.md
@@ -20,7 +20,7 @@ The skill is opinionated about three things:
 Needs: `uv`, `kind`, `podman`, `kubectl`, `helm`, `go`, `jq` plus a local clone of `aerospike-ce-kubernetes-operator`. One-shot installer:
 
 ```bash
-cd skills/acko-e2e-test/e2e_pytest
+cd "${CLAUDE_PLUGIN_ROOT}/skills/acko-e2e-test/e2e_pytest"
 bash scripts/bootstrap.sh                 # install everything missing (apt or brew)
 bash scripts/bootstrap.sh --check         # status only — install nothing
 bash scripts/bootstrap.sh --no-operator   # don't auto-clone the operator repo
@@ -31,7 +31,7 @@ The operator repo is discovered automatically — `helpers/env.py` tries (in ord
 ## How to run
 
 ```bash
-cd skills/acko-e2e-test/e2e_pytest
+cd "${CLAUDE_PLUGIN_ROOT}/skills/acko-e2e-test/e2e_pytest"
 uv sync                          # one-time: pull pytest + httpx + pyyaml + tenacity
 
 uv run pytest -m chart           # fast gate — chart-template only, no Kind (~5s)

--- a/skills/acko-e2e-test/reference/quick-commands.md
+++ b/skills/acko-e2e-test/reference/quick-commands.md
@@ -2,6 +2,8 @@
 
 Reference snippets for the scenarios listed in `SKILL.md`. Pull these in only when actually running the corresponding check; they're separated to keep the SKILL frontmatter scannable.
 
+**Working directory:** unless a block says otherwise, these run from the root of a local **`aerospike-ce-kubernetes-operator`** clone — that is what `./charts/…`, `./test/e2e/`, and the `make` targets resolve against. This is a different directory from the plugin's own bundled `e2e_pytest` project, which `SKILL.md` enters via `${CLAUDE_PLUGIN_ROOT}`. See `SKILL.md` for how the operator clone is discovered (`$OPERATOR_REPO` and fallbacks).
+
 ## Kind cluster lifecycle
 
 ```bash


### PR DESCRIPTION
## Problem

Both command blocks in `acko-e2e-test/SKILL.md` — `:23` and `:34` — start with a path relative to the user's own working directory:

```bash
cd skills/acko-e2e-test/e2e_pytest
```

Installed, the skill lives under the plugin cache, e.g.
`~/.claude/plugins/cache/aerospike-ce-ecosystem/aerospike-ce-ecosystem/<version>/skills/acko-e2e-test/e2e_pytest`,
while the user's cwd is their own project. The relative path resolves to nothing, so **every command the skill offers** fails with `cd: no such file or directory` — the `bootstrap.sh` block, `uv sync`, and all five `pytest` run lanes (`chart`, `smoke`, `smoke or full`, `heavy`).

The skill worked only for someone who had cloned this repo and happened to be at its root. That is not the install path this repo's own README documents (`claude plugin install aerospike-ce-ecosystem`), so the skill was inert for its actual audience.

The mechanism for this already exists and this repo used it nowhere:

```
$ grep -rn CLAUDE_PLUGIN_ROOT . --exclude-dir=.git    # before this PR
(0 hits)
```

## Fix

Anchored both blocks with `${CLAUDE_PLUGIN_ROOT}`:

```bash
cd "${CLAUDE_PLUGIN_ROOT}/skills/acko-e2e-test/e2e_pytest"
```

**On matching the existing convention rather than inventing one:** this repo had no prior usage to copy, so I took the form from the official marketplace, which quotes it the same way — `claude-plugins-official/plugins/claude-security/skills/claude-security/SKILL.md:21-23` (`Bash(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/render_report.py" *)`), and `plugin-dev` documents `${CLAUDE_PLUGIN_ROOT}` as *the* portable-path variable (`plugin-dev/README.md:66`, `commands/create-plugin.md:231`). Double-quoted, braced, full path from the plugin root.

While sweeping for the same pattern I found `reference/quick-commands.md` uses `./charts/…`, `./test/e2e/`, `cd charts/aerospike-ce-kubernetes-operator`, and `make` targets. Those are the same *shape* of bug but a different anchor: they resolve against an **operator-repo clone**, not the plugin, which is legitimate for that section. **I deliberately did not rewrite them** to `${OPERATOR_REPO}` — that would be a larger, more opinionated change than this fix, and `$OPERATOR_REPO` is only one of six discovery fallbacks `helpers/env.py` tries, so hardcoding it could break the workspace-sibling layout. Instead I documented the assumption at the top of the file, so the operator-clone directory is not confused with the plugin's own bundled `e2e_pytest`.

## Verification

No plugin-relative `cd` remains, and the two blocks now resolve from the plugin root:

```
$ grep -rn 'cd skills/' skills/ | wc -l
0
$ grep -rn 'CLAUDE_PLUGIN_ROOT' skills/
skills/acko-e2e-test/SKILL.md:23:cd "${CLAUDE_PLUGIN_ROOT}/skills/acko-e2e-test/e2e_pytest"
skills/acko-e2e-test/SKILL.md:34:cd "${CLAUDE_PLUGIN_ROOT}/skills/acko-e2e-test/e2e_pytest"
skills/acko-e2e-test/reference/quick-commands.md:5:**Working directory:** ... which `SKILL.md` enters via `${CLAUDE_PLUGIN_ROOT}`. ...
```

The target directory exists at the path the new command builds:

```
$ ls skills/acko-e2e-test/e2e_pytest
helpers  pyproject.toml  pytest.ini  scripts  tests  uv.lock
```

Plugin validation:

```
$ claude plugin validate .
Validating marketplace manifest: .../.claude-plugin/marketplace.json

✔ Validation passed
```

**Not verified:** I did not execute the test suite end-to-end from an installed plugin cache — that needs Kind, podman, an operator clone, and ~10 minutes per lane, which is beyond what I can stand up here. The path fix is verified structurally (the directory exists at `${CLAUDE_PLUGIN_ROOT}/skills/acko-e2e-test/e2e_pytest`) rather than by a full run.

## Risk

Low. Two `cd` lines and one added paragraph, no executable plugin code. `${CLAUDE_PLUGIN_ROOT}` is substituted by the harness at invocation; if it were ever unset the `cd` would fail loudly at `/skills/...` rather than silently landing somewhere wrong, which is still an improvement over today's behaviour.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)
