### PR TITLE
fix(skills): correct webhook rules the webhook never implemented and four policy defaults

### DIFF
--- a/skills/acko-config-reference/reference/crd-mapping.md
+++ b/skills/acko-config-reference/reference/crd-mapping.md
@@ -8,7 +8,12 @@ The operator converts CRD YAML fields to aerospike.conf syntax automatically.
 | `logging: [{ name: /path }]` | `logging { file /path { ... } }` |
 | `storage-engine: { type: memory, data-size: N }` | `storage-engine memory { data-size N }` |
 | `storage-engine: { type: device, file: ... }` | `storage-engine device { file ... }` |
-| `security: {}` | `security { }` |
+| `security: {}` | *(nothing — not rendered)* |
+
+**`security` is dropped, not rendered.** `generateConfig` hits `case SectionSecurity: continue`
+(`internal/configgen/generator.go:59-60`) and emits nothing, so no `security` stanza reaches
+`aerospike.conf` however the key is written. CE has no security feature to configure, and the
+webhook separately rejects the Enterprise `security` sub-keys (`tls`/`ldap`/`log`/`syslog`).
 
 **Key rule**: Size values in `aerospikeConfig` are always integer bytes. The operator passes them directly to the generated config file.
 

--- a/skills/acko-config-reference/reference/parameters-8.md
+++ b/skills/acko-config-reference/reference/parameters-8.md
@@ -4,12 +4,12 @@
 
 | Parameter | Default | Dynamic | Notes |
 |-----------|---------|---------|-------|
-| `max-record-size` | **1M** | Yes | 7.1+ new default. Max 8M |
+| `max-record-size` | **1M** | No | 7.1+ new default. Max 8M. Absent from the operator's dynamic allowlist — editing it cold-restarts the pods |
 | `flush-size` | **1M** | No | 7.1+ replaces write-block-size. NVMe: 128K recommended |
 | `data-size` | - | No | 7.0+ replaces memory-size. Specified inside storage-engine block |
 | `stop-writes-sys-memory-pct` | **90** | Yes | 7.0+ replaces stop-writes-pct |
-| `evict-used-pct` | **70** | Yes | Device storage utilization eviction threshold |
-| `evict-tenths-pct` | **5** | Yes | Eviction rate per cycle (0.5%) |
+| `evict-used-pct` | **70** | No | Device storage utilization eviction threshold. Absent from the operator's dynamic allowlist — editing it cold-restarts the pods |
+| `evict-tenths-pct` | **5** | No | Eviction rate per cycle (0.5%). Absent from the operator's dynamic allowlist — editing it cold-restarts the pods |
 | `cluster-name` | (none) | No | **8.0+ strongly recommended**; prevents unintended cluster joins |
 | `nsup-period` | **0** | Yes | If 0 and default-ttl != 0, **server fails to start** |
 

--- a/skills/acko-config-reference/reference/webhook-validation.md
+++ b/skills/acko-config-reference/reference/webhook-validation.md
@@ -9,7 +9,15 @@ The ACKO webhook rejects CRs that violate these constraints:
 - `size > 8` -> rejected
 - `namespaces > 2` -> rejected; duplicate namespace name -> rejected
 - Image contains `enterprise`/`ee-`/`ent-` or references `aerospike-server-enterprise` -> rejected; CE image major `< 8` (incl. dotless `ce-7`/`7`) -> rejected
