### PR TITLE
fix(skills): route dynamic-config failure diagnosis to signals the operator writes

### DIFF
--- a/skills/acko-config-reference/reference/conditions-and-phases.md
+++ b/skills/acko-config-reference/reference/conditions-and-phases.md
@@ -52,7 +52,7 @@ Each condition has `type`, `status` (`True`/`False`/`Unknown`), `reason`, `messa
 | `MigrationComplete` | no data migrations pending |
 | `ReconciliationPaused` | `spec.paused: true` in effect |
 | `ReconcileHealthy` | `False` = circuit broken (reasons `PermanentError`, `Recovered`) |
-| `DynamicConfigDegraded` | pods hold inconsistent dynamic config (reasons `RollbackFailed`, `ApplyFailed`) |
+| `DynamicConfigDegraded` | pods hold inconsistent dynamic config (sole reason: `RollbackFailed` — `reconciler_status.go:800-801` is the only setter) |
 
 ### `ConfigApplied`
 
@@ -81,9 +81,11 @@ Each `AerospikePodStatus.dynamicConfigChanges[]` entry tracks one config path mu
 | `path` | string | Dotted config path, e.g. `service.proto-fd-max` |
 | `oldValue` | string | Previous value (TOML-rendered) |
 | `newValue` | string | Attempted new value |
-| `result` | enum | `Applied`, `Failed`, `Pending`, `RolledBack`, `RollbackFailed` |
+| `result` | string | Only ever `Applied` — see the note below |
 
-Use this to debug which specific change failed in a 2PC rollout:
+**Only `Applied` is ever written.** `reconciler_dynamic_config.go:515` is the sole writer of `result` and hardcodes `"Applied"`, reached only on the success path; `:228` is the sole writer of `dynamicConfigStatus`, also literal `"Applied"`. `Failed`, `RolledBack` and `RollbackFailed` appear in the API doc-comment (`aerospikecluster_types.go:529`) but are never assigned, and `Pending` is not even in that list. A change that failed leaves **no entry at all** rather than a failure value — so absence, not a status string, is the signal. Diagnose failures from the `DynamicConfigDegraded` condition (reason `RollbackFailed`, `reconciler_status.go:800-801`), `status.phaseReason`, `phase=ConfigDegraded`, and `ConfigDegradedSkip` events.
+
+List the changes that *did* apply:
 
 ```bash
 kubectl get asc <name> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq

--- a/skills/acko-config-reference/reference/crd-mapping.md
+++ b/skills/acko-config-reference/reference/crd-mapping.md
@@ -81,10 +81,15 @@ status:
         - path: namespaces.testns.default-ttl
           oldValue: "0"
           newValue: "3600"
