### PR TITLE
fix(skills): correct three aerospike-py claims that source contradicts

### DIFF
--- a/skills/aerospike-py-api/reference/health.md
+++ b/skills/aerospike-py-api/reference/health.md
@@ -61,4 +61,6 @@ If the cluster has gone fully unreachable but the tend interval has not yet elap
 
 ## Tuning timeouts
 
-`ping()` honors the client's default operation timeouts. To bound probe latency tightly, configure the client with a short `operation_queue_timeout_ms` and a short `total_timeout` policy. A failed `ping()` typically returns within a few hundred milliseconds; readiness probes with `periodSeconds: 5` give the client time to recover from a transient blip without flapping out of the Service.
+**`ping()` is not tunable.** `do_ping` (`rust/src/client_ops.rs:525-532`) picks a random node and calls `node.info(&AdminPolicy::default(), &["build"])` — the policy is constructed inline, so neither `operation_queue_timeout_ms` nor any `total_timeout` policy reaches it, and no limiter permit is acquired. Its bound is the `AdminPolicy` default: the field is `0`, which `AdminPolicy::timeout()` substitutes with **3000 ms**.
+
+Size readiness probes around that 3 s ceiling rather than trying to shorten it — `periodSeconds: 5` with a `timeoutSeconds` above 3 gives the client room to ride out a transient blip without flapping out of the Service. To bound probe latency more tightly than 3 s, use a real read against a known key instead of `ping()`.

--- a/skills/aerospike-py-api/reference/observability.md
+++ b/skills/aerospike-py-api/reference/observability.md
@@ -49,7 +49,7 @@ Operation-level metrics collected in Rust, exposed in Prometheus text format. Me
 
 Histogram. Labels: `db_system_name` (always `aerospike`), `db_namespace`, `db_collection_name`, `db_operation_name`, `error_type` (empty on success, exception name on failure). Buckets: `0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0` seconds.
 
-Instrumented operations: `put`, `get`, `select`, `exists`, `remove`, `touch`, `append`, `prepend`, `increment`, `operate`, `batch_read`, `batch_operate`, `batch_remove`, `batch_write`, `query`. (`exists()` treats `KeyNotFoundError` as success.)
+Instrumented operations: `put`, `get`, `select`, `exists`, `delete`, `touch`, `append`, `prepend`, `increment`, `operate`, `batch_read`, `batch_operate`, `batch_remove`, `batch_write`, `query`. (`exists()` treats `KeyNotFoundError` as success.)
 
 ### Example output
 