-- `xdr` or `tls` section present -> rejected
+- `xdr` section present -> rejected
+- **TLS, at every place it can be written** -> rejected (ACKO #349). All three layers — cluster webhook, template webhook, and merged-template resolver — check:
+  - top-level `aerospikeConfig.tls`
+  - `aerospikeConfig.network.tls` — the certificate/key stanza; **presence of the key is enough**, the value shape is irrelevant
+  - any `tls-*` key under `network.service`, `network.heartbeat`, `network.fabric` (`tls-port`, `tls-name`, `tls-authenticate-client`, …) — matched by prefix, which is safe because no CE config key starts with `tls-`
+
+  The nested forms matter more than the top-level one, because `network { tls <name> {...} }` plus `tls-port`/`tls-name` on the endpoints is exactly what the Aerospike docs tell a user to write. Before #349 only the top-level key was checked, so that config was **admitted**, configgen passed it through verbatim, and the CE `asd` process refused to start — a permanent CrashLoopBackOff with no admission error naming the Enterprise feature. On a live cluster it was worse: the edit bumps the config hash, so the rolling restart walks every pod into the crash loop one batch at a time.
+
+  Same coverage on **update**, not just create, and via per-rack `aerospikeConfig` and `spec.overrides.aerospikeConfig`. Messages name the full key path, e.g. `"aerospikeConfig.network must not contain 'tls' section (TLS is Enterprise-only)"` and `"aerospikeConfig.network.heartbeat.tls-port is not allowed in CE edition (TLS is Enterprise-only)"`.
 - Enterprise `security` keys (`tls`/`ldap`/`log`/`syslog`) or logging contexts (`audit`/`report-*`) -> rejected
 - Admin user missing `sys-admin` + `user-admin` -> rejected
 - Admin privilege (`sys-admin`/`user-admin`/`data-admin`) with a `.namespace`/`.set` scope, or a malformed scope -> rejected

--- a/skills/acko-deploy/reference/cr-spec-fields.md
+++ b/skills/acko-deploy/reference/cr-spec-fields.md
@@ -12,7 +12,7 @@ Complete field reference for the AerospikeCluster Custom Resource.
 | `spec.image` | string | Yes | Aerospike CE container image (e.g., `aerospike:ce-8.1.1.1`) |
 | `spec.paused` | bool | No | Set `true` to pause all reconciliation |
 | `spec.enableDynamicConfigUpdate` | bool | No | Apply config changes without pod restart |
-| `spec.rollingUpdateBatchSize` | int/string | No | Pods to restart per batch (default: 1, or "25%") |
+| `spec.rollingUpdateBatchSize` | int | No | Pods to restart per batch (default: 1). Integer only — `*int32` with `Minimum=1`; percentages are accepted only at `rackConfig.rollingUpdateBatchSize` |
 | `spec.disablePDB` | bool | No | Set `true` to skip PodDisruptionBudget creation |
 | `spec.maxUnavailable` | int/string | No | PDB maxUnavailable value (default: 1) |
 | `spec.templateRef.name` | string | No | Reference an AerospikeClusterTemplate (immutable after creation) |

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -25,7 +25,7 @@ kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"size":5}}'
 kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"image":"aerospike:ce-8.1.1.1"}}'
 ```
 
-`RollingRestart` → `Completed`. Batch control: `spec.rollingUpdateBatchSize` (int or `"25%"`), per-rack override `rackConfig.rollingUpdateBatchSize`. Besides image/static config, editing `spec.podService` or `spec.aerospikeNetworkPolicy` also rolls pods (pod-spec hash).
+`RollingRestart` → `Completed`. Batch control: `spec.rollingUpdateBatchSize` (**integer only** — `*int32`, min 1; a percentage string is rejected by the API server), per-rack override `rackConfig.rollingUpdateBatchSize` (`IntOrString` — integer **or** percentage like `"50%"`). Besides image/static config, editing `spec.podService` or `spec.aerospikeNetworkPolicy` also rolls pods (pod-spec hash).
 
 ## 3. Dynamic Config Update — 2-Phase Commit (ops ref §2)
 
@@ -48,7 +48,7 @@ spec:
       # podList: ["<cluster>-0-0"]   # optional: specific pods
 ```
 
