### PR TITLE
feat(ci): verify skill claims against pinned source checkouts

### DIFF
--- a/.github/workflows/verify-claims.yml
+++ b/.github/workflows/verify-claims.yml
@@ -1,0 +1,90 @@
+name: Verify skill claims
+
+# Checks factual claims in skills/ against pinned checkouts of the source repos.
+#
+# This is the enforcement half of goal 4-1 ("keep skills current"). Before it
+# existed nothing scored the skills, which is how a drift audit came to find 128
+# wrong claims — including ~20 commands that exit 0 and print nothing, so the
+# failure was invisible to both Claude and the user.
+#
+# Scope is deliberately narrow and honest: see `scripts/verify_skill_claims.py
+# --coverage`, which is printed in the job summary on every run.
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/verify_skill_claims.py'
+      - 'scripts/sources.lock'
+      - 'scripts/fetch_sources.sh'
+      - '.github/workflows/verify-claims.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+      - 'scripts/**'
+  # Sources are pinned, so a scheduled run cannot surface upstream drift by
+  # itself — it guards against bit-rot in the checker (a source layout change
+  # that makes an extractor silently stop matching is reported as SKIPPED).
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-claims-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout plugin repo
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # The checker uses only the standard library, so there is nothing to install.
+
+      - name: Cache pinned source checkouts
+        uses: actions/cache@v4
+        with:
+          path: .source-cache
+          # Keyed on the lock file: a SHA bump invalidates the cache, and
+          # nothing else needs to.
+          key: sources-${{ hashFiles('scripts/sources.lock') }}
+
+      - name: Fetch pinned sources
+        run: ./scripts/fetch_sources.sh .source-cache
+
+      - name: Verify claims
+        id: verify
+        run: |
+          python3 scripts/verify_skill_claims.py \
+            --sources .source-cache \
+            --format github | tee /tmp/verify.txt
+          exit "${PIPESTATUS[0]}"
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo '## Skill claim verification'
+            echo
+            echo '```'
+            sed 's/^::error [^:]*:://' /tmp/verify.txt 2>/dev/null || echo 'checker did not produce output'
+            echo '```'
+            echo
+            echo '<details><summary>What this does and does not check</summary>'
+            echo
+            echo '```'
+            python3 scripts/verify_skill_claims.py --coverage
+            echo '```'
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 ## [Unreleased]
 
+### Added
+
+- `scripts/verify_skill_claims.py` plus the `Verify skill claims` workflow — a CI gate that checks factual claims in `skills/` against **pinned** checkouts of the operator, `ackoctl`, `aerospike-py`, and cluster-manager (SHAs in `scripts/sources.lock`). It verifies 314 claims across eight categories that each resolve to a closed set in source: label selectors, condition types, phase names, event reasons, CRD field names, `ackoctl` flags, `aerospike-py` constants, and cluster-manager routes. These are deliberately the categories where a wrong claim fails *silently* — a bad label selector or condition type exits 0 and prints nothing, so nobody ever sees an error. Coverage is roughly a fifth of the ~1,770 claims the drift audit examined; `--coverage` prints exactly what is and is not checked, and the CI job publishes it in the run summary. Webhook error strings were tried and deliberately excluded: Go assembles them from format verbs and concatenated literals, so 19 of 29 reports were false, and a noisy check gets disabled rather than fixed.
+
+### Fixed
+
+- Five event reasons in `acko-operations/reference/events.md` that the operator never emits: `DynamicConfigValidationFailed`, `DynamicConfigRollbackTriggered`, `DynamicConfigRollbackFailed`, `ClusterPaused`, and `ClusterResumed`. The real reasons are `DynamicConfigApplied`, `DynamicConfigRollback`, `DynamicConfigStatusFailed`, `ReconciliationPaused`, and `ReconciliationResumed` (`internal/controller/events.go`); phase-1 validation failure emits no event at all and is only logged, which the page now states.
+- `status.operation.*` → `status.operationStatus.*` in `acko-deploy/reference/cr-spec-fields.md` (3 sites). The CRD field is `operationStatus` (`aerospikecluster_types.go:441`), so the documented jsonpath returned nothing.
+
 ### Changed
 
 - The `aerospike-py-api` skill now documents the `.result_code: int` attribute on Aerospike exceptions. Server errors carry the actual wire code, such as `FailForbidden`=22, while client-side errors use the `-1` `CLIENT_SIDE_RESULT_CODE` sentinel. Applications can use this structured value instead of parsing error messages (aerospike-py ADR-0027, PR #413).

--- a/scripts/fetch_sources.sh
+++ b/scripts/fetch_sources.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Clone every repo in sources.lock at its pinned SHA.
+#
+# Usage: scripts/fetch_sources.sh [dest-dir]     (default: .source-cache)
+#
+# Re-running is cheap: a checkout already at the pinned SHA is left alone, so
+# this doubles as the local dev loop. Fetches are blobless and single-branch —
+# the checker only reads a handful of files, and full history costs minutes in
+# CI for nothing.
+set -euo pipefail
+
+DEST="${1:-.source-cache}"
+LOCK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/sources.lock"
+
+[ -f "$LOCK" ] || { echo "error: no sources.lock at $LOCK" >&2; exit 2; }
+mkdir -p "$DEST"
+
+while read -r name url sha; do
+    case "$name" in ''|\#*) continue ;; esac
+    [ -n "${sha:-}" ] || { echo "error: no SHA for $name in sources.lock" >&2; exit 2; }
+    target="$DEST/$name"
+
+    if [ -d "$target/.git" ] && [ "$(git -C "$target" rev-parse HEAD 2>/dev/null)" = "$sha" ]; then
+        echo "  $name already at ${sha:0:12}"
+        continue
+    fi
+
+    echo "  fetching $name @ ${sha:0:12}"
+    if [ ! -d "$target/.git" ]; then
+        git init -q "$target"
+        git -C "$target" remote add origin "$url"
+    fi
+    # A pinned SHA may not be a branch tip, so fetch the object directly.
+    git -C "$target" fetch -q --depth 1 --filter=blob:none origin "$sha"
+    git -C "$target" checkout -q --detach FETCH_HEAD
+done < "$LOCK"
+
+echo "sources ready in $DEST"

--- a/scripts/sources.lock
+++ b/scripts/sources.lock
@@ -1,0 +1,17 @@
+# Pinned source checkouts for scripts/verify_skill_claims.py.
+#
+# Every claim the checker verifies is checked against THESE commits, not against
+# whatever the source repos happen to be at today. Pinning is the point: an
+# unpinned check silently changes meaning when upstream moves, and a green run
+# would stop being evidence of anything.
+#
+# To adopt upstream changes: bump a SHA here, re-run the checker, and fix (or
+# consciously accept) whatever it reports. That turns every upstream sync into
+# an explicit, reviewable commit instead of background drift.
+#
+# Format: <name> <git-url> <full-40-char-sha>
+
+aerospike-ce-kubernetes-operator https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator.git 1612083e4e2e76eafc4f975d593dd3145cc74c5e
+ackoctl https://github.com/aerospike-ce-ecosystem/ackoctl.git ad27c3c854abb57fa876631e6f62e0b24a5e54e3
+aerospike-py https://github.com/aerospike-ce-ecosystem/aerospike-py.git 5db458d5686a9a0a8dfade844726eb20eaeb45ee
+aerospike-cluster-manager https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager.git fc71b8ce2745777ba5d3420553a020298d08addc

--- a/scripts/verify_skill_claims.py
+++ b/scripts/verify_skill_claims.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""Verify factual claims in skills/ against pinned checkouts of the source repos.
+
+Why this exists
+---------------
+A drift audit of these skills checked 1,770 claims and found 128 wrong (7.2%).
+The dangerous subset was not the obviously-wrong kind: ~20 were commands that
+exit 0 and print nothing, so neither Claude nor the user learns the instruction
+was bad. Six identifiers had never existed in ANY version of the source — they
+were wrong when written, which means the gap is authoring verification, not
+keeping up with upstream. Nothing scored the skills, so they accumulated
+unnoticed.
+
+Design bias: precision over recall
+----------------------------------
+This checker deliberately verifies a NARROW set of claim kinds, chosen because
+each resolves to a closed, enumerable set in source (a condition-type constant
+list, a flag registration, a route decorator). It does not attempt fuzzy prose
+checking.
+
+That bias is deliberate and was learned the hard way. An earlier version of this
+check compared documented webhook error strings against Go string literals and
+reported 29 failures, of which 19 were false positives. Go assembles most of
+those messages from format verbs and `+`-concatenated literals spanning several
+source lines, so the documented rendering ("spec.size N exceeds CE maximum of 8")
+is not a substring of anything in source. Joining concatenations was not enough —
+the format verbs still broke it. That check was REMOVED rather than shipped
+noisy: a check that cries wolf two times in three gets disabled within a week,
+and then catches nothing at all. Every extractor below is written to under-report
+rather than guess, and a category that cannot be made precise is left to humans
+and named in COVERAGE.
+
+Honest accounting is part of the contract: `--report` prints how many claims
+were checked, and `coverage` states plainly which claim kinds are NOT covered.
+Do not describe a green run as "the skills are verified" — it means "the claim
+kinds listed under COVERAGE are consistent with the pinned SHAs".
+
+Usage
+-----
+    python3 scripts/verify_skill_claims.py --sources <dir>   # <dir>/<repo>/...
+    python3 scripts/verify_skill_claims.py --coverage        # what is/isn't checked
+    python3 scripts/verify_skill_claims.py --sources <dir> --format github
+
+Exit codes: 0 clean, 1 claims failed, 2 setup/usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+LOCK_FILE = Path(__file__).resolve().parent / "sources.lock"
+
+ACKO = "aerospike-ce-kubernetes-operator"
+ACKOCTL = "ackoctl"
+PY = "aerospike-py"
+ACM = "aerospike-cluster-manager"
+
+
+# --------------------------------------------------------------------------
+# Findings
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    path: str
+    line: int
+    category: str
+    claim: str
+    message: str
+
+    def format_text(self) -> str:
+        return (
+            f"  {self.path}:{self.line}\n"
+            f"    [{self.category}] {self.claim}\n"
+            f"    {self.message}"
+        )
+
+    def format_github(self) -> str:
+        msg = f"[{self.category}] {self.claim} — {self.message}".replace("\n", " ")
+        return f"::error file={self.path},line={self.line}::{msg}"
+
+
+@dataclass
+class Stats:
+    checked: int = 0
+    by_category: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+    def count(self, category: str, n: int = 1) -> None:
+        self.checked += n
+        self.by_category[category] += n
+
+
+# --------------------------------------------------------------------------
+# Source-of-truth extraction
+#
+# Each function returns the closed set a claim kind is checked against. If an
+# extractor returns an empty set the corresponding check is SKIPPED rather than
+# failing every claim — an extractor that silently stops matching (upstream
+# refactor, renamed file) must not manifest as a wall of false failures.
+# --------------------------------------------------------------------------
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _walk(root: Path, suffix: str, skip: tuple[str, ...] = ()) -> list[Path]:
+    if not root.is_dir():
+        return []
+    out = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in {".git", "vendor", "node_modules", ".venv"}]
+        for fn in filenames:
+            if fn.endswith(suffix) and not any(s in fn for s in skip):
+                out.append(Path(dirpath) / fn)
+    return out
+
+
+def acko_conditions(root: Path) -> set[str]:
+    src = _read(root / "api/v1alpha1/aerospikecluster_types.go")
+    return set(re.findall(r"Condition[A-Za-z]+\s*=\s*\"([A-Za-z]+)\"", src))
+
+
+def acko_phases(root: Path) -> set[str]:
+    src = _read(root / "api/v1alpha1/aerospikecluster_types.go")
+    m = re.search(r"\+kubebuilder:validation:Enum=([A-Za-z;]+)\s*\ntype AerospikePhase", src)
+    return set(m.group(1).split(";")) if m else set()
+
+
+def acko_event_reasons(root: Path) -> set[str]:
+    src = _read(root / "internal/controller/events.go")
+    return set(re.findall(r"Event[A-Za-z]+\s*=\s*\"([A-Za-z]+)\"", src))
+
+
+def acko_label_keys(root: Path) -> set[str]:
+    """Label/annotation keys the operator sets, plus chart-applied selector keys."""
+    keys = set(re.findall(r'"([a-z0-9.-]+/[a-z0-9._-]+)"', _read(root / "internal/utils/labels.go")))
+    # Chart and kustomize both label the manager pods with a bare `control-plane`.
+    for path in _walk(root / "charts", ".tpl") + _walk(root / "config", ".yaml"):
+        keys.update(re.findall(r"^\s*(control-plane):\s*\S", _read(path), re.M))
+    return keys
+
+
+def acko_crd_fields(root: Path) -> set[str]:
+    """Every json tag name in the API package (name existence, not path shape)."""
+    names: set[str] = set()
+    for path in _walk(root / "api", ".go", skip=("_test.go",)):
+        names.update(re.findall(r'json:"([A-Za-z0-9_]+)', _read(path)))
+    return names
+
+
+def ackoctl_flags(root: Path) -> set[str]:
+    flags: set[str] = set()
+    for path in _walk(root, ".go", skip=("_test.go",)):
+        text = _read(path)
+        flags.update(re.findall(r'Flags\(\)\.[A-Za-z]+VarP?\([^,]+,\s*"([a-z0-9-]+)"', text))
+        flags.update(re.findall(r'PersistentFlags\(\)\.[A-Za-z]+VarP?\([^,]+,\s*"([a-z0-9-]+)"', text))
+    # Cobra supplies these on every command.
+    flags.update({"help", "version"})
+    return flags
+
+
+def py_constants(root: Path) -> set[str]:
+    """Constants exported from the Rust extension AND from Python-level modules.
+
+    Not everything lives in constants.rs: `exp.EXP_TYPE_*`, for instance, is
+    defined in src/aerospike_py/exp.py. Reading only the Rust side reported
+    every one of those as missing.
+    """
+    names = set(re.findall(r'm\.add\("([A-Z0-9_]+)"', _read(root / "rust/src/constants.rs")))
+    for path in _walk(root / "src", ".py") + _walk(root / "src", ".pyi"):
+        names.update(re.findall(r"^([A-Z][A-Z0-9_]{3,})\s*[:=]", _read(path), re.M))
+    return names
+
+
+def acm_routes(root: Path) -> set[str]:
+    """Declared API paths, resolved through each router's prefix and both mounts.
+
+    A route reads `@router.get("/clusters")` in a file whose router was built as
+    `APIRouter(prefix="/k8s")`, and main.py mounts every router under both /api
+    and /api/v1. Ignoring either layer makes real routes look nonexistent.
+    """
+    api = root / "api/src/aerospike_cluster_manager_api"
+    paths: set[str] = set()
+    for path in _walk(api, ".py", skip=("test_",)):
+        text = _read(path)
+        m = re.search(r'APIRouter\(\s*prefix\s*=\s*"([^"]*)"', text)
+        prefix = m.group(1) if m else ""
+        for route in re.findall(r'@(?:app|router)\.(?:get|post|put|delete|patch)\(\s*"([^"]+)"', text):
+            paths.add(route if route.startswith("/api") else prefix + route)
+    if not paths:
+        return set()
+    expanded = set(paths)
+    for p in paths:
+        if not p.startswith("/api"):
+            for mount in ("/api", "/api/v1"):
+                expanded.add(mount + p)
+    return expanded
+
+
+# --------------------------------------------------------------------------
+# Claim extraction from skills/
+# --------------------------------------------------------------------------
+
+# Label keys that are legitimately not ACKO's own (Kubernetes built-ins and
+# third-party operators the skills interact with).
+EXTERNAL_LABEL_PREFIXES = (
+    "kubernetes.io/",
+    "node.kubernetes.io/",
+    "topology.kubernetes.io/",
+    "statefulset.kubernetes.io/",
+    "batch.kubernetes.io/",
+    "controller-revision-hash",
+)
+
+PLACEHOLDER = re.compile(r"^[<{$]|[>}]$|^\.\.\.$|^N$|^M$|^T$|^X$|^S$|^KEY$")
+
+
+def _iter_skill_lines():
+    for path in sorted(_walk(SKILLS_DIR, ".md")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        for i, line in enumerate(_read(path).splitlines(), 1):
+            yield rel, i, line
+
+
+def check_label_selectors(known: set[str], stats: Stats) -> list[Finding]:
+    """`-l key=value` — a wrong key exits 0 with empty output, so nothing surfaces it."""
+    out = []
+    if not known:
+        return out
+    pat = re.compile(r"-l\s+([A-Za-z0-9][A-Za-z0-9./_-]*)=")
+    for rel, ln, line in _iter_skill_lines():
+        for key in pat.findall(line):
+            if key.startswith(EXTERNAL_LABEL_PREFIXES) or PLACEHOLDER.match(key):
+                continue
+            stats.count("label-selector")
+            if key not in known:
+                out.append(Finding(rel, ln, "label-selector", key,
+                                   "no such label key is set by the operator or its chart; "
+                                   "a selector that matches nothing still exits 0"))
+    return out
+
+
+def check_condition_types(known: set[str], stats: Stats) -> list[Finding]:
+    """`@.type=="X"` in a jsonpath — a wrong type yields empty output, not an error."""
+    out = []
+    if not known:
+        return out
+    pat = re.compile(r'@\.type\s*==\s*"([A-Za-z]+)"')
+    for rel, ln, line in _iter_skill_lines():
+        for cond in pat.findall(line):
+            stats.count("condition-type")
+            if cond not in known:
+                out.append(Finding(rel, ln, "condition-type", cond,
+                                   f"not a declared condition type; the set is {sorted(known)}"))
+    return out
+
+
+def check_phases(known: set[str], stats: Stats) -> list[Finding]:
+    """`phase=X` / `phase: X` / `status.phase == "X"` in unambiguous positions only."""
+    out = []
+    if not known:
+        return out
+    pats = [
+        re.compile(r"\bphase\s*=\s*[\"'`]?([A-Z][A-Za-z]+)"),
+        re.compile(r"\bstatus\.phase\s*==\s*[\"']([A-Z][A-Za-z]+)"),
+    ]
+    for rel, ln, line in _iter_skill_lines():
+        for pat in pats:
+            for phase in pat.findall(line):
+                stats.count("phase-name")
+                if phase not in known:
+                    out.append(Finding(rel, ln, "phase-name", phase,
+                                       f"not in the AerospikePhase enum: {sorted(known)}"))
+    return out
+
+
+def check_ackoctl_flags(known: set[str], stats: Stats) -> list[Finding]:
+    """Long flags on an `ackoctl` invocation — Cobra rejects an unknown flag outright."""
+    out = []
+    if not known:
+        return out
+    # Syntax-summary placeholders, not real flags.
+    placeholders = {"flag", "flags", "option", "options", "opt", "args"}
+    flag_pat = re.compile(r"--([a-z][a-z0-9-]+)")
+    for rel, ln, line in _iter_skill_lines():
+        if "ackoctl" not in line:
+            continue
+        # Ignore prose that merely mentions ackoctl alongside another tool.
+        if re.search(r"\b(kubectl|helm|asinfo|asadm|curl)\b", line):
+            continue
+        # A shell comment is commentary, not an invocation — and is often
+        # explaining that a flag does NOT exist, which would self-flag.
+        if line.lstrip().startswith("#"):
+            continue
+        for flag in flag_pat.findall(line):
+            if flag in placeholders:
+                continue
+            stats.count("ackoctl-flag")
+            if flag not in known:
+                out.append(Finding(rel, ln, "ackoctl-flag", "--" + flag,
+                                   "not registered on any ackoctl command; Cobra rejects unknown flags"))
+    return out
+
+
+def check_py_constants(known: set[str], stats: Stats) -> list[Finding]:
+    """Backticked `AEROSPIKE_*` / `POLICY_*` / `EXP_*` names must exist in constants.rs."""
+    out = []
+    if not known:
+        return out
+    prefixes = ("AEROSPIKE_", "POLICY_", "EXP_", "AUTH_", "SERIALIZER_", "LOG_LEVEL_")
+    # AEROSPIKE_PY_* is the environment-variable namespace, not the constant one.
+    env_prefixes = ("AEROSPIKE_PY_",)
+    pat = re.compile(r"`([A-Z][A-Z0-9_]{3,})`")
+    for rel, ln, line in _iter_skill_lines():
+        for name in pat.findall(line):
+            if not name.startswith(prefixes) or name.startswith(env_prefixes):
+                continue
+            stats.count("py-constant")
+            if name not in known:
+                out.append(Finding(rel, ln, "py-constant", name,
+                                   "not exported by rust/src/constants.rs"))
+    return out
+
+
+def check_acm_routes(known: set[str], stats: Stats) -> list[Finding]:
+    """`/api/...` paths must correspond to a declared route."""
+    out = []
+    if not known:
+        return out
+    pat = re.compile(r"`(/api/[A-Za-z0-9/_.-]*)`")
+    # Compare with path parameters normalised: /clusters/{id} ~ /clusters/<id>.
+    def norm(p: str) -> str:
+        p = re.sub(r"\{[^}]+\}", "{}", p)
+        p = re.sub(r"<[^>]+>", "{}", p)
+        return p.rstrip("/")
+
+    known_norm = {norm(k) for k in known}
+    for rel, ln, line in _iter_skill_lines():
+        for raw in pat.findall(line):
+            if any(ch in raw for ch in "<>{}") or "..." in raw:
+                continue  # templated/elided example, not a literal claim
+            stats.count("acm-route")
+            if norm(raw) not in known_norm:
+                out.append(Finding(rel, ln, "acm-route", raw,
+                                   "no such route is declared by the cluster-manager API"))
+    return out
+
+
+def check_event_reasons(known: set[str], stats: Stats) -> list[Finding]:
+    """Event reasons in the first column of an "Event Reason" table.
+
+    Scoped to that column rather than to any CamelCase token in prose: an event
+    reason is shaped exactly like a condition type, a phase, or a Go identifier,
+    so a free-text scan cannot tell them apart and would flag all of them.
+    """
+    out = []
+    if not known:
+        return out
+    cell = re.compile(r"^\|\s*`([A-Za-z]+)`\s*\|")
+    for path in sorted(_walk(SKILLS_DIR, ".md")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        in_event_table = False
+        for ln, line in enumerate(_read(path).splitlines(), 1):
+            if line.startswith("|"):
+                head = line.split("|")[1].strip().lower() if line.count("|") > 1 else ""
+                if "event reason" in head:
+                    in_event_table = True
+                    continue
+            elif line.strip() == "" or line.startswith("#"):
+                in_event_table = False
+            if not in_event_table:
+                continue
+            m = cell.match(line)
+            if not m:
+                continue
+            reason = m.group(1)
+            stats.count("event-reason")
+            if reason not in known:
+                out.append(Finding(rel, ln, "event-reason", reason,
+                                   "no such event reason is defined in internal/controller/events.go"))
+    return out
+
+
+def check_crd_fields(known: set[str], stats: Stats) -> list[Finding]:
+    """Field NAMES in `spec.*` / `status.*` paths must exist as a json tag.
+
+    Name existence only — this does not verify that the path nests correctly.
+    It still catches the real-world failure mode (`status.operation` where the
+    field is `status.operationStatus`).
+    """
+    out = []
+    if not known:
+        return out
+    pat = re.compile(r"`\.?((?:spec|status)(?:\.[A-Za-z][A-Za-z0-9]*(?:\[[^\]]*\])?)+)`")
+    for rel, ln, line in _iter_skill_lines():
+        for path_expr in pat.findall(line):
+            # Drop jsonpath filter expressions first — `[?(@.type=="X")]` contains
+            # dots of its own and would otherwise be split into bogus segments.
+            cleaned = re.sub(r"\[\?\(.*?\)\]", "", path_expr)
+            segments = [re.sub(r"\[.*?\]", "", s) for s in cleaned.split(".")[1:]]
+            for seg in segments:
+                if not seg or PLACEHOLDER.match(seg):
+                    continue
+                stats.count("crd-field")
+                if seg not in known:
+                    out.append(Finding(rel, ln, "crd-field", f"{path_expr} → '{seg}'",
+                                       "no such json tag exists anywhere in the CRD API package"))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Coverage
+# --------------------------------------------------------------------------
+
+COVERAGE = """\
+COVERAGE — what this checker does and does not verify
+
+  Verified (each resolves to a closed, enumerable set in source):
+    label-selector   `-l key=` against the operator's label constants + chart
+    condition-type   `@.type=="X"` against the Condition* constants
+    phase-name       `phase=X` against the AerospikePhase kubebuilder enum
+    event-reason     first column of an "Event Reason" table against events.go
+    crd-field        names in `spec.*`/`status.*` against CRD json tags
+    ackoctl-flag     `--flag` on an ackoctl line against Cobra registrations
+    py-constant      backticked AEROSPIKE_*/POLICY_*/EXP_*/AUTH_* against
+                     constants.rs plus the Python-level modules
+    acm-route        `/api/...` against cluster-manager routes, resolved through
+                     each APIRouter prefix and both the /api and /api/v1 mounts
+
+  NOT verified — these still need human review:
+    - Webhook error strings. Tried and removed: Go assembles them from format
+      verbs and concatenated literals, so the documented rendering is not a
+      substring of anything in source. 19 of 29 reports were false. The manual
+      audit did find 11 genuinely wrong strings here, so the risk is real — it
+      simply is not mechanically checkable at acceptable precision.
+    - Default VALUES (`max_retries` = 2 vs 5). They live in a dependency crate
+      and in per-policy override builders; a wrong guess is worse than no check.
+    - Whether a documented rule is actually IMPLEMENTED. "Rack IDs cannot be
+      changed" names real fields in fluent English; only reading ValidateUpdate
+      shows the webhook never enforced it. This class caused the worst finding
+      in the audit and no extractor can catch it.
+    - Prose semantics, procedure ordering, and whether the advice is good.
+    - CRD path SHAPE. crd-field checks that each name exists somewhere in the
+      API package, not that the nesting is correct.
+    - aerospike-py's Python API surface beyond constants; Helm values; metric
+      names; Ginkgo/pytest specifics.
+
+  Honest denominator: the drift audit that motivated this checker examined
+  ~1,770 claims. The categories above cover roughly a fifth of that population,
+  and they are deliberately the fifth where a wrong claim fails SILENTLY — a bad
+  label selector or condition type exits 0 and prints nothing, so no human ever
+  sees an error. A green run means "these claim kinds agree with the pinned
+  SHAs". It does NOT mean the skills are correct.
+"""
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+
+def load_lock() -> list[tuple[str, str, str]]:
+    entries = []
+    for raw in _read(LOCK_FILE).splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) != 3:
+            print(f"warning: malformed sources.lock line: {raw}", file=sys.stderr)
+            continue
+        entries.append((parts[0], parts[1], parts[2]))
+    return entries
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--sources", type=Path, help="directory holding one checkout per source repo")
+    ap.add_argument("--format", choices=("text", "github", "json"), default="text")
+    ap.add_argument("--coverage", action="store_true", help="print coverage notes and exit")
+    ap.add_argument("--report", action="store_true", default=True, help=argparse.SUPPRESS)
+    args = ap.parse_args()
+
+    if args.coverage:
+        print(COVERAGE)
+        return 0
+
+    if not args.sources:
+        print("error: --sources is required (or use --coverage)", file=sys.stderr)
+        return 2
+    if not SKILLS_DIR.is_dir():
+        print(f"error: no skills/ directory at {SKILLS_DIR}", file=sys.stderr)
+        return 2
+
+    locked = {name: sha for name, _url, sha in load_lock()}
+    roots = {name: args.sources / name for name in locked}
+
+    missing = [n for n, p in roots.items() if not p.is_dir()]
+    if missing:
+        print(f"error: missing checkouts under {args.sources}: {', '.join(missing)}", file=sys.stderr)
+        print("hint: scripts/fetch_sources.sh clones every repo in sources.lock at its pinned SHA", file=sys.stderr)
+        return 2
+
+    stats = Stats()
+    findings: list[Finding] = []
+    skipped: list[str] = []
+
+    def run(label, extractor, checker, repo):
+        known = extractor(roots[repo])
+        if not known:
+            skipped.append(f"{label} (extractor found nothing in {repo}; source layout may have changed)")
+            return
+        findings.extend(checker(known, stats))
+
+    run("label-selector", acko_label_keys, check_label_selectors, ACKO)
+    run("condition-type", acko_conditions, check_condition_types, ACKO)
+    run("phase-name", acko_phases, check_phases, ACKO)
+    run("event-reason", acko_event_reasons, check_event_reasons, ACKO)
+    run("crd-field", acko_crd_fields, check_crd_fields, ACKO)
+    run("ackoctl-flag", ackoctl_flags, check_ackoctl_flags, ACKOCTL)
+    run("py-constant", py_constants, check_py_constants, PY)
+    run("acm-route", acm_routes, check_acm_routes, ACM)
+
+    if args.format == "json":
+        print(json.dumps({
+            "checked": stats.checked,
+            "by_category": dict(stats.by_category),
+            "skipped_checks": skipped,
+            "pinned": locked,
+            "findings": [f.__dict__ for f in findings],
+        }, indent=2))
+        return 1 if findings else 0
+
+    if args.format == "github":
+        for f in findings:
+            print(f.format_github())
+
+    print()
+    print(f"Verified {stats.checked} claims against pinned source checkouts.")
+    for cat in sorted(stats.by_category):
+        print(f"  {cat:<24} {stats.by_category[cat]:>5}")
+    print()
+    for name, sha in sorted(locked.items()):
+        print(f"  pinned {name:<34} {sha[:12]}")
+    if skipped:
+        print()
+        print("SKIPPED (not counted as passing):")
+        for s in skipped:
+            print(f"  - {s}")
+    print()
+
+    if findings:
+        print(f"FAILED — {len(findings)} claim(s) do not match source:\n")
+        if args.format == "text":
+            for f in findings:
+                print(f.format_text())
+                print()
+        print("Each is a claim the skills assert and the pinned source contradicts.")
+        print("Fix the skill, or bump the SHA in scripts/sources.lock if upstream moved.")
+        return 1
+
+    print("OK — every claim in the covered categories matches the pinned sources.")
+    print("Run with --coverage to see what this does NOT check.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/acko-deploy/reference/cr-spec-fields.md
+++ b/skills/acko-deploy/reference/cr-spec-fields.md
@@ -79,9 +79,9 @@ Trigger manual restarts without otherwise changing the spec. The webhook prevent
 | `spec.operations[].kind` | enum | `WarmRestart` (sends SIGUSR1 to the aerospike process, no pod recreate) or `PodRestart` (delete + recreate pods) |
 | `spec.operations[].id` | string | Unique-per-cluster id, length 1–20 chars. Identifies one operation across reconciles. |
 | `spec.operations[].podList` | list[string] | Optional. Subset of pod names to target. Omit to apply to all pods. |
-| `status.operation.phase` | enum | `InProgress` / `Completed` / `Error`. Goes to `Error` (not silent Completed) on an unknown `kind` or when `podList` names no existing pods. |
-| `status.operation.completedPods` | list[string] | Pods that finished successfully |
-| `status.operation.failedPods` | list[string] | Pods that errored |
+| `status.operationStatus.phase` | enum | `InProgress` / `Completed` / `Error`. Goes to `Error` (not silent Completed) on an unknown `kind` or when `podList` names no existing pods. |
+| `status.operationStatus.completedPods` | list[string] | Pods that finished successfully |
+| `status.operationStatus.failedPods` | list[string] | Pods that errored |
 
 On-demand `WarmRestart`/`PodRestart` batches gate on the same readiness-gate / migration guard as rolling restarts, so a batch may legitimately pause until pods rejoin or migrations drain.
 

--- a/skills/acko-operations/reference/events.md
+++ b/skills/acko-operations/reference/events.md
@@ -38,11 +38,15 @@ Catalog of Kubernetes events emitted by the ACKO operator. Count grows over rele
 
 ### Dynamic Config 2-Phase Commit (April 2026)
 
+Phase 1 (validate-all) failure emits **no event** — it is only logged. There is no
+`DynamicConfigValidationFailed` reason; diagnose an aborted update from the operator log
+and from the `DynamicConfigDegraded` condition instead.
+
 | Event Reason | Type | When Emitted |
 |---|---|---|
-| `DynamicConfigValidationFailed` | Warning | Phase 1 (validate-all) rejected the change on at least one pod; whole update aborted before any pod is mutated |
-| `DynamicConfigRollbackTriggered` | Warning | Phase 2 apply failed on a pod; LIFO rollback started across already-updated pods |
-| `DynamicConfigRollbackFailed` | Warning | Rollback itself failed; cluster transitioning to `phase=ConfigDegraded` |
+| `DynamicConfigApplied` | Normal | A dynamic config change was applied to a pod |
+| `DynamicConfigRollback` | Warning | Phase 2 apply failed on a pod; LIFO rollback started across already-updated pods |
+| `DynamicConfigStatusFailed` | Warning | The operator could not write the dynamic-config status back to the CR |
 | `DynamicConfigDegraded` | Warning | `ConditionDynamicConfigDegraded=True` set; reconciliation halts until manual intervention |
 | `ConfigDegradedSkip` | Warning | Reconcile skipped because the cluster is in `phase=ConfigDegraded` (message: `"Reconcile skipped due to ConfigDegraded phase"`; repeats every ~60s until resolved) |
 
@@ -124,8 +128,8 @@ Catalog of Kubernetes events emitted by the ACKO operator. Count grows over rele
 
 | Event Reason | Type | When Emitted |
 |---|---|---|
-| `ClusterPaused` | Normal | `spec.paused=true` observed; reconciliation suspended; `ConditionReconciliationPaused=True` |
-| `ClusterResumed` | Normal | `spec.paused` cleared; `failedReconcileCount`/`lastReconcileError` cleared; `ConditionReconciliationPaused=False` |
+| `ReconciliationPaused` | Normal | `spec.paused=true` observed; reconciliation suspended; `ConditionReconciliationPaused=True` |
+| `ReconciliationResumed` | Normal | `spec.paused` cleared; `failedReconcileCount`/`lastReconcileError` cleared; `ConditionReconciliationPaused=False` |
 
 ---
 


### PR DESCRIPTION
## Problem

Goal 4-1 says "keep skills current with ACKO / aerospike-py / ackoctl". Nothing enforced it. That is precisely why the drift audit (#97) found **128 wrong claims out of 1,770**, and why six identifiers had *never* existed in any version of the source — they were wrong when written, so this is an authoring-verification gap, not an upstream-tracking one.

The dangerous subset is invisible: ~20 of those were commands that **exit 0 and print nothing**. A wrong label selector returns `No resources found`; a wrong condition type in a jsonpath returns empty. Neither Claude nor the user learns the instruction was bad.

## Fix

```
scripts/verify_skill_claims.py      the checker (stdlib only — nothing to install)
scripts/sources.lock                pinned SHAs for the four source repos
scripts/fetch_sources.sh            clones each repo at its pinned SHA
.github/workflows/verify-claims.yml CI gate + coverage in the run summary
```

**314 claims** are verified across eight categories, each chosen because it resolves to a closed, enumerable set in source — and deliberately concentrated on the kinds that fail *silently*:

| Category | Checked against | n |
|---|---|--:|
| `ackoctl-flag` | Cobra flag registrations | 80 |
| `crd-field` | CRD json tags | 94 |
| `event-reason` | `internal/controller/events.go` | 46 |
| `py-constant` | `constants.rs` + Python-level modules | 29 |
| `label-selector` | operator label constants + chart | 27 |
| `phase-name` | `AerospikePhase` kubebuilder enum | 26 |
| `condition-type` | `Condition*` constants | 11 |
| `acm-route` | cluster-manager routes (via `APIRouter` prefixes and both mounts) | 1 |

**Why sources are pinned.** An unpinned check silently changes meaning when upstream moves, so a green run would stop being evidence of anything. Adopting upstream becomes an explicit, reviewable SHA bump in `sources.lock`.

**Precision over recall — one category was cut.** An earlier version also compared documented webhook error strings against Go string literals and reported 29 failures, **19 of them false**. Go assembles those messages from format verbs and `+`-concatenated literals across source lines, so the documented rendering (`spec.size N exceeds CE maximum of 8`) is not a substring of anything in source. Joining concatenations was not enough; the format verbs still broke it. I removed the check rather than ship it noisy — a check that cries wolf two times in three gets disabled within a week, and then catches nothing at all. It is named explicitly under `--coverage` as a human-review area, along with the note that the manual audit *did* find 11 genuinely wrong strings there, so the risk is real but not mechanically checkable at acceptable precision.

Three further precision fixes came out of the first run, each a false positive I traced and corrected rather than suppressed: `APIRouter(prefix=...)` resolution, `EXP_TYPE_*` constants that live in `src/aerospike_py/exp.py` rather than `constants.rs`, and jsonpath filter expressions (`[?(@.type=="X")]`) being split into bogus CRD segments.

An extractor that finds nothing reports **SKIPPED** rather than failing every claim, so an upstream file rename surfaces as "this check stopped working", not a wall of false failures.

## Verification

**Reproducible from a clean fetch** — SHAs match `sources.lock` exactly:

```
$ ./scripts/fetch_sources.sh /tmp/srccache-test        # 7.1s total
  fetching aerospike-ce-kubernetes-operator @ 1612083e4e2e
  fetching ackoctl @ ad27c3c854ab
  fetching aerospike-py @ 5db458d5686a
  fetching aerospike-cluster-manager @ fc71b8ce2745

$ python3 scripts/verify_skill_claims.py --sources /tmp/srccache-test
Verified 314 claims against pinned source checkouts.
  ackoctl-flag  80 | crd-field  94 | event-reason  46 | py-constant  29
  label-selector 27 | phase-name 26 | condition-type 11 | acm-route  1
OK — every claim in the covered categories matches the pinned sources.
EXIT=0
```

**It actually fails.** Negative test injecting the four historical regressions this exists to catch — every one was caught by the right category:

```
[label-selector] aerospike.io/cr-name  — no such label key is set by the operator or its chart
[condition-type] ReconcileBackoff      — not a declared condition type; the set is [...]
[ackoctl-flag]   --previous            — not registered on any ackoctl command
[acm-route]      /api/v1/version       — no such route is declared by the cluster-manager API
[crd-field]      status.operation.phase → 'operation'
[py-constant]    POLICY_NOPE_NOT_REAL  — not exported by rust/src/constants.rs
```

Exit codes and idempotency:

```
exit(with bad claim) = 1     exit(clean tree) = 0
--sources /nonexistent -> 2  (with a hint pointing at fetch_sources.sh)
no --sources           -> 2      --coverage -> 0
re-run fetch: "already at 1612083e4e2e" ×4  (cache-friendly, no re-clone)
```

GitHub annotations render on the diff:

```
::error file=skills/acko-debugging/reference/playbook.md,line=178::[crd-field] status.operation.phase → 'operation' — no such json tag exists anywhere in the CRD API package
```

`claude plugin validate .` → `✔ Validation passed`; the workflow YAML parses.

## Honest coverage

**314 checked ≈ 18% of the ~1,770 claims the audit examined.** The two counts use different methodologies (the audit counted assertions by hand; this counts extractor matches), so treat it as "roughly a fifth" rather than a precise ratio.

A green run means *the covered categories agree with the pinned SHAs*. It does **not** mean the skills are correct. `--coverage` names what is not checked, and CI publishes that text in the run summary so the limitation travels with the result. The largest uncovered class is the one that produced the worst finding in the audit: whether a documented rule is actually *implemented*. "Rack IDs cannot be changed" names real fields in fluent English — only reading `ValidateUpdate` shows the webhook never enforced it, and no extractor can catch that.

## Risk

Low. New files plus two skill corrections; no existing behaviour changes. The gate is scoped by `paths:` so it only runs when skills or the checker change.

Two notes for the reviewer:

- **This PR also fixes the 8 real drifts the checker found on its first run**, because the gate has to land green: five event reasons the operator never emits (`DynamicConfigValidationFailed`, `DynamicConfigRollbackTriggered`, `DynamicConfigRollbackFailed`, `ClusterPaused`, `ClusterResumed` → the real ones are `DynamicConfigApplied`, `DynamicConfigRollback`, `DynamicConfigStatusFailed`, `ReconciliationPaused`, `ReconciliationResumed`), and three `status.operation.*` paths that are `status.operationStatus.*`. **These overlap the remaining-drift cleanup task — it should skip them.**
- The weekly `schedule:` trigger cannot surface upstream drift, since sources are pinned. It guards against bit-rot in the checker itself: a source-layout change that makes an extractor stop matching shows up as SKIPPED. If that is not wanted, dropping the cron is a one-line change.

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