--- a/skills/aerospike-py-api/reference/write.md
+++ b/skills/aerospike-py-api/reference/write.md
@@ -676,4 +676,6 @@ results = await async_client.batch_write_numpy(data, "test", "demo", dtype, retr
 results = client.batch_write_numpy(data, "test", "demo", dtype, key_field="user_id")
 ```
 
-A custom `key_field` not starting with `_` is **also** stored as a bin. Round-trip read: `client.batch_read(keys, policy={"key": aerospike.POLICY_KEY_SEND}).to_numpy(read_dtype)`. Keep batches at 100–5,000 rows; chunk larger datasets.
+The `key_field` is **not** stored as a bin — `numpy_to_records` filters it out when building the bin list (`rust/src/numpy_support.rs:1084`: `.filter(|f| f.name != key_field && !f.name.starts_with('_'))`), so it is consumed as the user key and nothing else. If you need the value readable as data, add a second dtype field carrying a copy.
+
+Round-trip read: `client.batch_read(keys).to_numpy(read_dtype)`. Do **not** pass `policy={"key": POLICY_KEY_SEND}` — `batch_read` ignores it. Neither `parse_batch_policy` nor `parse_batch_read_policy` reads a `key` entry (`rust/src/policy/batch_policy.rs`), so the option is silently dropped rather than rejected, and the keys are not returned. Keep batches at 100–5,000 rows; chunk larger datasets.


### PR DESCRIPTION
## Problem

Three claims in the `aerospike-py-api` reference that the source contradicts. All verified against aerospike-py `origin/main` (`5db458d`), which pins `aerospike-core 2.0.0`.

### 1. `observability.md:52` — instrumented op is `delete`, not `remove`

The file lists the instrumented operations users should graph. The label emitted is `delete`:

```
$ grep -rn '"remove"\|"delete"' rust/src/client_ops.rs
rust/src/client_ops.rs:100:        "delete",
```

Any PromQL written against `remove` matches nothing and returns no data — a silent failure in the one file whose whole job is telling users what to graph.

### 2. `write.md:679` — the `key_field` claim is backwards, and its round-trip recipe is a no-op

Documented: "A custom `key_field` not starting with `_` is **also** stored as a bin."

`numpy_to_records` filters it **out** when building the bin list (`rust/src/numpy_support.rs:1084`):

```rust
.filter(|f| f.name != key_field && !f.name.starts_with('_'))
```

So the field is consumed as the user key and written nowhere else. A reader following the old text expects a bin that does not exist.

The same line's round-trip recipe passes `policy={"key": aerospike.POLICY_KEY_SEND}` to `batch_read`. Neither policy parser reads a `key` entry:

```
$ sed -n '/pub fn parse_batch_policy/,/^}/p' rust/src/policy/batch_policy.rs | grep -oE '"[a-z_]+"' | sort -u
"allow_inline" "allow_inline_ssd" "concurrency" "max_retries" "read_mode_ap" "read_touch_ttl_percent"
"replica" "respond_all_keys" "sleep_between_retries" "socket_timeout" "timeout_delay" "total_timeout"

$ sed -n '/pub fn parse_batch_read_policy/,/^}/p' rust/src/policy/batch_policy.rs | grep -oE 'get_item\("[a-z_]+"\)'
get_item("read_touch_ttl_percent")
```

The dict entry is **dropped rather than rejected** — no error, no keys returned.

### 3. `health.md:64` — the `ping()` tuning knobs are both inert

Documented: tune probe latency with a short `operation_queue_timeout_ms` and a short `total_timeout` policy.

`do_ping` (`rust/src/client_ops.rs:525-532`) takes no policy at all:

```rust
pub async fn do_ping(client: &AsClient) -> bool {
    let node = match client.cluster.get_random_node() { Ok(n) => n, Err(_) => return false };
    let policy = aerospike_core::AdminPolicy::default();
    node.info(&policy, &["build"]).await.is_ok()
}
```

The policy is constructed inline, so no caller setting reaches it, and no limiter permit is acquired (so the queue timeout is irrelevant by construction). Its real bound is the `AdminPolicy` default — field `0`, which `AdminPolicy::timeout()` substitutes with **3000 ms**.

## Fix

- `remove` → `delete`.
- State that `key_field` is *not* stored as a bin, cite the filter, and give the workaround (carry a second dtype field if the value must be readable as data). Drop the no-op policy from the round-trip recipe and say explicitly that `batch_read` ignores it.
- Replace the inert tuning advice with the real 3 s ceiling, sizing probes around it, and note that a real read against a known key is how to bound probe latency more tightly than `ping()` allows.

## Verification

Every source line is quoted above. Skill-side:

```
$ sed -n '52p' skills/aerospike-py-api/reference/observability.md
Instrumented operations: `put`, `get`, `select`, `exists`, `delete`, `touch`, ...
```

`claude plugin validate .` → `✔ Validation passed`.

**Not verified:** I did not run these against a live Aerospike server — `aerospike_py` is not installed in this environment and the claims are about which code paths exist, not about runtime values. Each is read from source at `5db458d`.

## Risk

Low — documentation only, three files, no executable plugin code. Each change replaces an instruction that currently fails silently (empty PromQL result, a missing bin, a tuning knob with no effect) with one that matches the source.

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