-Webhook-enforced: `kind` ∈ {`WarmRestart`, `PodRestart`}; one operation at a time; the list (incl. `podList`) cannot change while one is `InProgress` (`"cannot change operations while operation \"ID\" is InProgress"`). Controller: op ends `phase=Error` on unknown kind / nonexistent pod; batches gate on the readiness/migration guard and honor `rackConfig.rollingUpdateBatchSize`. Check `status.operationStatus`; clean up (or unstick — §10) with:
+`kind` ∈ {`WarmRestart`, `PodRestart`} is enforced by the CRD enum (API server), not the webhook. Webhook-enforced: one operation at a time; the list (incl. `podList`) cannot change while one is `InProgress` (`"cannot change operations while operation \"ID\" is InProgress"`). Controller: op ends `phase=Error` on unknown kind / nonexistent pod; batches gate on the readiness/migration guard and honor `rackConfig.rollingUpdateBatchSize`. Check `status.operationStatus`; clean up (or unstick — §10) with:
 
 ```bash
 kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"operations":null}}'

--- a/skills/acko-operations/reference/operations.md
+++ b/skills/acko-operations/reference/operations.md
@@ -123,9 +123,9 @@ status:
 
 ```yaml
 spec:
-  rollingUpdateBatchSize: 1             # Global (integer or "25%")
+  rollingUpdateBatchSize: 1             # Global — INTEGER ONLY (*int32, min 1)
   rackConfig:
-    rollingUpdateBatchSize: "50%"       # Per-rack override
+    rollingUpdateBatchSize: "50%"       # Per-rack override — integer OR percentage
 ```
 
 ### What triggers a rolling (cold) restart

--- a/skills/acko-operations/reference/validation-rules.md
+++ b/skills/acko-operations/reference/validation-rules.md
@@ -2,6 +2,14 @@
 
 Canonical catalog of ACKO webhook validation errors and non-blocking warnings. The exact count grows over releases — this page is the source of truth; `acko-config-reference/reference/webhook-validation.md` is a shape-and-constraints summary that links here.
 
+**How these strings reach the user.** The webhook collects every failure and returns them joined by `; `, wrapped once:
+
+```
+validation failed: <error>; <error>; …
+```
+
+(`aerospikecluster_webhook.go:643`; the template webhook uses `template validation failed: …`, `aerospikeclustertemplate_webhook.go:197`.) So the strings below are **substrings** of what `kubectl apply` prints, never the whole message — match on a fragment, not on equality. Placeholders shown as `N`, `T`, `"..."` are Go format verbs (`%d`, `%T`, `%q`) filled in at rejection time.
+
 ---
 
 ## Validation Errors (CR Rejected)
@@ -11,7 +19,7 @@ Canonical catalog of ACKO webhook validation errors and non-blocking warnings. T
 | Rule | Error Message |
 |------|--------------|
 | `spec.size > 8` | `"spec.size N exceeds CE maximum of 8"` |
-| `spec.size == 0` + no templateRef | `"spec.size must be set (1-8) when spec.templateRef is not specified"` |
+| `spec.size == 0` + no templateRef | `"spec.size must be set (1–8) when spec.templateRef is not specified"` |
 | `spec.image` empty + no templateRef | `"spec.image must not be empty when spec.templateRef is not specified"` |
 | Image references the enterprise repo | `"spec.image \"...\" references the enterprise repository (aerospike-server-enterprise); CE clusters must use a CE image such as aerospike:ce-8.1.1.1"` |
 | Image contains `enterprise`/`ee-`/`ent-` | `"spec.image \"...\" is an Enterprise Edition image; only Community Edition images are allowed"` |
@@ -32,10 +40,11 @@ Image tag parsing (#321) uses the last colon after the final `/` and strips `@sh
 | `logging` not a list | `"aerospikeConfig.logging must be a list"` |
 | `namespaces` a scalar (string/int/bool) | `"aerospikeConfig.namespaces must be a list of namespace maps (e.g. [{name: foo, ...}]), got T"` |
 | `namespaces` a map (keyed by name) | `"aerospikeConfig.namespaces must be a list of namespace maps ..., got map with N entries; per-namespace validation cannot run on the map form"` |