-          result: RolledBack       # phase 2 apply failed -> LIFO rollback succeeded
+          result: Applied
 ```
 
-Per-change `result` enum: `Applied`, `Failed`, `Pending`, `RolledBack`, `RollbackFailed`.
+**`result` is only ever `Applied`.** `reconciler_dynamic_config.go:515` is the sole writer and
+hardcodes it on the success path. `Failed`, `RolledBack` and `RollbackFailed` appear in the API
+doc-comment (`aerospikecluster_types.go:529`) but are never assigned; `Pending` is not even in
+that list. A path that failed to apply is **absent** from the list rather than carrying a failure
+value, so diagnose from the `DynamicConfigDegraded` condition (reason `RollbackFailed`),
+`status.phaseReason`, and `ConfigDegradedSkip` events instead.
 
 Inspect with:
 

--- a/skills/acko-debugging/SKILL.md
+++ b/skills/acko-debugging/SKILL.md
@@ -33,7 +33,7 @@ Execute in order; stop and report as soon as the root cause is identified. Comma
 3. **Pod-level issues** — logs via `ackoctl k8s cluster logs` or kubectl; for CrashLoopBackOff use `kubectl logs --previous` (ackoctl has no such flag). CrashLoopBackOff → config parse error (removed 7.x params), OOM, `data-size` < 512 MiB; ImagePullBackOff → image/pull-secret; Pending → resources/PVC.
 4. **Operator logs** — `kubectl -n aerospike-operator logs -l control-plane=controller-manager --tail=200`: reconcile errors, webhook rejections, resource-creation failures.
 5. **Events timeline** — `ackoctl k8s cluster events` (classified) or raw kubectl events. Key reasons: `CircuitBreakerActive` (→ `BackoffActive`, `acko_circuit_breaker_active=1`), `RestartFailed`, `ScaleDownDeferred`, `DynamicConfigStatusFailed`, `ACLSyncError`, `ConfigDegradedSkip`, `TemplateResolutionError`, `ReadinessGateBlocking`.
-6. **Dynamic config status** — `status.pods[].dynamicConfigStatus`; `Failed` = parameter not dynamic → advise `enableDynamicConfigUpdate: false` for a rolling restart.
+6. **Dynamic config status** — `status.pods[].dynamicConfigStatus` is only ever `Applied`; a change that did not take has **no** entry. Read the `DynamicConfigDegraded` condition (reason `RollbackFailed`) and the operator log — phase-1 validation failure is logged, not evented. Non-dynamic parameter → advise `enableDynamicConfigUpdate: false` for a rolling restart.
 
 ## Remediation actions
 

--- a/skills/acko-deploy/reference/cr-spec-fields.md
+++ b/skills/acko-deploy/reference/cr-spec-fields.md
@@ -91,4 +91,4 @@ On-demand `WarmRestart`/`PodRestart` batches gate on the same readiness-gate / m
 |-------|------|-------------|
 | `status.phase` | enum | `""`, `InProgress`, `Completed`, `Error`, `ScalingUp`, `ScalingDown`, `WaitingForMigration`, `RollingRestart`, `ACLSync`, `Paused`, `Deleting`, `ConfigDegraded`, `BackoffActive`. Circuit breaker is `BackoffActive` (not `Error`); ACL-failure stays in `ACLSync`. |
 | `status.conditions[]` | list | `Available`, `Ready`, `ConfigApplied`, `ACLSynced`, `MigrationComplete`, `ReconciliationPaused`, `ReconcileHealthy`, `DynamicConfigDegraded` (full reference in `acko-config-reference/reference/conditions-and-phases.md`) |
-| `status.pods[].dynamicConfigChanges[]` | list | Per-path tracking from last 2PC dynamic config attempt: `path`, `oldValue`, `newValue`, `result` ∈ {`Applied`,`Failed`,`Pending`,`RolledBack`,`RollbackFailed`} |
+| `status.pods[].dynamicConfigChanges[]` | list | Per-path tracking from last 2PC dynamic config attempt: `path`, `oldValue`, `newValue`, `result`. `result` is only ever `Applied` — the operator writes no other value, so a failed change leaves no entry rather than a failure status |

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -31,7 +31,7 @@ kubectl patch asc <name> -n <ns> --type=merge -p '{"spec":{"image":"aerospike:ce
 
 Set `spec.enableDynamicConfigUpdate: true`, then patch the config value. The operator runs a 2PC rollout: **validate-all** (any pod rejects → whole update aborted, nothing mutated) → **apply sequentially** (per-pod 30s timeout) → on apply failure, **LIFO rollback**. Net effect: all pods on the new value, all pods back on the old value, or `phase=ConfigDegraded`.
 
-- Verify: `kubectl get asc <name> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq` (`result`: `Applied`/`Failed`/`Pending`/`RolledBack`/`RollbackFailed`).
+- Verify: `kubectl get asc <name> -o jsonpath='{.status.pods[*].dynamicConfigChanges}' | jq`. `result` is only ever `Applied` — a failed change leaves no entry. For failures read the `DynamicConfigDegraded` condition (reason `RollbackFailed`) and `status.phaseReason`.
 - `Failed` = phase-1 rejection or apply-failed-rollback-succeeded → set `enableDynamicConfigUpdate: false` to force a rolling restart instead.
 - **Removing** a key always forces a rolling restart (revert-to-default is not expressible as `set-config`). `replication-factor` (and legacy `memory-size`) are never dynamic — they cold-restart.
 - **ConfigDegraded** (apply AND rollback both failed): reconciliation **halts** with `ConfigDegradedSkip` Warning events (~60s requeue) until you intervene — revert the offending value, then cold-restart pods / reset the phase. Do NOT toggle `enableDynamicConfigUpdate`. Full recovery flow: `acko-debugging` skill.
@@ -90,7 +90,7 @@ Patch `spec.operations` to `null` (§4 command). Via cluster-manager API: `DELET
 
 ## 14. Troubleshooting
 
-For symptom-driven diagnosis (`phase=Error`, stuck migrations, `CrashLoopBackOff`, `CircuitBreakerActive`, `ConfigDegraded`, `ReadinessGateBlocking`, webhook rejection, `dynamicConfigStatus=Failed`), use the **`acko-debugging`** skill. It cross-links this skill's `reference/troubleshooting.md` (symptom→command table) and `reference/validation-rules.md` (canonical webhook error/warning catalog).
+For symptom-driven diagnosis (`phase=Error`, stuck migrations, `CrashLoopBackOff`, `CircuitBreakerActive`, `ConfigDegraded`, `ReadinessGateBlocking`, webhook rejection, a dynamic config change that did not take effect), use the **`acko-debugging`** skill. It cross-links this skill's `reference/troubleshooting.md` (symptom→command table) and `reference/validation-rules.md` (canonical webhook error/warning catalog).
 
 ## 15. Diagnostics / Metrics / Events / OTel
 

