### PR TITLE
feat(ci): verify skill claims against pinned source checkouts

### DIFF
--- a/.github/workflows/claim-check.yml
+++ b/.github/workflows/claim-check.yml
@@ -1,0 +1,88 @@
+name: Claim Check
+
+# Verifies that the factual claims in skills/ still match the source repos the
+# skills document. See tools/claim-check/README.md for what this proves and,
+# just as importantly, what it does not.
+
+on:
+  pull_request:
+    paths:
+      - "skills/**"
+      - "tools/claim-check/**"
+      - ".github/workflows/claim-check.yml"
+  schedule:
+    # Weekly, Monday 05:00 UTC — an hour before the link check. The scheduled
+    # run is what catches drift introduced by a change in a *source* repo,
+    # which no PR here would touch.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  claim-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: python -m pip install --quiet pyyaml
+
+      - name: Cache source checkouts
+        uses: actions/cache@v4
+        with:
+          path: .claim-check-cache
+          # Keyed on sources.json: a ref bump must re-clone rather than reuse a
+          # checkout of the previous commit, which would verify against the
+          # wrong source and pass for the wrong reason.
+          key: claim-check-${{ hashFiles('tools/claim-check/sources.json') }}
+
+      - name: Self-test the checker
+        # A verifier that accepts everything is indistinguishable from a
+        # passing rule. This asserts each rule still rejects a known-false
+        # claim before any of them are trusted below.
+        env:
+          CLAIM_CHECK_CACHE: .claim-check-cache
+        run: python3 tools/claim-check/selftest.py
+
+      - name: Verify skill claims against source
+        env:
+          CLAIM_CHECK_CACHE: .claim-check-cache
+        # --strict fails the job when a source repo could not be cloned, so a
+        # network problem cannot look like a clean run.
+        run: python3 tools/claim-check/check_claims.py --strict --coverage
+
+      - name: Machine-readable report
+        if: always()
+        env:
+          CLAIM_CHECK_CACHE: .claim-check-cache
+        run: |
+          python3 tools/claim-check/check_claims.py --json > claim-check.json || true
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, pathlib
+          d = json.loads(pathlib.Path("claim-check.json").read_text())
+          t = d["totals"]
+          print(f"### claim-check\n")
+          print(f"`{t['checked']}` claims checked · "
+                f"`{t['failed']}` failed · `{t['skipped']}` unverifiable\n")
+          print("| rule | checked | failed |")
+          print("|---|--:|--:|")
+          for r in d["rules"]:
+              print(f"| `{r['rule']}` | {r['checked']} | {len(r['failures'])} |")
+          print(f"\nrefs: " + ", ".join(f"`{k}@{v}`" for k, v in d["refs"].items()))
+          PY
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claim-check-report
+          path: claim-check.json
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# claim-check writes its report and its source checkouts here
+claim-check.json
+.claim-check-cache/
+
+# Python bytecode from tools/
+__pycache__/
+*.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Per-release notes are also auto-published to [GitHub Releases](https://github.co
 
 ## [Unreleased]
 
+### Added
+
+- `tools/claim-check` — a CI check that extracts factual claims from `skills/` and verifies them against pinned checkouts of the three source repos, plus a `Claim Check` workflow that runs it on every PR touching `skills/` and weekly on a schedule. Fourteen rules cover webhook error strings, CRD field paths, event reasons, phases, conditions, the dynamic-parameter allowlist, Helm values keys, `acko.io`/`aerospike.io` label keys, `aerospike-py` constant name+value pairs, client methods and exception classes, and the `ackoctl` cobra command tree and flags. It is syntactic, not semantic: it catches renames, typos and invented identifiers, and cannot tell you whether a documented procedure works. Coverage and its limits are stated in `tools/claim-check/README.md`; `--coverage` prints the figure on every run.
+
 ### Changed
 
 - The `aerospike-py-api` skill now documents the `.result_code: int` attribute on Aerospike exceptions. Server errors carry the actual wire code, such as `FailForbidden`=22, while client-side errors use the `-1` `CLIENT_SIDE_RESULT_CODE` sentinel. Applications can use this structured value instead of parsing error messages (aerospike-py ADR-0027, PR #413).

--- a/tools/claim-check/README.md
+++ b/tools/claim-check/README.md
@@ -1,0 +1,143 @@
+# claim-check
+
+Verifies factual claims in `skills/` against the source repositories those
+skills document. Runs in CI on every PR and blocks merge on a failure.
+
+```bash
+# clone the pinned refs and check everything
+python3 tools/claim-check/check_claims.py
+
+# reuse checkouts you already have
+CLAIM_CHECK_SRC_ACKO=~/src/aerospike-ce-kubernetes-operator \
+CLAIM_CHECK_SRC_AEROSPIKE_PY=~/src/aerospike-py \
+CLAIM_CHECK_SRC_ACKOCTL=~/src/ackoctl \
+  python3 tools/claim-check/check_claims.py --offline --coverage
+
+# one rule at a time while you are fixing something
+python3 tools/claim-check/check_claims.py --rule acko-error-strings
+```
+
+Requires Python 3.10+ and PyYAML. Exit status is 1 when any claim fails.
+
+## What it actually proves — read this before trusting a green run
+
+**It is syntactic.** Each rule asks "does this string appear where it would
+have to appear if the claim were true". That catches renames, typos, and
+identifiers that never existed. It does not compile anything, does not run the
+operator, and cannot tell you whether a documented *procedure* works.
+
+A green run means: the identifiers, error strings, CRD paths, constant values,
+CLI verbs and flags that the rules extract all still exist in source at the
+pinned refs. It does not mean the skills are correct.
+
+**Coverage is partial, and the tool tells you how partial.** `--coverage`
+prints how many claims the rules extracted against the total number of
+backticked spans across `skills/`. The current figure is around 27%. That
+denominator is deliberately unflattering — it counts every backticked span,
+including prose emphasis and shell fragments that are not factual claims at
+all — so the real proportion of *claims* covered is higher than the number
+shown. Treat it as a floor.
+
+**What is definitely not covered:**
+
+- Prose. "Removing a key always forces a rolling restart" is a claim about
+  behaviour with no identifier to match; nothing here checks it.
+- Semantics of any kind: argument order, whether an example would run,
+  whether a documented default is the one a user actually gets after the
+  wrapper layer has had its say.
+- Whether a command that exists does what the docs say it does.
+- Anything in the three source repos that the skills *should* document but
+  don't. This finds wrong claims, never missing ones.
+
+Every past defect class this tool would have caught is listed at the bottom.
+Anything not on that list, it would have missed.
+
+**A false positive is worse than a miss.** Reporting correct documentation as
+drift costs a reviewer's time and, repeated, teaches everyone to skim past the
+check — after which it may as well not exist. Three rules carry extra logic for
+exactly this reason, and the same care applies to any rule you add:
+
+- `acko-helm-values` attributes each `--set` to the chart of the enclosing
+  `helm install`. A page that installs cert-manager first has `--set
+  crds.enabled=true` on it, which is a real cert-manager value and absent from
+  ACKO's chart.
+- `ackoctl-flags` skips comment lines inside code fences, because a comment
+  saying a flag does *not* exist would otherwise be read as a claim that it
+  does.
+- `acko-event-reasons` and friends read markdown *data* rows only, never the
+  header — otherwise "Phase" and "Type" get checked as if they were claims.
+
+When a rule fires on something correct, fix the rule. Do not add the claim to
+`ignore` unless it is genuinely unverifiable, and say why in a comment.
+
+## Rules
+
+| id | source | what it checks |
+|---|---|---|
+| `acko-error-strings` | operator | Every quoted webhook message in the reference catalog, run by run, against Go string literals |
+| `acko-crd-paths` | operator | `spec.*` / `status.*` paths resolve in the generated CRD schema |
+| `acko-event-reasons` | operator | Event reasons are defined in `internal/controller/events.go` |
+| `acko-phases` | operator | Phase names are `AerospikePhase` constants |
+| `acko-conditions` | operator | Condition types, by value or by Go constant name |
+| `acko-dynamic-params` | operator | Params documented `Dynamic=Yes` are in `dynamic_params.go` |
+| `acko-helm-values` | operator | `--set key=` keys exist in the chart's `values.yaml` |
+| `acko-label-keys` | operator | `acko.io/…` and `aerospike.io/…` keys exist in operator source |
+| `apy-constant-values` | aerospike-py | Constant **name and value** match what PyO3 registers |
+| `apy-constant-names` | aerospike-py | Referenced constants are registered on the module |
+| `apy-client-methods` | aerospike-py | `client.foo(...)` exists on `Client`/`AsyncClient` in the stubs |
+| `apy-exceptions` | aerospike-py | Exception classes are defined |
+| `ackoctl-commands` | ackoctl | `ackoctl <noun> <verb>` resolves in the cobra command tree |
+| `ackoctl-flags` | ackoctl | Long flags in `ackoctl` invocations are registered |
+
+## Pinned refs
+
+`sources.json` pins the commit of each source repo. **Bumping a ref is a
+claim**: it says the skills were checked against that commit and passed. Bump
+it only alongside a passing run, never as routine maintenance — a ref moved
+forward without a check turns this tool into decoration.
+
+## Adding a rule
+
+A rule is an extractor plus a verifier. The extractor pulls candidate claims
+out of markdown; the verifier decides whether an index confirms one.
+
+1. Add whatever index the verifier needs to `indexes.py`.
+2. Add the `Rule(...)` to `RULES` in `rules.py`.
+3. **Add a case to `CASES` in `selftest.py`** — one claim that must verify and
+   one that must not. `selftest.py` fails if any rule lacks a case, because a
+   verifier that returns `True` for everything looks exactly like a passing
+   rule, which is the failure mode this whole tool exists to prevent.
+
+Run `python3 tools/claim-check/selftest.py` before opening the PR.
+
+## Placeholder convention
+
+Error-message rules split a documented message on placeholder tokens and
+require each remaining literal run of 12+ characters to appear in source. The
+placeholders are `N M T S KEY MIN ID FIELD v i j k`, anything in quotes,
+`<angle brackets>`, `...`, and bare digits. This mirrors the convention
+documented at the top of
+`skills/acko-operations/reference/validation-rules.md`; if you change one,
+change the other.
+
+## Defect classes this would have caught
+
+From the drift audit in issue #97, with the rule that catches each:
+
+- `aerospike.io/cr-name` — a label selector that never existed, in 12 places
+  (`acko-label-keys`)
+- Five more never-existed identifiers (`acko-event-reasons`,
+  `acko-crd-paths`, `ackoctl-commands`)
+- `k8s pod logs` → `k8s cluster logs`, and `udf register` → `udf upload`
+  (`ackoctl-commands`)
+- `--namespace`/`--set` → `--name`/`--param` on `configure-namespace`
+  (`ackoctl-flags`)
+- The phantom `DynamicConfigRecovered` event (`acko-event-reasons`)
+- `max-record-size` / `evict-used-pct` / `evict-tenths-pct` documented as
+  dynamic (`acko-dynamic-params`)
+- Webhook error strings that are not substrings of the real message
+  (`acko-error-strings`)
+
+It would **not** have caught the FastAPI `JSONResponse` argument-order bug,
+the reversed NumPy `key_field` round-trip, or the no-op `ping()` tuning knobs.
+Those are semantic, and they need a human or a test.

--- a/tools/claim-check/check_claims.py
+++ b/tools/claim-check/check_claims.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Verify factual claims in the skills against the source repos they document.
+
+    python3 tools/claim-check/check_claims.py            # clone pinned refs, check
+    python3 tools/claim-check/check_claims.py --coverage # add the coverage report
+    python3 tools/claim-check/check_claims.py --json     # machine-readable
+
+Exit status is 1 if any claim fails, 0 otherwise. A rule whose source repo is
+unavailable is reported as SKIPPED and does **not** pass silently -- with
+--strict, an unavailable source is an error instead.
+
+What this does and does not prove is documented in README.md next to this file.
+Read it before trusting a green run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+
+sys.path.insert(0, str(HERE))
+
+import indexes  # noqa: E402
+import rules as rulesmod  # noqa: E402
+
+
+def resolve_checkouts(config: dict, cache: Path, offline: bool) -> dict[str, Path]:
+    """Return {source key: checkout path}, cloning pinned refs when needed."""
+    out: dict[str, Path] = {}
+    for key, spec in config["sources"].items():
+        override = os.environ.get(f"CLAIM_CHECK_SRC_{key.upper()}")
+        if override:
+            path = Path(override).expanduser().resolve()
+            if path.is_dir():
+                out[key] = path
+                continue
+            print(f"warning: CLAIM_CHECK_SRC_{key.upper()}={path} is not a directory",
+                  file=sys.stderr)
+        if offline:
+            continue
+        dest = cache / key
+        try:
+            if not dest.exists():
+                subprocess.run(
+                    ["git", "clone", "--quiet", "--filter=blob:none",
+                     spec["repo"], str(dest)],
+                    check=True, capture_output=True,
+                )
+            subprocess.run(["git", "-C", str(dest), "fetch", "--quiet", "origin",
+                            spec["ref"]], check=False, capture_output=True)
+            subprocess.run(["git", "-C", str(dest), "checkout", "--quiet",
+                            spec["ref"]], check=True, capture_output=True)
+            out[key] = dest
+        except (subprocess.CalledProcessError, OSError) as exc:
+            print(f"warning: could not prepare {key} at {spec['ref']}: {exc}",
+                  file=sys.stderr)
+    return out
+
+
+def iter_files(globs: tuple[str, ...]) -> list[Path]:
+    seen: dict[Path, None] = {}
+    for g in globs:
+        for p in sorted(REPO.glob(g)):
+            if p.is_file():
+                seen.setdefault(p, None)
+    return list(seen)
+
+
+def run(sources, only: str | None):
+    results = []
+    for rule in rulesmod.RULES:
+        if only and rule.id != only:
+            continue
+        index = sources.get(rule.source)
+        entry = {
+            "rule": rule.id,
+            "description": rule.description,
+            "source": rule.source,
+            "status": "ok",
+            "checked": 0,
+            "skipped": 0,
+            "failures": [],
+        }
+        if index is None:
+            entry["status"] = "skipped-no-source"
+            results.append(entry)
+            continue
+
+        for path in iter_files(rule.globs):
+            rel = path.relative_to(REPO).as_posix()
+            text = path.read_text(errors="replace")
+            for line_no, claim, detail in rule.extract(text):
+                if claim in rule.ignore:
+                    entry["skipped"] += 1
+                    continue
+                if rule.id == "acko-error-strings" and not rulesmod._checkable_message(claim):
+                    entry["skipped"] += 1
+                    continue
+                entry["checked"] += 1
+                try:
+                    ok = rule.verify(index, claim)
+                except Exception as exc:  # a broken rule must not look like a pass
+                    entry["status"] = "error"
+                    entry["failures"].append(
+                        {"file": rel, "line": line_no, "claim": claim,
+                         "detail": f"rule raised {exc!r}"}
+                    )
+                    continue
+                if not ok:
+                    entry["failures"].append(
+                        {"file": rel, "line": line_no, "claim": claim,
+                         "detail": detail}
+                    )
+        if entry["failures"] and entry["status"] == "ok":
+            entry["status"] = "failed"
+        results.append(entry)
+    return results
+
+
+def coverage_report() -> dict:
+    """How much of the skills' backticked content any rule even looks at.
+
+    This is the honest denominator: total backticked spans across every skill
+    file, versus the spans some rule extracted. It intentionally over-counts the
+    denominator -- plenty of backticked text is prose formatting, not a claim --
+    so treat the percentage as a floor on coverage, not a grade.
+    """
+    import re
+
+    total = 0
+    per_file: dict[str, int] = {}
+    for p in sorted((REPO / "skills").rglob("*.md")):
+        n = len(re.findall(r"`[^`\n]+`", p.read_text(errors="replace")))
+        total += n
+        per_file[p.relative_to(REPO).as_posix()] = n
+    return {"backticked_spans_total": total, "per_file": per_file}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--json", action="store_true", help="emit JSON")
+    ap.add_argument("--coverage", action="store_true",
+                    help="also report how much of the skills the rules look at")
+    ap.add_argument("--offline", action="store_true",
+                    help="never clone; use CLAIM_CHECK_SRC_* checkouts only")
+    ap.add_argument("--strict", action="store_true",
+                    help="treat an unavailable source repo as a failure")
+    ap.add_argument("--rule", help="run a single rule by id")
+    ap.add_argument("--cache", default=os.environ.get("CLAIM_CHECK_CACHE"),
+                    help="directory to clone source repos into")
+    args = ap.parse_args()
+
+    config = json.loads((HERE / "sources.json").read_text())
+
+    tmp = None
+    if args.cache:
+        cache = Path(args.cache).expanduser()
+        cache.mkdir(parents=True, exist_ok=True)
+    else:
+        tmp = tempfile.TemporaryDirectory(prefix="claim-check-")
+        cache = Path(tmp.name)
+
+    try:
+        checkouts = resolve_checkouts(config, cache, args.offline)
+        sources = indexes.load_sources(HERE / "sources.json", checkouts)
+        results = run(sources, args.rule)
+    finally:
+        if tmp is not None:
+            tmp.cleanup()
+
+    checked = sum(r["checked"] for r in results)
+    skipped = sum(r["skipped"] for r in results)
+    failed = sum(len(r["failures"]) for r in results)
+    no_source = [r["rule"] for r in results if r["status"] == "skipped-no-source"]
+
+    payload = {
+        "refs": {k: v["ref"] for k, v in config["sources"].items()},
+        "sources_available": sorted(sources),
+        "totals": {"checked": checked, "skipped": skipped, "failed": failed},
+        "rules": results,
+    }
+    if args.coverage:
+        payload["coverage"] = coverage_report()
+        payload["coverage"]["claims_extracted"] = checked + skipped
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"claim-check — {checked} claims checked, {failed} failed, "
+              f"{skipped} skipped as unverifiable\n")
+        for r in results:
+            mark = {"ok": "PASS", "failed": "FAIL", "error": "ERROR",
+                    "skipped-no-source": "SKIP"}[r["status"]]
+            print(f"[{mark}] {r['rule']:<24} {r['checked']:>4} checked  "
+                  f"{len(r['failures']):>3} failed   ({r['source']})")
+            for f in r["failures"]:
+                extra = f" — {f['detail']}" if f["detail"] else ""
+                print(f"         {f['file']}:{f['line']}: {f['claim']}{extra}")
+        if no_source:
+            print(f"\nno source checkout for: {', '.join(no_source)}")
+        if args.coverage:
+            cov = payload["coverage"]
+            spans = cov["backticked_spans_total"]
+            pct = 100.0 * (checked + skipped) / spans if spans else 0.0
+            print(f"\ncoverage: {checked + skipped} claims extracted from "
+                  f"{spans} backticked spans across skills/ ({pct:.1f}%).")
+            print("That percentage is a floor, not a grade: the denominator "
+                  "counts every backticked span,\nincluding prose formatting "
+                  "that is not a factual claim at all. See README.md.")
+
+    if failed:
+        return 1
+    if args.strict and no_source:
+        return 1
+    if any(r["status"] == "error" for r in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/claim-check/indexes.py
+++ b/tools/claim-check/indexes.py
@@ -1,0 +1,438 @@
+"""Searchable indexes built from the source repositories the skills document.
+
+Each index is a set (or dict) of facts read out of source, so a rule can ask
+"is this identifier real?" without knowing anything about Go, Rust or cobra.
+
+Everything here is deliberately syntactic. There is no compiler and no test
+run: an index answers "does this string appear where it would have to appear
+if the claim were true", which catches renames, typos and inventions, and does
+not catch semantics. Rules that need semantics are out of scope by design --
+see README.md.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from functools import cached_property
+from pathlib import Path
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_GO_STR = re.compile(r'"((?:[^"\\\n]|\\.)*)"')
+# Go concatenates adjacent literals across lines: `"a " +\n  "b"`. Fold those
+# before extracting so a message split over three lines is indexed as one.
+_GO_CONCAT = re.compile(r'"\s*\+\s*\n?\s*"')
+_GO_CONST = re.compile(
+    r'^\s*(?:const\s+)?([A-Z]\w*)\s+(?:[\w.]+\s*)?=\s*"([^"]*)"', re.M
+)
+_JSON_TAG = re.compile(r'json:"([^",]+)')
+_RUST_CONST = re.compile(
+    r'^\s*pub const ([A-Z][A-Z0-9_]*)\s*:\s*[\w:<>&\[\] ]+\s*=\s*(.+?);', re.M
+)
+# What PyO3 actually registers on the module: `m.add("NAME", 1)?;`
+_PYO3_ADD = re.compile(r'\bm\.add\(\s*"([A-Z][A-Z0-9_]*)"\s*,\s*([^)]+?)\s*\)')
+# What the type stub advertises: `NAME: Literal[1]`
+_PYI_LITERAL = re.compile(
+    r'^([A-Z][A-Z0-9_]*)\s*:\s*(?:Final\[)?Literal\[\s*(-?\d+)\s*\]', re.M
+)
+_PY_DEF = re.compile(r'^\s*(?:async\s+)?def\s+(\w+)', re.M)
+_PY_CLASS = re.compile(r'^\s*class\s+(\w+)', re.M)
+_PY_ASSIGN = re.compile(r'^([A-Za-z_]\w*)\s*[:=]', re.M)
+_COBRA_USE = re.compile(r'Use:\s*"([^"\s]+)')
+# Any pflag registrar: .StringVar, .BoolVarP, .StringArrayVar, .IntSliceVarP, …
+_COBRA_FLAG = re.compile(
+    r'\.[A-Z]\w*Var P?\(\s*&[\w.\[\]()]+\s*,\s*"([a-zA-Z0-9][\w-]*)"'.replace(" ", "")
+)
+_GO_FUNC = re.compile(r'^func\s+(\w+)\s*\(', re.M)
+_ADD_CHILD = re.compile(r'\b(new\w*Cmd)\s*\(')
+
+
+def _is_test(path: Path) -> bool:
+    n = path.name
+    return n.endswith("_test.go") or n.endswith("_test.rs") or "/tests/" in str(path)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return ""
+
+
+def _walk_schema(node, prefix: str, out: set[str]) -> None:
+    """Collect every dotted path in a CRD openAPIV3Schema."""
+    if not isinstance(node, dict):
+        return
+    for name, child in (node.get("properties") or {}).items():
+        path = f"{prefix}.{name}" if prefix else name
+        out.add(path)
+        _walk_schema(child, path, out)
+    items = node.get("items")
+    if isinstance(items, dict):
+        # List entries keep the parent path: `spec.racks.id` and
+        # `spec.racks[].id` and `spec.racks[0].id` all normalise to the same
+        # thing, so index the un-subscripted form and normalise on lookup.
+        _walk_schema(items, prefix, out)
+    if isinstance(node.get("additionalProperties"), dict):
+        _walk_schema(node["additionalProperties"], prefix, out)
+
+
+def _flatten_yaml(node, prefix: str, out: set[str]) -> None:
+    if isinstance(node, dict):
+        for k, v in node.items():
+            path = f"{prefix}.{k}" if prefix else str(k)
+            out.add(path)
+            _flatten_yaml(v, path, out)
+
+
+# ---------------------------------------------------------------------------
+# ACKO (aerospike-ce-kubernetes-operator)
+# ---------------------------------------------------------------------------
+
+
+class AckoIndex:
+    key = "acko"
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    @cached_property
+    def _go_files(self) -> list[Path]:
+        dirs = ["api", "internal", "cmd", "controllers"]
+        return [
+            p
+            for d in dirs
+            for p in (self.root / d).rglob("*.go")
+            if not _is_test(p)
+        ]
+
+    @cached_property
+    def go_strings(self) -> str:
+        """All Go string literals, newline-joined, with concatenations folded.
+
+        Kept as one blob rather than a set: webhook messages interpolate in the
+        middle (`"rack ID must be > 0, got %d (…)"`), so rules substring-match
+        literal runs rather than looking up whole messages.
+        """
+        parts = []
+        for p in self._go_files:
+            text = _GO_CONCAT.sub("", _read(p))
+            parts.extend(m.group(1).replace('\\"', '"') for m in _GO_STR.finditer(text))
+        return "\n".join(parts)
+
+    @cached_property
+    def go_string_set(self) -> set[str]:
+        return set(self.go_strings.split("\n"))
+
+    @cached_property
+    def events(self) -> set[str]:
+        src = _read(self.root / "internal/controller/events.go")
+        return {m.group(2) for m in _GO_CONST.finditer(src)}
+
+    @cached_property
+    def phases(self) -> set[str]:
+        src = _read(self.root / "api/v1alpha1/aerospikecluster_types.go")
+        return {
+            m.group(2)
+            for m in _GO_CONST.finditer(src)
+            if m.group(1).startswith("AerospikePhase")
+        }
+
+    @cached_property
+    def conditions(self) -> set[str]:
+        """Condition types, by both their value and their Go constant name.
+
+        The reference pages cite both forms — `ConditionDynamicConfigDegraded`
+        when pointing at source, `DynamicConfigDegraded` when showing what
+        `kubectl` prints — and both are true statements about the operator.
+        """
+        src = _read(self.root / "api/v1alpha1/aerospikecluster_types.go")
+        out: set[str] = set()
+        for m in _GO_CONST.finditer(src):
+            if m.group(1).startswith("Condition"):
+                out.add(m.group(1))
+                out.add(m.group(2))
+        return out
+
+    @cached_property
+    def dynamic_params(self) -> set[str]:
+        src = _read(self.root / "internal/configdiff/dynamic_params.go")
+        return set(re.findall(r'^\s*"([\w.-]+)":\s*true', src, re.M))
+
+    @cached_property
+    def crd_paths(self) -> set[str]:
+        """Every dotted path in the AerospikeCluster / template CRD schemas."""
+        out: set[str] = set()
+        base = self.root / "config/crd/bases"
+        for f in sorted(base.glob("*.yaml")):
+            try:
+                doc = yaml.safe_load(_read(f))
+            except yaml.YAMLError:
+                continue
+            for version in (doc or {}).get("spec", {}).get("versions", []):
+                schema = version.get("schema", {}).get("openAPIV3Schema", {})
+                _walk_schema(schema, "", out)
+        return out
+
+    @cached_property
+    def helm_values(self) -> set[str]:
+        out: set[str] = set()
+        for f in self.root.rglob("charts/*/values.yaml"):
+            try:
+                _flatten_yaml(yaml.safe_load(_read(f)), "", out)
+            except yaml.YAMLError:
+                continue
+        return out
+
+    @cached_property
+    def label_keys(self) -> set[str]:
+        """Operator-owned label/annotation keys, plus the CR's apiVersion.
+
+        Deliberately scoped to the `acko.io` / `aerospike.io` domains. Upstream
+        keys (`app.kubernetes.io/*`, cloud-provider annotations) are not the
+        operator's to define, so asserting they appear in operator source would
+        produce noise, not signal — and the failure this rule exists to catch,
+        an invented `aerospike.io/...` selector that silently matches nothing,
+        lives entirely in those two domains.
+        """
+        keys = {
+            s
+            for s in re.findall(
+                r'(?<![\w./-])((?:acko|aerospike)\.io/[a-z0-9._-]+)', self.go_strings
+            )
+        }
+        src = _read(self.root / "api/v1alpha1/groupversion_info.go")
+        group = re.search(r'Group:\s*"([^"]+)"', src)
+        version = re.search(r'Version:\s*"([^"]+)"', src)
+        if group and version:
+            keys.add(f"{group.group(1)}/{version.group(1)}")
+        return keys
+
+
+# ---------------------------------------------------------------------------
+# aerospike-py
+# ---------------------------------------------------------------------------
+
+
+class AerospikePyIndex:
+    key = "aerospike_py"
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    @cached_property
+    def constants(self) -> dict[str, str]:
+        """Python-visible constant values.
+
+        Two sources, and they must agree: `m.add("NAME", value)?` is what PyO3
+        actually registers on the module, and `NAME: Literal[value]` in the type
+        stub is what a reader's editor shows. A disagreement between them is
+        itself a defect, so it is reported as an unknown value rather than
+        silently preferring one.
+        """
+        registered: dict[str, str] = {}
+        src = _read(self.root / "rust/src/constants.rs")
+        for m in _PYO3_ADD.finditer(src):
+            registered[m.group(1)] = m.group(2).strip().rstrip(",")
+        for m in _RUST_CONST.finditer(src):
+            registered.setdefault(m.group(1), m.group(2).strip().rstrip(","))
+
+        stub = _read(self.root / "src/aerospike_py/__init__.pyi")
+        for m in _PYI_LITERAL.finditer(stub):
+            name, val = m.group(1), m.group(2).strip()
+            if name in registered and registered[name] != val:
+                registered[name] = "<disagreement: rust=%s stub=%s>" % (
+                    registered[name], val)
+            else:
+                registered.setdefault(name, val)
+        return registered
+
+    @cached_property
+    def constant_names(self) -> set[str]:
+        return set(self.constants)
+
+    @cached_property
+    def _stub_files(self) -> list[Path]:
+        return sorted((self.root / "src/aerospike_py").rglob("*.pyi"))
+
+    @cached_property
+    def symbols(self) -> set[str]:
+        out: set[str] = set()
+        for p in self._stub_files:
+            src = _read(p)
+            out |= set(_PY_DEF.findall(src))
+            out |= set(_PY_CLASS.findall(src))
+            out |= set(_PY_ASSIGN.findall(src))
+        return out
+
+    @cached_property
+    def client_methods(self) -> set[str]:
+        """Methods on Client / AsyncClient in the type stubs."""
+        src = _read(self.root / "src/aerospike_py/__init__.pyi")
+        out: set[str] = set()
+        current = None
+        for line in src.splitlines():
+            cls = _PY_CLASS.match(line)
+            if cls:
+                current = cls.group(1)
+                continue
+            if current in ("Client", "AsyncClient"):
+                d = re.match(r'\s+(?:async\s+)?def\s+(\w+)', line)
+                if d:
+                    out.add(d.group(1))
+        return out
+
+    @cached_property
+    def exceptions(self) -> set[str]:
+        """Every exception class aerospike-py defines.
+
+        Not all of them end in `Error`: `RecordNotFound`, `RecordTooBig`,
+        `BinNotFound` and `FilteredOut` are classes too, so a suffix heuristic
+        would reject true claims about them.
+        """
+        out: set[str] = set()
+        stub = _read(self.root / "src/aerospike_py/exception.pyi")
+        out |= set(re.findall(r'^class\s+(\w+)\s*\(', stub, re.M))
+        rust = _read(self.root / "rust/src/errors.rs")
+        # create_exception!(module, Name, Base, "docstring");
+        out |= set(re.findall(r'create_exception!\(\s*[\w:]+\s*,\s*(\w+)', rust))
+        out |= set(re.findall(r'\b([A-Z]\w*(?:Error|Exception))\b', rust))
+        return out
+
+    @cached_property
+    def rust_strings(self) -> str:
+        parts = []
+        for p in (self.root / "rust/src").rglob("*.rs"):
+            if _is_test(p):
+                continue
+            parts.extend(m.group(1) for m in _GO_STR.finditer(_read(p)))
+        return "\n".join(parts)
+
+    @cached_property
+    def pytest_markers(self) -> set[str]:
+        src = _read(self.root / "pyproject.toml")
+        block = re.search(r'markers\s*=\s*\[(.*?)\]', src, re.S)
+        if not block:
+            return set()
+        return set(re.findall(r'"(\w+)\s*:', block.group(1)))
+
+
+# ---------------------------------------------------------------------------
+# ackoctl
+# ---------------------------------------------------------------------------
+
+
+class AckoctlIndex:
+    key = "ackoctl"
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    @cached_property
+    def _go_files(self) -> list[Path]:
+        return [p for p in self.root.rglob("*.go") if not _is_test(p)]
+
+    @cached_property
+    def _src(self) -> str:
+        return "\n".join(_read(p) for p in self._go_files)
+
+    @cached_property
+    def _funcs(self) -> dict[str, str]:
+        """Map each `func newXCmd(...)` to its body text."""
+        bodies: dict[str, str] = {}
+        for p in self._go_files:
+            src = _read(p)
+            marks = [(m.start(), m.group(1)) for m in _GO_FUNC.finditer(src)]
+            for i, (start, name) in enumerate(marks):
+                end = marks[i + 1][0] if i + 1 < len(marks) else len(src)
+                bodies[name] = src[start:end]
+        return bodies
+
+    @cached_property
+    def command_tree(self) -> dict[tuple[str, ...], set[str]]:
+        """Full cobra command tree, as {path: set of child tokens}.
+
+        Reconstructed from `Use:` strings plus `AddCommand(newXCmd(...))`
+        wiring. Knowing the tree — rather than a flat bag of verbs — is what
+        lets the rule tell `ackoctl config use-context kind-local` (valid, with
+        a context *name* as the argument) from a subcommand that does not
+        exist. A flat check calls `kind-local` a bad subcommand; a tree check
+        knows `use-context` is a leaf and stops.
+        """
+        tree: dict[tuple[str, ...], set[str]] = {}
+
+        def token_of(func: str) -> str | None:
+            body = self._funcs.get(func)
+            if not body:
+                return None
+            m = _COBRA_USE.search(body)
+            return m.group(1) if m else None
+
+        def walk(func: str, path: tuple[str, ...], seen: frozenset[str]) -> None:
+            if func in seen:
+                return
+            body = self._funcs.get(func)
+            if body is None:
+                return
+            children: set[str] = set()
+            for call in _ADD_CHILD.finditer(body):
+                child = call.group(1)
+                if child == func:
+                    continue
+                tok = token_of(child)
+                if tok:
+                    children.add(tok)
+            tree.setdefault(path, set()).update(children)
+            for call in _ADD_CHILD.finditer(body):
+                child = call.group(1)
+                tok = token_of(child)
+                if tok and child != func:
+                    walk(child, path + (tok,), seen | {func})
+
+        roots = [f for f in self._funcs if f in ("newRootCmd", "NewRootCmd")]
+        for r in roots:
+            walk(r, (), frozenset())
+        return tree
+
+    @cached_property
+    def commands(self) -> set[str]:
+        """Every command token anywhere in the tree (flat fallback)."""
+        flat = {t for children in self.command_tree.values() for t in children}
+        flat |= {u.split()[0] for u in _COBRA_USE.findall(self._src) if u.strip()}
+        return flat
+
+    @cached_property
+    def flags(self) -> set[str]:
+        return set(_COBRA_FLAG.findall(self._src))
+
+    @cached_property
+    def go_strings(self) -> str:
+        return "\n".join(m.group(1) for m in _GO_STR.finditer(self._src))
+
+    @cached_property
+    def rest_paths(self) -> set[str]:
+        return {s for s in self.go_strings.split("\n") if s.startswith("/api/")}
+
+
+# ---------------------------------------------------------------------------
+
+
+INDEX_CLASSES = {
+    "acko": AckoIndex,
+    "aerospike_py": AerospikePyIndex,
+    "ackoctl": AckoctlIndex,
+}
+
+
+def load_sources(config_path: Path, checkouts: dict[str, Path]):
+    config = json.loads(config_path.read_text())
+    out = {}
+    for key in config["sources"]:
+        if key in checkouts:
+            out[key] = INDEX_CLASSES[key](checkouts[key])
+    return out

--- a/tools/claim-check/rules.py
+++ b/tools/claim-check/rules.py
@@ -1,0 +1,537 @@
+"""Extraction rules: what counts as a checkable claim, and what proves it.
+
+A rule is (id, description, file glob, extractor, verifier). The extractor
+pulls candidate claims out of a markdown file; the verifier says whether an
+index confirms it. A rule that cannot find its index is reported as SKIPPED,
+never as passing.
+
+Adding a rule is the way to raise coverage. See README.md for the shape.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Iterator
+
+# A claim is (line number, the literal text, optional detail for the report).
+Claim = tuple[int, str, str]
+
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    description: str
+    globs: tuple[str, ...]
+    source: str  # index key this rule needs
+    extract: Callable[[str], Iterator[Claim]]
+    verify: Callable[[object, str], bool]
+    # Claims matching these are structurally unverifiable and are counted as
+    # skipped rather than failed (documented placeholders, mostly).
+    ignore: tuple[str, ...] = field(default=())
+
+
+# ---------------------------------------------------------------------------
+# shared extractors
+# ---------------------------------------------------------------------------
+
+
+def _lines(text: str):
+    return enumerate(text.splitlines(), 1)
+
+
+def _backticked(pattern: re.Pattern):
+    """Extract backticked spans whose whole content matches `pattern`."""
+
+    def extractor(text: str) -> Iterator[Claim]:
+        in_fence = False
+        for n, line in _lines(text):
+            if line.lstrip().startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            for m in re.finditer(r"`([^`\n]+)`", line):
+                s = m.group(1)
+                if pattern.fullmatch(s):
+                    yield (n, s, "")
+
+    return extractor
+
+
+# Placeholder tokens the reference pages use for interpolated values. Splitting
+# a documented message on these leaves the literal runs, which is what has to
+# appear in source. Keep this in sync with the "How the messages reach you"
+# note in acko-operations/reference/validation-rules.md.
+_PLACEHOLDER = re.compile(
+    r'%\w'                      # a raw Go verb, if one leaked into the docs
+    r'|\b(?:N|M|T|S|KEY|MIN|ID|FIELD|v|i|j|k)\b'
+    r'|\\"[^"]*\\"|"[^"]*"'     # any quoted sub-value
+    r'|<[^>]+>'                 # <inner CE error>
+    r'|\.\.\.'
+    r'|\d+'
+)
+_MIN_RUN = 12  # a run shorter than this matches too much to be evidence
+
+
+def _quoted_message(text: str) -> Iterator[Claim]:
+    """Backticked, double-quoted strings — the webhook error catalog shape."""
+    in_fence = False
+    for n, line in _lines(text):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for m in re.finditer(r'`"((?:[^"`\\]|\\.)*)"`', line):
+            yield (n, m.group(1).replace('\\"', '"'), "")
+
+
+def _message_runs(claim: str) -> list[str]:
+    return [r.strip() for r in _PLACEHOLDER.split(claim) if len(r.strip()) >= _MIN_RUN]
+
+
+def _verify_message(index, claim: str) -> bool:
+    runs = _message_runs(claim)
+    if not runs:
+        return True  # too templated to check; counted as skipped by the caller
+    return all(run in index.go_strings for run in runs)
+
+
+def _checkable_message(claim: str) -> bool:
+    return bool(_message_runs(claim))
+
+
+# ---------------------------------------------------------------------------
+# ACKO rules
+# ---------------------------------------------------------------------------
+
+_ACKO_GLOBS = (
+    "skills/acko-*/SKILL.md",
+    "skills/acko-*/reference/*.md",
+)
+
+
+def _crd_paths(text: str) -> Iterator[Claim]:
+    in_fence = False
+    for n, line in _lines(text):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for m in re.finditer(r"`((?:spec|status)\.[A-Za-z0-9_.\[\]-]+)`", line):
+            yield (n, m.group(1), "")
+
+
+def _normalise_crd_path(p: str) -> str:
+    p = re.sub(r"\[[^\]]*\]", "", p)          # racks[0] / racks[] -> racks
+    p = re.sub(r"\.(N|i|j|k)\b", "", p)       # racks.N -> racks
+    return p.rstrip(".")
+
+
+def _verify_crd_path(index, claim: str) -> bool:
+    return _normalise_crd_path(claim) in index.crd_paths
+
+
+_SEPARATOR = re.compile(r"^\s*\|[\s:\-|]+\|\s*$")
+
+
+def _table_rows(text: str) -> Iterator[tuple[int, list[str]]]:
+    """Yield (line, cells) for data rows only — header and separator skipped.
+
+    A markdown table header is the line immediately above the `|---|` rule, so
+    the header is recognised by lookahead rather than by guessing at its text.
+    Without this, "Phase" and "Type" get extracted as if they were claims.
+    """
+    lines = text.splitlines()
+    header_rows = set()
+    for i, line in enumerate(lines):
+        if _SEPARATOR.match(line) and i > 0:
+            header_rows.add(i - 1)
+            header_rows.add(i)
+    for i, line in enumerate(lines):
+        if i in header_rows or not line.strip().startswith("|"):
+            continue
+        yield i + 1, [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def _table_first_col(pattern: re.Pattern):
+    """Extract the first column of every markdown data row matching pattern."""
+
+    def extractor(text: str) -> Iterator[Claim]:
+        for n, cells in _table_rows(text):
+            if not cells:
+                continue
+            cell = cells[0].strip("`*_ ")
+            if pattern.fullmatch(cell):
+                yield (n, cell, "")
+
+    return extractor
+
+
+def _const_table(text: str) -> Iterator[Claim]:
+    """`| `NAME` | value | ... |` rows — name and value checked together."""
+    for n, cells in _table_rows(text):
+        if len(cells) < 2:
+            continue
+        name = cells[0].strip("`*_ ")
+        value = cells[1].strip("`*_ ")
+        if re.fullmatch(r"[A-Z][A-Z0-9_]{2,}", name) and re.fullmatch(r"-?\d+", value):
+            yield (n, f"{name}={value}", f"documented value {value}")
+
+
+def _verify_const_pair(index, claim: str) -> bool:
+    name, _, value = claim.partition("=")
+    actual = index.constants.get(name)
+    if actual is None:
+        return False
+    return actual.replace("_", "").strip() == value.strip()
+
+
+_ACKO_CHART = "aerospike-ce-kubernetes-operator"
+
+
+def _helm_set_keys(text: str) -> Iterator[Claim]:
+    """`--set key=` keys, but only for the ACKO chart.
+
+    A `helm install` block routinely installs cert-manager first, and
+    cert-manager has its own values with its own names — `crds.enabled` is
+    real there and absent from ACKO's chart. Attributing every `--set` on the
+    page to ACKO's values.yaml reports correct documentation as drift, which
+    is worse than missing it: it costs a reviewer's time and teaches everyone
+    to ignore the check.
+
+    A `--set` belongs to the most recent `helm install`/`helm upgrade`
+    command, so the extractor tracks which chart that was, across line
+    continuations.
+    """
+    in_command = False        # inside a multi-line `helm ...` invocation
+    command_is_acko = False
+
+    for n, line in _lines(text):
+        if re.search(r"\bhelm\s+(?:install|upgrade|template)\b", line):
+            in_command = True
+            command_is_acko = _ACKO_CHART in line
+        elif in_command:
+            command_is_acko = command_is_acko or _ACKO_CHART in line
+
+        if in_command:
+            attribute = command_is_acko
+            if not line.rstrip().endswith("\\"):
+                in_command = False    # command ends at the last unescaped EOL
+        else:
+            # Outside an invocation, a `--set` in an install-variant table or
+            # bullet refers to the chart the page is about, unless the line
+            # itself names another one.
+            attribute = "cert-manager" not in line
+
+        if not attribute:
+            continue
+        for m in re.finditer(r"--set(?:-string)?[= ]([A-Za-z][\w.]*)=", line):
+            yield (n, m.group(1), "")
+
+
+def _ackoctl_lines(text: str) -> Iterator[tuple[int, str]]:
+    """Lines that are an actual `ackoctl` invocation, not prose mentioning it.
+
+    Prose says things like "if `ackoctl guide get` 404s, say so and do not
+    invent a policy" — extracting every following word as a subcommand turns
+    "say", "so", "do" into failures. An invocation is either a whole line
+    inside a fenced code block, or a backticked span that starts with the
+    binary name.
+    """
+    in_fence = False
+    for n, line in _lines(text):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            # `# ackoctl has no --previous equivalent` is a comment about the
+            # CLI, and often a *negative* claim. Extracting from it inverts the
+            # check: the rule would demand that a flag the docs say does not
+            # exist does exist.
+            if stripped.startswith("#"):
+                continue
+            if stripped.startswith("ackoctl ") or " ackoctl " in f" {stripped} ":
+                yield n, stripped
+            continue
+        for m in re.finditer(r"`(ackoctl\s[^`\n]*)`", line):
+            span = m.group(1)
+            # `ackoctl <noun> <verb> [POSITIONAL] [--flag value]` is the
+            # grammar, not an invocation — `--flag` is the word "flag".
+            if re.search(r"<(?:noun|verb|flag|command|subcommand)>", span):
+                continue
+            yield n, span
+
+
+def _ackoctl_invocations(text: str) -> Iterator[Claim]:
+    """Yield the whole command path so the verifier can walk the cobra tree."""
+    for n, cmd in _ackoctl_lines(text):
+        after = cmd.split("ackoctl", 1)[1]
+        path = []
+        for token in after.split():
+            if token.startswith("-"):
+                continue  # a global flag may precede the subcommand
+            if not re.fullmatch(r"[a-z][a-z0-9-]*", token):
+                break     # placeholder, ALL-CAPS arg, shell operator
+            path.append(token)
+        if path:
+            yield (n, " ".join(path), "")
+
+
+def _verify_ackoctl_path(index, claim: str) -> bool:
+    """Walk the cobra tree, distinguishing a bad verb from a positional arg.
+
+    The rule that makes this useful: a *group* node (one with children) is
+    never invoked directly, so the next token must be one of its children. A
+    *leaf* takes positional arguments, so anything after it is data.
+
+    `ackoctl k8s pod logs` therefore fails — `k8s` has children `{cluster}` and
+    `pod` is not among them — while `ackoctl config use-context kind-local`
+    passes, because `use-context` is a leaf and `kind-local` is a context name.
+    Without the group/leaf distinction the first case passes too, which is the
+    exact drift (`k8s pod logs` → `k8s cluster logs`) this repo has already had
+    to fix once by hand.
+    """
+    tree = index.command_tree
+    path: tuple[str, ...] = ()
+    for token in claim.split():
+        children = tree.get(path, set())
+        if token in children:
+            path += (token,)
+            continue
+        if children:
+            return False       # group node, and this is not one of its verbs
+        return len(path) > 0   # leaf reached; the rest are arguments
+    return len(path) > 0
+
+
+def _ackoctl_flags(text: str) -> Iterator[Claim]:
+    """Long flags inside an actual `ackoctl` invocation."""
+    for n, cmd in _ackoctl_lines(text):
+        for m in re.finditer(r"(?<![\w-])--([a-z][\w-]*)", cmd):
+            yield (n, m.group(1), "")
+
+
+def _py_client_calls(text: str) -> Iterator[Claim]:
+    seen_on_line = set()
+    for n, line in _lines(text):
+        for m in re.finditer(r"\b(?:client|aclient|async_client)\.(\w+)\s*\(", line):
+            key = (n, m.group(1))
+            if key in seen_on_line:
+                continue
+            seen_on_line.add(key)
+            yield (n, m.group(1), "")
+
+
+def _py_exceptions(text: str) -> Iterator[Claim]:
+    """Exception classes named where the name has to be exactly right.
+
+    Two positions: caught/raised in example code, and any backticked name with
+    an `Error`/`Exception` suffix. The suffix rule alone would miss classes
+    like `RecordNotFound`, which is why the `except` / `raise` forms are
+    extracted regardless of how the name is spelled — those are the ones that
+    fail loudly at runtime if wrong.
+    """
+    for n, line in _lines(text):
+        for m in re.finditer(r"\bexcept\s+\(?([A-Za-z_][\w.]*(?:\s*,\s*[A-Za-z_][\w.]*)*)",
+                             line):
+            for name in re.split(r"\s*,\s*", m.group(1)):
+                name = name.split(".")[-1]
+                if re.fullmatch(r"[A-Z]\w*", name):
+                    yield (n, name, "caught in an example")
+        for m in re.finditer(r"\braise\s+([A-Z]\w*)\s*\(", line):
+            yield (n, m.group(1), "raised in an example")
+        for m in re.finditer(r"`([A-Z]\w*(?:Error|Exception))`", line):
+            yield (n, m.group(1), "")
+
+
+def _domain_keys(text: str) -> Iterator[Claim]:
+    """Operator-owned `acko.io/…` / `aerospike.io/…` keys.
+
+    Scoped to the two domains the operator defines. `app.kubernetes.io/*` and
+    cloud-provider annotations are upstream and are not checked — see the
+    label_keys index for why.
+    """
+    for n, line in _lines(text):
+        for m in re.finditer(
+            r"(?<![\w./-])((?:acko|aerospike)\.io/[a-z0-9._-]+)", line
+        ):
+            yield (n, m.group(1), "")
+
+
+def _condition_refs(text: str) -> Iterator[Claim]:
+    """Condition types written as `type=Foo` / `Condition<Foo>` / jsonpath.
+
+    Only forms that unambiguously name a status condition are extracted; a bare
+    capitalised word could be anything.
+    """
+    pats = (
+        r'conditions\[\?\(@\.type=="(\w+)"\)\]',   # jsonpath selector
+        r'`(Condition[A-Z]\w+)`',                  # the Go constant name
+    )
+    for n, line in _lines(text):
+        for p in pats:
+            for m in re.finditer(p, line):
+                yield (n, m.group(1), "")
+
+
+# Python builtins and stdlib names that legitimately appear in prose/examples.
+_PY_EXC_ALLOW = (
+    "Exception", "BaseException", "ValueError", "TypeError", "KeyError",
+    "RuntimeError", "OSError", "IOError", "AttributeError", "IndexError",
+    "NotImplementedError", "TimeoutError", "ConnectionError", "ImportError",
+    "HTTPException", "ValidationError", "AssertionError", "StopIteration",
+)
+
+
+RULES: list[Rule] = [
+    Rule(
+        id="acko-error-strings",
+        description="Webhook error messages quoted in the reference catalog must "
+                    "appear, run for run, in operator source",
+        globs=_ACKO_GLOBS,
+        source="acko",
+        extract=_quoted_message,
+        verify=_verify_message,
+    ),
+    Rule(
+        id="acko-crd-paths",
+        description="`spec.*` / `status.*` field paths must resolve in the "
+                    "generated CRD schema",
+        globs=_ACKO_GLOBS + ("skills/acko-deploy/examples/*.yaml",),
+        source="acko",
+        extract=_crd_paths,
+        verify=_verify_crd_path,
+    ),
+    Rule(
+        id="acko-event-reasons",
+        description="Event reasons must be defined in internal/controller/events.go",
+        globs=("skills/acko-operations/reference/events.md",),
+        source="acko",
+        extract=_table_first_col(re.compile(r"[A-Z][A-Za-z]{5,}")),
+        verify=lambda idx, c: c in idx.events,
+    ),
+    Rule(
+        id="acko-phases",
+        description="Cluster phases must be AerospikePhase constants",
+        globs=("skills/acko-config-reference/reference/conditions-and-phases.md",),
+        source="acko",
+        extract=_table_first_col(re.compile(r"[A-Z][A-Za-z]{3,}")),
+        verify=lambda idx, c: c in idx.phases or c in idx.conditions,
+    ),
+    Rule(
+        id="acko-dynamic-params",
+        description="Parameters documented as dynamic must be in the operator's "
+                    "dynamic_params.go allowlist",
+        globs=("skills/acko-config-reference/reference/parameters-8.md",),
+        source="acko",
+        extract=lambda t: _dynamic_yes_rows(t),
+        verify=lambda idx, c: any(
+            p.split(".")[-1] == c for p in idx.dynamic_params
+        ),
+    ),
+    Rule(
+        id="acko-helm-values",
+        description="`--set key=` keys must exist in the operator chart's values.yaml",
+        globs=("skills/acko-deploy/reference/helm-install.md", "skills/acko-*/**/*.md"),
+        source="acko",
+        extract=_helm_set_keys,
+        verify=lambda idx, c: c in idx.helm_values,
+    ),
+    Rule(
+        id="acko-label-keys",
+        description="Domain-qualified label/annotation keys must appear in "
+                    "operator source",
+        globs=_ACKO_GLOBS,
+        source="acko",
+        extract=_domain_keys,
+        verify=lambda idx, c: c in idx.label_keys,
+        # User-chosen, not operator-defined: the docs use it to force a
+        # pod-spec-hash change, and any annotation key would do. There is
+        # nothing in operator source for it to match.
+        ignore=("acko.io/restart-trigger",),
+    ),
+    Rule(
+        id="apy-constant-values",
+        description="Constant name+value pairs must match rust/src/constants.rs",
+        globs=("skills/aerospike-py-api/reference/constants.md",
+               "skills/aerospike-py-api/reference/policies.md"),
+        source="aerospike_py",
+        extract=_const_table,
+        verify=_verify_const_pair,
+    ),
+    Rule(
+        id="apy-client-methods",
+        description="`client.foo(...)` calls must exist on Client/AsyncClient "
+                    "in the type stubs",
+        globs=("skills/aerospike-py-*/**/*.md", "skills/aerospike-py-*/SKILL.md"),
+        source="aerospike_py",
+        extract=_py_client_calls,
+        verify=lambda idx, c: c in idx.client_methods,
+    ),
+    Rule(
+        id="apy-exceptions",
+        description="Exception class names must be defined in aerospike-py",
+        globs=("skills/aerospike-py-*/**/*.md", "skills/aerospike-py-*/SKILL.md",
+               "skills/bug-reporter/**/*.md"),
+        source="aerospike_py",
+        extract=_py_exceptions,
+        verify=lambda idx, c: c in idx.exceptions,
+        ignore=_PY_EXC_ALLOW,
+    ),
+    Rule(
+        id="apy-constant-names",
+        description="`SCREAMING_CASE` constants referenced in aerospike-py "
+                    "skills must be registered on the module",
+        globs=("skills/aerospike-py-*/**/*.md", "skills/aerospike-py-*/SKILL.md"),
+        source="aerospike_py",
+        extract=_backticked(re.compile(
+            r"(?:POLICY|AS|TTL|PRIV|AUTH|REGEX|OP|INDEX|SERIALIZER|"
+            r"CLIENT_SIDE|LOG|MAP|LIST|BIT|HLL|EXPIRATION)_[A-Z0-9_]+"
+        )),
+        verify=lambda idx, c: c in idx.constant_names,
+    ),
+    Rule(
+        id="acko-conditions",
+        description="Status condition types must be Condition* constants",
+        globs=("skills/acko-*/SKILL.md", "skills/acko-*/reference/*.md"),
+        source="acko",
+        extract=_condition_refs,
+        verify=lambda idx, c: c in idx.conditions,
+    ),
+    Rule(
+        id="ackoctl-commands",
+        description="`ackoctl <noun> <verb>` paths must resolve in the CLI's "
+                    "cobra command tree",
+        globs=("skills/ackoctl/SKILL.md", "skills/ackoctl/reference/*.md",
+               "skills/acko-debugging/**/*.md"),
+        source="ackoctl",
+        extract=_ackoctl_invocations,
+        verify=_verify_ackoctl_path,
+    ),
+    Rule(
+        id="ackoctl-flags",
+        description="Long flags on `ackoctl` lines must be registered on some "
+                    "cobra command",
+        globs=("skills/ackoctl/SKILL.md", "skills/ackoctl/reference/*.md",
+               "skills/acko-debugging/**/*.md"),
+        source="ackoctl",
+        extract=_ackoctl_flags,
+        verify=lambda idx, c: c in idx.flags,
+        ignore=("help",),
+    ),
+]
+
+
+def _dynamic_yes_rows(text: str) -> Iterator[Claim]:
+    """Rows of the parameters table whose Dynamic column says Yes."""
+    for n, cells in _table_rows(text):
+        if len(cells) < 3:
+            continue
+        name = cells[0].strip("`*_ ")
+        dynamic = cells[2].strip("`*_ ").lower()
+        if dynamic == "yes" and re.fullmatch(r"[a-z][a-z0-9-]+", name):
+            yield (n, name, "documented Dynamic=Yes")

--- a/tools/claim-check/selftest.py
+++ b/tools/claim-check/selftest.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Self-test for the claim checker.
+
+A verifier that returns True for everything passes silently and looks green
+forever — the same failure mode as the drift it exists to catch. These tests
+feed each rule a claim that is known-good and a claim that is known-bad,
+against real source checkouts, and assert it separates them.
+
+Run it the same way as the checker:
+
+    CLAIM_CHECK_SRC_ACKO=… CLAIM_CHECK_SRC_AEROSPIKE_PY=… CLAIM_CHECK_SRC_ACKOCTL=… \
+        python3 tools/claim-check/selftest.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import check_claims  # noqa: E402
+import indexes  # noqa: E402
+import rules as rulesmod  # noqa: E402
+
+# (rule id, a claim that must verify, a claim that must NOT verify)
+CASES = [
+    ("acko-error-strings",
+     "spec.size N exceeds CE maximum of 8",
+     "spec.size N exceeds the community edition limit of 8"),
+    ("acko-crd-paths", "spec.rackConfig.racks", "spec.rackConfiguration.racks"),
+    ("acko-event-reasons", "RollingRestartStarted", "RollingRestartBegun"),
+    ("acko-phases", "WaitingForMigration", "WaitingOnMigration"),
+    ("acko-conditions", "ConditionReconcileHealthy", "ConditionReconcileHappy"),
+    ("acko-dynamic-params", "proto-fd-max", "max-record-size"),
+    ("acko-helm-values", "crds.install", "crds.enabled"),
+    ("acko-label-keys", "acko.io/rack", "aerospike.io/cr-name"),
+    ("apy-constant-values", "POLICY_KEY_SEND=1", "POLICY_KEY_SEND=7"),
+    ("apy-constant-names", "POLICY_KEY_SEND", "POLICY_KEY_TRANSMIT"),
+    ("apy-client-methods", "batch_read", "batch_fetch"),
+    ("apy-exceptions", "RecordNotFound", "RecordVanishedError"),
+    ("ackoctl-commands", "k8s cluster logs", "k8s pod logs"),
+    ("ackoctl-flags", "allow-write", "allow-writes"),
+]
+
+
+def main() -> int:
+    import contextlib
+    import os
+
+    config = check_claims.json.loads((HERE / "sources.json").read_text())
+    cache_env = os.environ.get("CLAIM_CHECK_CACHE")
+    if cache_env:
+        cache_ctx = contextlib.nullcontext(cache_env)
+        Path(cache_env).mkdir(parents=True, exist_ok=True)
+    else:
+        cache_ctx = tempfile.TemporaryDirectory(prefix="claim-selftest-")
+    with cache_ctx as tmp:
+        checkouts = check_claims.resolve_checkouts(config, Path(tmp), offline=False)
+        sources = indexes.load_sources(HERE / "sources.json", checkouts)
+
+        by_id = {r.id: r for r in rulesmod.RULES}
+        failures = []
+        skipped = []
+        for rule_id, good, bad in CASES:
+            rule = by_id.get(rule_id)
+            if rule is None:
+                failures.append(f"{rule_id}: no such rule")
+                continue
+            index = sources.get(rule.source)
+            if index is None:
+                skipped.append(rule_id)
+                continue
+            if not rule.verify(index, good):
+                failures.append(f"{rule_id}: rejected a true claim {good!r}")
+            if rule.verify(index, bad):
+                failures.append(f"{rule_id}: accepted a false claim {bad!r}")
+
+    covered = {c[0] for c in CASES}
+    uncovered = sorted({r.id for r in rulesmod.RULES} - covered)
+    if uncovered:
+        failures.append(
+            "rules with no self-test case: " + ", ".join(uncovered)
+            + " — add one to CASES before merging the rule"
+        )
+
+    for f in failures:
+        print(f"FAIL {f}")
+    if skipped:
+        print(f"skipped (no source checkout): {', '.join(sorted(set(skipped)))}")
+    if failures:
+        return 1
+    print(f"selftest: {len(CASES) - len(set(skipped))} rules verified "
+          f"positive and negative")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/claim-check/sources.json
+++ b/tools/claim-check/sources.json
@@ -1,0 +1,29 @@
+{
+  "_comment": [
+    "Source repositories the skills document, and the ref each claim was last",
+    "verified against. Bump a ref only together with a run of check_claims.py",
+    "that passes at that ref -- the ref is a statement that the skills matched",
+    "that commit, not just a pointer at something newer.",
+    "",
+    "Set CLAIM_CHECK_SRC_<KEY> to reuse a local checkout instead of cloning,",
+    "e.g. CLAIM_CHECK_SRC_ACKO=/path/to/aerospike-ce-kubernetes-operator.",
+    "A local checkout is used as-is; its ref is NOT checked out or verified."
+  ],
+  "sources": {
+    "acko": {
+      "repo": "https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator.git",
+      "ref": "7cc48da957f5f407434ebb42c66fdc47c0bf9fd0",
+      "describes": "aerospike-ce-kubernetes-operator"
+    },
+    "aerospike_py": {
+      "repo": "https://github.com/aerospike-ce-ecosystem/aerospike-py.git",
+      "ref": "5db458d5686a9a0a8dfade844726eb20eaeb45ee",
+      "describes": "aerospike-py"
+    },
+    "ackoctl": {
+      "repo": "https://github.com/aerospike-ce-ecosystem/ackoctl.git",
+      "ref": "ad27c3c854abb57fa876631e6f62e0b24a5e54e3",
+      "describes": "ackoctl"
+    }
+  }
+}


### PR DESCRIPTION
Part of #97 — deliverable (b), the scoring mechanism the issue asks for first.

> "Nothing scores the skills. … That is the mechanism by which 128 claims accumulated unnoticed."

This adds a check that extracts factual claims from `skills/` and verifies each against pinned checkouts of the three source repos, wired into CI on every PR and weekly on a schedule.

## Merge order

**This PR should merge last.** It fails on current `main` — by design, because the drift is still there. The failures it reports are the same ones the other PRs fix:

| Rule | Failures on `main` | Fixed by |
|---|--:|---|
| `acko-error-strings` | 18 | #103 |
| `acko-dynamic-params` | 3 | #103 |
| `acko-event-reasons` | 5 | #107 |
| `acko-crd-paths` | 3 | #110 |
| `apy-constant-names` | 1 | the `aerospike-py-api` PR |

Once those are in, this is green. If you would rather merge it first, the honest options are to let `main` sit red or to add a baseline file, and I would not recommend the second — a baseline is how a check quietly stops meaning anything.

## What it does

```
$ python3 tools/claim-check/check_claims.py --coverage
claim-check — 745 claims checked, 30 failed, 29 skipped as unverifiable

[FAIL] acko-error-strings         92 checked   18 failed   (acko)
[FAIL] acko-crd-paths             69 checked    3 failed   (acko)
[FAIL] acko-event-reasons         46 checked    5 failed   (acko)
[PASS] acko-phases                18 checked    0 failed   (acko)
[FAIL] acko-dynamic-params         5 checked    3 failed   (acko)
[PASS] acko-helm-values           13 checked    0 failed   (acko)
[PASS] acko-label-keys             7 checked    0 failed   (acko)
[PASS] apy-constant-values       132 checked    0 failed   (aerospike_py)
[PASS] apy-client-methods        131 checked    0 failed   (aerospike_py)
[PASS] apy-exceptions             54 checked    0 failed   (aerospike_py)
[FAIL] apy-constant-names         45 checked    1 failed   (aerospike_py)
[PASS] acko-conditions            11 checked    0 failed   (acko)
[PASS] ackoctl-commands           48 checked    0 failed   (ackoctl)
[PASS] ackoctl-flags              74 checked    0 failed   (ackoctl)

coverage: 774 claims extracted from 2910 backticked spans across skills/ (26.6%).
That percentage is a floor, not a grade: the denominator counts every backticked span,
including prose formatting that is not a factual claim at all. See README.md.
```

Fourteen rules. Each builds an index from source — Go string literals, the generated CRD schema, `events.go` constants, the `dynamic_params.go` allowlist, chart `values.yaml`, PyO3 constant registrations, `.pyi` stubs, the cobra command tree — and checks the claims that shape can prove.

## On coverage, since the issue asks for honesty about it

> "a checker that verifies 20% of claims is useful if it says so; one that claims 100% and silently passes is the same failure mode as the drift itself."

**It covers about 27% by the printed metric, and that metric is deliberately unflattering.** The denominator is every backticked span in `skills/` — 2,910 of them — which includes prose emphasis, shell fragments, YAML keys in examples, and file paths that are not factual claims at all. The proportion of *actual claims* covered is higher than 26.6%, but I did not want to pick a denominator that flattered the number, so the tool prints the one that cannot be gamed and the README says what it means.

`README.md` opens with what a green run does **not** prove, and ends with a list of the audit's defect classes it would have caught versus the ones it would have missed:

**Would have caught:** `aerospike.io/cr-name` (the P0, 12 sites), the other five never-existed identifiers, `k8s pod logs` → `k8s cluster logs`, `udf register` → `udf upload`, the `configure-namespace` flags, the phantom `DynamicConfigRecovered` event, the three wrongly-dynamic parameters, and the webhook error strings that are not substrings of the real message.

**Would have missed:** the FastAPI `JSONResponse` argument-order bug (#94), the reversed NumPy `key_field` round-trip, and the inert `ping()` tuning knobs. Those are semantic. This tool is syntactic and says so in its first paragraph.

## Three design decisions worth review

**1. `selftest.py` — a rule that accepts everything looks exactly like a passing rule.** Every rule gets one claim that must verify and one that must not, run against real checkouts. It fails if any rule lacks a case, so coverage of the self-test cannot silently rot either.

This caught two real bugs while I was writing the tool:

- `apy-exceptions` rejected `RecordNotFound`, because the index assumed every exception class ends in `Error`. Several don't — `RecordNotFound`, `RecordTooBig`, `BinNotFound`, `FilteredOut`.
- `ackoctl-commands` **accepted** `k8s pod logs`. The walk stopped at the first unrecognised token and called it a positional argument. That is the exact wrong-verb drift this repo already fixed by hand once (CHANGELOG, Unreleased). Fixed by reconstructing the cobra tree properly and distinguishing a group node (next token must be one of its children) from a leaf (the rest are arguments), so `config use-context kind-local` passes and `k8s pod logs` fails.

**2. A false positive is treated as worse than a miss.** Reporting correct documentation as drift wastes review time and, repeated, trains everyone to skim past the check. Three rules carry extra logic for this, each of which I hit for real:

- `acko-helm-values` attributes each `--set` to the chart of the enclosing `helm install`. Without it, `--set crds.enabled=true` on the **cert-manager** line in `acko-deploy` is reported as a bad ACKO value. It is a real cert-manager value, and the docs are correct.
- `ackoctl-flags` skips comment lines inside code fences. `# ackoctl has no --previous equivalent` is a *negative* claim; extracting from it inverts the check.
- Table rules read data rows only, never the header, or "Phase" and "Type" get checked as claims.

**3. The pinned ref is a claim, not a pointer.** `sources.json` pins a full SHA per repo, and the README says bumping one asserts that the skills were checked against that commit and passed. A ref advanced as routine maintenance turns the tool into decoration.

## All six PRs together: green

I merged every PR in this set onto `origin/main` in a throwaway branch and ran the check. Exit 0, all fourteen rules passing:

```
$ python3 tools/claim-check/check_claims.py --coverage
claim-check — 774 claims checked, 0 failed, 37 skipped as unverifiable

[PASS] acko-error-strings        107 checked    0 failed   (acko)
[PASS] acko-crd-paths             79 checked    0 failed   (acko)
[PASS] acko-event-reasons         46 checked    0 failed   (acko)
[PASS] acko-phases                18 checked    0 failed   (acko)
[PASS] acko-dynamic-params         2 checked    0 failed   (acko)
[PASS] acko-helm-values           13 checked    0 failed   (acko)
[PASS] acko-label-keys             7 checked    0 failed   (acko)
[PASS] apy-constant-values       132 checked    0 failed   (aerospike_py)
[PASS] apy-client-methods        135 checked    0 failed   (aerospike_py)
[PASS] apy-exceptions             57 checked    0 failed   (aerospike_py)
[PASS] apy-constant-names         45 checked    0 failed   (aerospike_py)
[PASS] acko-conditions            11 checked    0 failed   (acko)
[PASS] ackoctl-commands           48 checked    0 failed   (ackoctl)
[PASS] ackoctl-flags              74 checked    0 failed   (ackoctl)

coverage: 811 claims extracted from 3205 backticked spans across skills/ (25.3%).
$ echo $?
0
```

Each PR touches the `Unreleased` section of `CHANGELOG.md`, so whichever merges second onto `main` will conflict there. The conflicts are additive list entries only — no PR edits another's lines.

Running the checker over the branches is also what turned up the last four defects in this set, after I thought I was finished: a merged namespace-entry error message, two messages whose interpolated argument had been baked into the documented text, and the aerospike-py `CLIENT_SIDE_RESULT_CODE` mention. That is the tool doing the job it was built for, on its own author.

## What CI does

- Runs `selftest.py` **before** the check, so no rule is trusted until it has demonstrated it can fail.
- Runs `check_claims.py --strict`, so a source repo that could not be cloned fails the job rather than looking like a clean run.
- Caches the checkouts keyed on `hashFiles('sources.json')`, so a ref bump re-clones instead of verifying against the previous commit and passing for the wrong reason.
- Writes a per-rule table to the job summary and uploads the JSON report.
- Runs weekly on a schedule as well as on PRs — drift introduced by a change in a *source* repo is invisible to any PR in this one.

## Verification

Everything below was run locally against the pinned refs.

**Self-test, positive and negative, every rule:**

```
$ CLAIM_CHECK_CACHE=… python3 tools/claim-check/selftest.py
selftest: 14 rules verified positive and negative
$ echo $?
0
```

**Exit status is non-zero while drift exists:**

```
$ python3 tools/claim-check/check_claims.py --strict
$ echo $?
1
```

**The clone path works unauthenticated, exactly as CI runs it** (no `CLAIM_CHECK_SRC_*` set):

```
$ env -u CLAIM_CHECK_SRC_ACKO -u CLAIM_CHECK_SRC_AEROSPIKE_PY -u CLAIM_CHECK_SRC_ACKOCTL \
    CLAIM_CHECK_CACHE=… python3 tools/claim-check/check_claims.py --strict
claim-check — 771 claims checked, 32 failed, 29 skipped as unverifiable
[FAIL] acko-error-strings         92 checked   18 failed   (acko)
…
```

The counts match the run against local checkouts at the same commits, so cloning and checkout are not silently truncating anything.

**A cached run is fast** — the whole self-test is 2.3s once the checkouts exist:

```
$ time python3 tools/claim-check/selftest.py
selftest: 14 rules verified positive and negative
0.59s user 0.12s system 30% cpu 2.340 total
```

**Pinned refs:**

```
$ python3 -c "import json;print(json.load(open('tools/claim-check/sources.json'))['sources'])"
acko          7cc48da957f5f407434ebb42c66fdc47c0bf9fd0
aerospike_py  5db458d5686a9a0a8dfade844726eb20eaeb45ee
ackoctl       ad27c3c854abb57fa876631e6f62e0b24a5e54e3
```

**Dependencies:** Python 3.10+ and PyYAML. Nothing else; no network at check time beyond the clones.

## What I did not do

The issue's suggested fix (1) is to convert `evals/evals.json` into `evals/<case>/prompt.md` + `graders/*.md` so `claude plugin eval` can run it. **That is not in this PR.** It is a different mechanism answering a different question — the eval suite scores whether the right skill *triggers* and behaves, this scores whether the skill's content is *true* — and the two want separate review. The eval conversion also needs decisions I should not make alone: which behaviours are worth a case, and what the graders assert.

I also have not touched `.github/workflows/link-check.yml` to pin `gaurav-nelson/github-action-markdown-link-check@v1` to a SHA, which #97 mentions as a smaller item. It is unrelated to this change and would be a one-line PR.