-| namespace entry not a map with `name` | `"aerospikeConfig.namespaces[N] must be a map with required key 'name'"` |
+| namespace entry not a map | `"aerospikeConfig.namespaces[N] must be a map, got T"` |
+| namespace entry missing `name` | `"aerospikeConfig.namespaces[N] is missing required 'name' key"` |
 | Duplicate namespace name | `"aerospikeConfig.namespaces[N]: duplicate namespace name \"name\"; each namespace must have a unique name"` |
 | Rack ID add+remove in single update (also fires when `rackConfig` is dropped entirely → implicit rack 0) | `"cannot add new rack IDs [...] and remove existing rack IDs [...] in the same update; please do this in two separate steps"` — when the implicit default rack (ID 0) is involved, the message instead explains that switching between the default rack and explicit racks recreates StatefulSets and risks data loss |
-| `MetricLabels` value contains control chars | `"monitoring.metricLabels[\"key\"]: control characters are not permitted in TOML output"` |
+| `MetricLabels` value contains control chars | `"monitoring.metricLabels[\"key\"] value must not contain control characters"` |
 
 ### Network Ports (fixed by the operator)
 
@@ -111,16 +120,16 @@ Privilege format: `"<code>"` / `"<code>.<namespace>"` / `"<code>.<namespace>.<se
 
 | Rule | Error Message |
 |------|--------------|
-| Rack ID <= 0 | `"rack ID must be > 0 (rack ID 0 is reserved)"` |
+| Rack ID <= 0 | `"rack ID must be > 0, got N (rack ID 0 is reserved for the default rack)"` |
 | Duplicate Rack ID | `"duplicate rack ID N"` |
 | Duplicate rackLabel | `"duplicate rackLabel \"label\""` |
-| Duplicate nodeName | `"racks[N] and racks[M] both constrained to node \"name\""` |
-| Invalid IntOrString | `"rackConfig.scaleDownBatchSize must be a positive integer or percentage"` |
-| Rack ID changed on update | `"rackConfig rack IDs cannot be changed"` |
+| Invalid IntOrString | `"rackConfig.scaleDownBatchSize must be a positive integer or a percentage string (e.g., \"25%\"); got \"...\""` |
 | More racks than `spec.size` | `"rackConfig defines N racks but spec.size is M; each rack must get at least 1 pod, so the rack count must not exceed spec.size"` (skipped when size deferred to templateRef) |
 | Per-rack `aerospikeConfig` override violates a CE constraint | `"rackConfig.racks[id=N].aerospikeConfig: <inner CE error>"` |
 
 A rack's `aerospikeConfig` is DeepMerged into the effective config, so it is validated against the **same** CE constraints as cluster-level config (xdr/tls/security keys, >2 namespaces, mesh-only heartbeat). Prevents a CE bypass via per-rack override.
+
+**Rack IDs are mutable.** `ValidateUpdate` blocks only *simultaneous* add-and-remove in one update (the row above); the source comment is explicit that "Pure additions or pure removals are fine" (`aerospikecluster_webhook.go:308-309`), and both error returns fire only when the added and removed sets are **both** non-empty. Adding a rack, or removing one, in a single update is legal — do not refuse it. `Rack.NodeName` is not validated at all: `validateRackConfig` checks rack ID, duplicate rack ID, duplicate `rackLabel`, per-rack `aerospikeConfig`, and the three batch-size fields, and never inspects `nodeName`.
 
 ### PodSpec Container Names
 
@@ -151,8 +160,8 @@ A rack's `aerospikeConfig` is DeepMerged into the effective config, so it is val
 | Port out of range | `"monitoring.port must be in range 1-65535"` |
 | Port conflicts with 3000-3003 | `"monitoring.port N conflicts with Aerospike service port"` |
 | exporterImage empty when enabled | `"monitoring.exporterImage must not be empty when monitoring is enabled"` |
-| metricLabels contain `=` or `,` | `"monitoring.metricLabels key/value must not contain '=' or ','"` |
-| customRules missing name/rules | `"customRules[N]: missing required field 'name'/'rules'"` |
+| metricLabels key outside `^[A-Za-z0-9_-]+$` | `"monitoring.metricLabels key \"k\" must contain only ASCII letters, digits, dashes, and underscores"` |
+| customRules missing `name` or `rules` | `"monitoring.prometheusRule.customRules[N]: missing required field 'name'"` / `"... missing required field 'rules'"` |
 | customRules `name` not a string / empty | `"monitoring.prometheusRule.customRules[N]: field 'name' must be a string, got T"` / `"... must not be empty"` |
 | customRules `rules` not a JSON array / empty array | `"monitoring.prometheusRule.customRules[N]: field 'rules' must be a JSON array, got T"` / `"... must contain at least one rule"` |
 | `serviceMonitor.interval` not a Prometheus duration (e.g. `"5 seconds"`) | `"monitoring.serviceMonitor.interval \"...\" is not a valid Prometheus duration ..."` |
@@ -173,8 +182,8 @@ These are validated because the reconciler copies them verbatim onto the Service
 | Rule | Error Message |
 |------|--------------|
 | More than 1 operation | `"only one operation can be specified at a time"` |
-| ID length outside 1-20 chars | `"operation id must be 1-20 characters"` |
-| Invalid `kind` | `"operation kind must be one of: WarmRestart, PodRestart"` |
+| ID length outside 1-20 chars | `"operation id \"ID\" must be 1-20 characters"` |
+| Invalid `kind` | *(not a webhook message)* — `OperationKind` carries `+kubebuilder:validation:Enum=WarmRestart;PodRestart`, so the **API server** rejects it: `Unsupported value: "X": supported values: "WarmRestart", "PodRestart"`. The controller's `"unsupported operation kind \"X\""` is a reconcile-time message, not admission. |
 | Change during InProgress (incl. changing `podList`) | `"cannot change operations while operation \"ID\" is InProgress"` |
 
 ### Template / Overrides Validation

--- a/skills/aerospike-py-api/reference/client-config.md
+++ b/skills/aerospike-py-api/reference/client-config.md
@@ -19,8 +19,8 @@ Import from `aerospike_py.types`. Used by `aerospike.client(config)` and `AsyncC
 | user | str | None | Username for authentication |
 | password | str | None | Password for authentication |
 | timeout | int | 30000 | Connection timeout (ms) |