--- a/skills/acko-operations/reference/operations.md
+++ b/skills/acko-operations/reference/operations.md
@@ -90,12 +90,14 @@ kubectl get asc <name> -n <ns> -o jsonpath='{.status.pods[*].dynamicConfigChange
 kubectl get asc <name> -o jsonpath='{.status.pods}' | jq '.[].dynamicConfigStatus'
 ```
 
-Per-change `result` enum: `Applied`, `Failed`, `Pending`, `RolledBack`, `RollbackFailed`.
+**Per-change `result` is only ever `Applied`.** `reconciler_dynamic_config.go:515` is the sole writer and hardcodes it on the success path; `:228` writes `dynamicConfigStatus` the same way. `Failed`, `RolledBack` and `RollbackFailed` are listed in the API doc-comment (`aerospikecluster_types.go:529`) but never assigned, and `Pending` is not even in that list. So a change that did not apply leaves **no entry**, not a failure value — absence is the signal.
 
-Top-level statuses:
-- `Applied`: Success (no restart needed)
-- `Failed`: Phase 1 validation rejected, OR phase 2 apply failed and rollback succeeded; set `enableDynamicConfigUpdate: false` to force rolling restart
-- `Pending`: Change is being applied
+To diagnose a change that did not take effect:
+- `DynamicConfigDegraded` condition, reason `RollbackFailed` (`reconciler_status.go:800-801`) — apply *and* rollback both failed
+- `status.phaseReason` — "Dynamic config rollback failed on pods: …"
+- `phase=ConfigDegraded` plus repeating `ConfigDegradedSkip` Warning events
+- the operator log — phase-1 validation failure is logged only, with no event and no status write
+- a non-dynamic parameter: set `enableDynamicConfigUpdate: false` to force a rolling restart
 
 **Removing** a config key (not just changing it) always forces a rolling restart, even for an otherwise-dynamic param — "revert to server default" cannot be expressed as `set-config`.
 
@@ -103,7 +105,9 @@ Top-level statuses:
 
 If phase 2 apply AND rollback both fail, the cluster enters `phase=ConfigDegraded` and `ConditionDynamicConfigDegraded=True`. Reconciliation then **halts** — the operator skips every reconcile with a `ConfigDegradedSkip` Warning (requeue ~60s) until you intervene: revert the offending value in the spec, then cold-restart the pods / reset the phase. Do not toggle `enableDynamicConfigUpdate` or re-apply the change during this window.
 
-Example status snapshot of a partial rollback:
+Example status snapshot. Note that the pod where the change did not apply carries **no**
+`dynamicConfigChanges` entry — the operator never writes a failure value, so this is what a
+partial rollout actually looks like:
 
 ```yaml
 status:
@@ -113,10 +117,8 @@ status:
         - { path: service.proto-fd-max, oldValue: "15000", newValue: "20000", result: Applied }
     cluster-1-1:
       dynamicConfigChanges:
-        - { path: service.proto-fd-max, oldValue: "15000", newValue: "20000", result: RolledBack }
-    cluster-1-2:
-      dynamicConfigChanges:
-        - { path: service.proto-fd-max, oldValue: "15000", newValue: "20000", result: Failed }
+        - { path: service.proto-fd-max, oldValue: "15000", newValue: "20000", result: Applied }
+    cluster-1-2: {}          # no entry — this is the pod to investigate
 ```
 
 ### Batch Size

--- a/skills/acko-operations/reference/troubleshooting.md
+++ b/skills/acko-operations/reference/troubleshooting.md
@@ -19,7 +19,7 @@ Symptom-based diagnostic reference for ACKO Aerospike clusters.
 | Pod `CrashLoopBackOff` | `kubectl logs <pod> -c aerospike-server --previous` | Config parse error, OOM, invalid parameters | Check server logs, fix aerospikeConfig |
 | Webhook rejects CR (shape) | Read `kubectl apply` error output | Wrong YAML shape | `service`/`network` maps; `logging` a list; namespace entries maps with unique `name` |
 | Webhook rejects CR (CE constraint) | Read `kubectl apply` error output | size>8, namespaces>2, dup namespace, enterprise/`ce-<8` image, xdr/tls, enterprise logging context, scoped admin privilege, per-rack CE violation | Fix per `validation-rules.md` |
-| `dynamicConfigStatus=Failed` | `kubectl get asc <name> -o jsonpath='{.status.pods}' \| jq '.[].dynamicConfigStatus'` | Parameter is not dynamically changeable | Set `enableDynamicConfigUpdate: false` to force rolling restart |
+| Dynamic config change did not take effect (no `dynamicConfigStatus` on the pod) | `kubectl get asc <name> -o jsonpath='{.status.conditions[?(@.type=="DynamicConfigDegraded")]}' \| jq` then the operator log | Parameter is not dynamically changeable, or phase-1 validation rejected it (logged only, no event) | Set `enableDynamicConfigUpdate: false` to force a rolling restart |
 | `ReadinessGateBlocking` | `kubectl get pod <pod> -o jsonpath='{.status.conditions}' \| jq '.[]'` | Readiness gate not satisfied | Check if Aerospike server is healthy inside the pod |
 
 ---


### PR DESCRIPTION
## Problem

The marquee dynamic-config troubleshooting flow could not produce a result. Seven files across four skills told the reader to inspect `status.pods[*].dynamicConfigChanges[].result` and `status.pods[].dynamicConfigStatus` to find which change `Failed`, was `RolledBack`, or is `Pending`. **The operator writes none of those values.**

Verified against operator `origin/main` (`1612083`):

```
$ grep -rn 'Result:' --include='*.go' internal/controller/ | grep -v _test
internal/controller/reconciler_dynamic_config.go:515:   Result:   "Applied",