-| idle_timeout | int | 55000 | Idle connection timeout (ms) |
-| max_conns_per_node | int | 300 | Max connections per node |
+| idle_timeout | int | 30000 | Idle connection timeout (ms) |
+| max_conns_per_node | int | 256 | Max connections per node |
 | min_conns_per_node | int | 0 | Min connections per node (pre-warm) |
 | conn_pools_per_node | int | 1 | Connection pools per node |
 | tend_interval | int | 1000 | Cluster tend interval (ms) |

--- a/skills/aerospike-py-api/reference/policies.md
+++ b/skills/aerospike-py-api/reference/policies.md
@@ -99,7 +99,7 @@ Used by: `Query.results()`, `Query.foreach()`
 |-----|------|---------|-------------|
 | socket_timeout | int | 30000 | Socket timeout (ms) |
 | total_timeout | int | 0 | Total timeout (0 = no limit) |
-| max_retries | int | 2 | Max retry attempts |
+| max_retries | int | 5 | Max retry attempts |
 | sleep_between_retries | int | 0 | Sleep between retries (ms) |
 | max_records | int | 0 | Max records to return (0 = all) |
 | records_per_second | int | 0 | Rate limit (0 = unlimited) |
@@ -117,7 +117,7 @@ Used by: all `admin_*` methods, index operations, `truncate()`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| timeout | int | 1000 | Admin operation timeout (ms) |
+| timeout | int | 0 | Admin operation timeout (ms). `0` means "unset" and the client substitutes **3000 ms** — `AdminPolicy` derives `Default` on a bare `u32`, and `AdminPolicy::timeout()` returns `3_000` when the field is `0`. |
 
 ---
 


### PR DESCRIPTION
## Problem

Both drift clusters in #96, plus the `network.tls` documentation gap opened by ACKO #349. Everything below was re-verified against **operator `origin/main` (7cc48da)** and **aerospike-py `origin/main` (5db458d)** rather than the versions the original audit ran on — which turned out to matter (see the last section).

### Cluster 1 — webhook rules the webhook does not implement

| # | Claim | Source reality |
|---|---|---|
| a | `validation-rules.md` "Rack IDs cannot be changed" | **Rack IDs are mutable.** `ValidateUpdate` blocks only *simultaneous* add-and-remove; both error returns require added **and** removed to be non-empty, and the comment at `aerospikecluster_webhook.go:308-309` reads "Pure additions or pure removals are fine." |
| b | Duplicate `nodeName` rejection | `Rack.NodeName` is never inspected. `validateRackConfig` checks rack ID, duplicate rack ID, duplicate `rackLabel`, per-rack `aerospikeConfig`, and three batch-size fields — nothing else. |
| c | metricLabels reject `=` and `,` | Backwards. `webhook.go:1966-1967`: "'=' and ',' are safe inside values; only control characters are rejected." The real constraint is a key charset, `tomlBareKeyRe = ^[A-Za-z0-9_-]+$` (`webhook.go:44`), which the catalog did not document at all. |
| d | `crd-mapping.md` `security: {}` → `security { }` | `generateConfig` hits `case SectionSecurity: continue` (`internal/configgen/generator.go:59-60`) and emits nothing. |
| e | `evict-used-pct`, `evict-tenths-pct`, `max-record-size` documented `Dynamic=Yes` | All three absent from `internal/configdiff/dynamic_params.go` → they cold-restart. |
| f | `spec.rollingUpdateBatchSize` accepts `"25%"` | Top-level is `*int32` with `Minimum=1` (`aerospikecluster_types.go:265`) — rejected by the API server before the webhook runs. Percentages are valid only at `rackConfig.rollingUpdateBatchSize`, which is `*intstr.IntOrString` (`types_rack.go`). |

(a) is the costly direction: Claude would refuse a legal operation and tell the user to rebuild a cluster and migrate data. (e) is the dangerous one: promising a dynamic update that actually cold-restarts production.

### Cluster 2 — policy defaults

`rust/Cargo.toml:31` still pins `aerospike-core = "2.0.0"`, and only `WritePolicy` has a custom default builder in aerospike-py; every other policy takes `::default()` unchanged.

| Site | Documented | Actual | Source |
|---|---|---|---|
| `policies.md` QueryPolicy `max_retries` | 2 | **5** | `query_policy.rs:97` |
| `client-config.md` `idle_timeout` | 55000 | **30000** | `client_policy.rs:195` |
| `client-config.md` `max_conns_per_node` | 300 | **256** | `client_policy.rs:197` |
| `policies.md` AdminPolicy `timeout` | 1000 | **0** raw / **3000** effective | `admin_policy.rs:19,24-28` |

## Fix

Deleted (a) and (b); corrected (c)–(f). Regenerated the quoted error strings — **11** were not substrings of the real messages — and documented that every message arrives wrapped as `validation failed: <e>; <e>` (`webhook.go:643`), so they must be matched as fragments rather than compared for equality.

Fixed one attribution while there: operation `kind` is enforced by the **CRD enum** (`+kubebuilder:validation:Enum=WarmRestart;PodRestart` on `OperationKind`), not by a webhook message. The `unsupported operation kind` string lives in `reconciler_operations.go:156` and fires at reconcile time.