$ grep -rn 'updateDynamicConfigStatus(ctx' --include='*.go' internal/controller/ | grep -v _test
internal/controller/reconciler_dynamic_config.go:228:   r.updateDynamicConfigStatus(ctx, cluster, t.pod.Name, "Applied")

$ grep -rn '"RolledBack"\|"Pending"\|"Failed"' internal/controller/reconciler_dynamic_config.go
(no output)
```

`:515` is the sole writer of `result` and is reached only on the success path. `:228` is the sole call site of `updateDynamicConfigStatus`. `Failed`, `RolledBack` and `RollbackFailed` exist **only** in the API doc-comment (`aerospikecluster_types.go:529`) and are never assigned — and `Pending` is not even in that list, yet four files documented it as a value to look for.

So a change that did not apply leaves **no entry at all**. Absence is the signal, not a status string. In practice Claude runs the documented jsonpath, reads `Applied` or empty output, and has nowhere to go — while the real signal sits unmentioned in the failure branch.

Two files went further and printed **fabricated** YAML depicting states the operator never writes:

```yaml
cluster-1-1:
  dynamicConfigChanges:
    - { path: service.proto-fd-max, ..., result: RolledBack }   # never written
cluster-1-2:
  dynamicConfigChanges:
    - { path: service.proto-fd-max, ..., result: Failed }       # never written
```

## Fix

Every site now states that `Applied` is the only value ever written, and routes failure diagnosis to what the operator actually produces:

- `DynamicConfigDegraded` condition, reason `RollbackFailed` (`reconciler_status.go:800-801`)
- `status.phaseReason` — "Dynamic config rollback failed on pods: …"
- `phase=ConfigDegraded` with repeating `ConfigDegradedSkip` Warning events
- the operator log — **phase-1 validation failure is logged only**, with no event and no status write, which the pages now say explicitly
- a non-dynamic parameter → `enableDynamicConfigUpdate: false` to force a rolling restart

The fabricated snapshots are replaced with what a partial rollout actually looks like — the pod to investigate is the one carrying *no* entry.

**One more phantom found while verifying:** `conditions-and-phases.md` listed the `DynamicConfigDegraded` reasons as `RollbackFailed, ApplyFailed`. `"ApplyFailed"` has **zero** hits in the operator; `reconciler_status.go:800-801` is the sole setter and `RollbackFailed` is its only reason.

`evals/evals.json` case #7 already asserts the `DynamicConfigDegraded` condition as the primary signal, so it needed no change — the skills were the half that disagreed with it.

## Verification

Source-side greps are quoted above. Skill-side, no claim of a non-`Applied` result value survives except the new explanatory text:

```
$ grep -rn 'result: Failed\|result: RolledBack\|dynamicConfigStatus=Failed\|ApplyFailed' skills/
(no output)
```

`claude plugin validate .` → `✔ Validation passed`.

I also ran the claim checker from #106 against this branch. It reports only the items **#106 itself fixes** (`status.operation.*` and five phantom event reasons), which is expected — this branch is cut from `main`, which does not yet have #106. Nothing in this PR regresses it.

**Not verified:** no live cluster, so no dynamic-config failure was actually triggered to observe the resulting status. Every claim here is read from operator source at `1612083`.

## Risk

Low — documentation only. The behavioural change is that Claude stops looking for status values that are never written and reads the condition instead, which is what eval #7 already expects.

**Ordering note:** this PR does not touch `acko-operations/reference/events.md`, which still lists `DynamicConfigRollbackFailed` and friends. Those are fixed in **#106**; I deliberately left them alone to avoid a conflict. The two PRs are independent and can merge in either order.

Closes #92
Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