**ACKO #349 — nested TLS.** `webhook-validation.md:12` documented TLS rejection at the top level only. All three layers now also reject `network.tls` and `tls-*` keys under `network.{service,heartbeat,fabric}`, on update as well as create, and via per-rack config and `spec.overrides`. The nested forms are the ones that matter: `network { tls <name> {...} }` with `tls-port`/`tls-name` is exactly what the Aerospike docs tell users to write, and before #349 it was **admitted**, passed through configgen verbatim, and left CE `asd` in a permanent CrashLoopBackOff that the rolling restart walked across every pod.

## Verification

Stale claims, all gone:

```
$ for s in 'rack IDs cannot be changed' 'both constrained to node' \
           "must not contain '=' or ','" 'control characters are not permitted in TOML' \
           'operation kind must be one of'; do printf "  %-46s " "$s"; \
     echo "$(grep -rF "$s" skills/ | wc -l) hits"; done
  rack IDs cannot be changed                     0 hits
  both constrained to node                       0 hits
  must not contain '=' or ','                    0 hits
  control characters are not permitted in TOML   0 hits
  operation kind must be one of                  0 hits
```

The en-dash fix is real (`e2 80 93` = U+2013, where the doc previously had ASCII `2d`):

```
$ sed -n '22p' skills/acko-operations/reference/validation-rules.md | grep -o '(1.8)' | hexdump -C
00000000  28 31 e2 80 93 38 29 0a                           |(1...8).|
```

Every row of the `parameters-8.md` table audited against the allowlist, not just the three flagged:

```
  max-record-size              absent      -> Dynamic=No
  flush-size                   absent      -> Dynamic=No
  data-size                    absent      -> Dynamic=No
  stop-writes-sys-memory-pct   in allowlist -> Dynamic=Yes
  evict-used-pct               absent      -> Dynamic=No
  evict-tenths-pct             absent      -> Dynamic=No
  cluster-name                 absent      -> Dynamic=No
  nsup-period                  in allowlist -> Dynamic=Yes
```

I wrote a checker that extracts every quoted message from `validation-rules.md` and diffs its literal fragments against all Go string literals in the operator. It went **29 → 19** flags. I then confirmed **all 19 remaining are false positives**, by hand: Go messages assembled with `+` across source lines (so no single literal matches — e.g. `spec.image %q references the enterprise repository ` + `(aerospike-server-enterprise); CE clusters must use...`), and index placeholders the splitter cannot know about (`sidecars[i]`, `network.S.port`, `.KEY`). I verified the concatenated forms individually, including `storage.volumes[%d] %q: sidecars[%d] containerName %q duplicates sidecars[%d]`, which does exist.

```
$ claude plugin validate .
✔ Validation passed
```

**Not verified:** no live cluster, so none of these rejections were exercised against a running API server. Every claim is read from source at the pinned commits above.

## Risk

Low — documentation only, no executable plugin code. The behavioural change is that Claude will now permit rack-ID changes it previously refused, and will warn that three parameters cold-restart. Both match the source.

The `parameters-8.md` `Dynamic` column is worth a reviewer's eye: I read it as "will ACKO apply this dynamically", which is how the file frames itself ("When `enableDynamicConfigUpdate: true` is set in the CR, the operator uses these commands internally"). The server-side `asinfo set-config` block further down still shows `max-record-size` being set live, which remains true at the server level — the new notes say "absent from the operator's dynamic allowlist" to keep that distinction explicit rather than implying the server cannot do it.

## Two audit claims deliberately NOT changed

Both recorded in #96, and `origin/main` now settles them:

1. **WritePolicy `max_retries` stays `0`.** PR **#431** landed on main (`5db458d`, merged 2026-08-17T12:39Z — *after* #96 was filed) and makes `0` the actual write default. The existing text is now correct; patching it to `2` would have introduced the bug.
2. **`auth_mode` stays `AUTH_INTERNAL (0)`.** Core `ClientPolicy::default()` is `AuthMode::None`, but aerospike-py only touches `auth_mode` when a user is supplied, and then falls back to `AuthMode::Internal` (`rust/src/policy/client_policy.rs:54-55`). The core default is not the user-visible one.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
