### PR TITLE
security(ci): add CodeQL, dependency review, and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Dependency update PRs. Added alongside CodeQL and dependency-review
+# because this repository had no dependency scanning of any kind.
+# See aerospike-ce-ecosystem/project-hub#160.
+version: 2
+updates:
+  # the only Python manifest
+  - package-ecosystem: "pip"
+    directory: "/skills/acko-e2e-test/e2e_pytest"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      pip-deps:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-deps:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+name: codeql
+# GitHub-native static analysis. Results land in the repository's Security tab
+# under Code scanning, and on pull requests as inline annotations.
+#
+# Added because no repository in the organisation ran any code scanning, while
+# this one publishes the Claude Code plugin via GitHub Releases.
+# See aerospike-ce-ecosystem/project-hub#160.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so new CodeQL queries are applied to code that is not changing.
+    - cron: '17 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      # Required to upload results to the code-scanning API.
+      security-events: write
+      # Required by the CodeQL action to read workflow run status.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # skills/acko-e2e-test/e2e_pytest/ test suite
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,35 @@
+name: dependency-review
+# Fails a pull request that introduces a dependency with a known vulnerability,
+# before it can reach a published artefact. GitHub-native; reads the dependency
+# graph rather than running a third-party scanner.
+#
+# See aerospike-ce-ecosystem/project-hub#160.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      # Lets the action post its summary as a PR comment.
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # Block on high and critical; report the rest without failing, so
+          # this lands without stalling unrelated work on day one.
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
This is the `aerospike-ce-ecosystem-plugins` part of `aerospike-ce-ecosystem/project-hub#160` — no code, dependency, or secret scanning anywhere in the organisation. One PR per repo; this one adds only new files, so it cannot conflict with anything in flight here.

## Evidence this repo has never been scanned

```
$ gh api repos/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/code-scanning/analyses
{"message":"no analysis found","documentation_url":"https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository","status":"404"}
```

## What this adds

- `.github/dependabot.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/dependency-review.yml`

Nothing existing is modified:

```
$ git diff --cached --name-status
A	.github/dependabot.yml
A	.github/workflows/codeql.yml
A	.github/workflows/dependency-review.yml
```

| CodeQL language | Build mode | Covers |
|---|---|---|
| `python` | `none` | `skills/acko-e2e-test/e2e_pytest/` — the repo's only Python source |

### Scope note

This repo is mostly Markdown skills; the only compilable source is the pytest suite under `skills/acko-e2e-test/e2e_pytest/`. CodeQL covers that, which is honest about what there is to scan rather than claiming broader coverage.

`.github/dependabot.yml` is new. Its `pip` entry points at `/skills/acko-e2e-test/e2e_pytest` — the manifest sits four levels deep, and a `directory: "/"` entry would silently track nothing.

## Verification

Every added file parses, and the CodeQL matrix resolves to the languages above:

```
$ python3 -c "import yaml; ..."
aerospike-ce-ecosystem-plugins     .github/workflows/codeql.yml               OK
aerospike-ce-ecosystem-plugins     .github/workflows/dependency-review.yml    OK
aerospike-ce-ecosystem-plugins     .github/dependabot.yml                     OK
```
(Full run across all repos in this batch: **21 files parsed, 0 failures**.)

## Why GitHub-native rather than a third-party scanner

The issue asked for GitHub-native tooling, and it is the right call here: CodeQL results land in the repository's Security tab and on the PR itself with no extra account, no extra token, and no new supply-chain dependency in the scanning path. Trivy/gitleaks/semgrep would each add one.

## Actions are SHA-pinned

The issue notes only 3 of ~190 `uses:` references across the org are SHA-pinned. Every action added here is:

```
actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1        # v7.0.1
github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd    # v4
github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
```

Each SHA was resolved from the tag, dereferencing annotated tags to their commit:

```
$ gh api repos/github/codeql-action/git/ref/tags/v4 --jq '.object.type + " " + .object.sha'
tag 988661ebb5e81487b3fb31b2185d2856c0a10679
$ gh api repos/github/codeql-action/git/tags/988661ebb5e81487b3fb31b2185d2856c0a10679 --jq .object.sha
ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd
```

## Secret scanning still needs a settings change — no workflow can do it

GitHub's secret scanning and push protection are repository/org settings, not workflows. Both are off across the whole org:

```
$ gh api repos/aerospike-ce-ecosystem/<repo> \
    --jq '.security_and_analysis.secret_scanning.status + "/" + .security_and_analysis.secret_scanning_push_protection.status'
disabled/disabled
```

I did not change it — that is a settings change and outside what this PR was authorised to do. Enabling it org-wide is **Organisation settings → Code security → Secret scanning / Push protection → Enable for all repositories**, or per repo:

```bash
gh api -X PATCH repos/aerospike-ce-ecosystem/<repo> \
  -f 'security_and_analysis[secret_scanning][status]=enabled' \
  -f 'security_and_analysis[secret_scanning_push_protection][status]=enabled'
```

## Update: these workflows have now actually run on this PR

The earlier caveat that nothing had been exercised no longer applies. Results on `0d9125f`:

```
Analyze (python)                   success
CodeQL                             success
dependency-review                  success
```

Every added job is green, and no existing check on this PR regressed.

**One thing this flushed out.** `dependency-review` failed on the first attempt in every repo in this batch, with:

```
##[error]Dependency review is not supported on this repository. Please ensure that
Dependency graph is enabled, see .../settings/security_analysis
```

That was not a vulnerability finding and not a workflow defect — the **dependency graph was switched off org-wide**. It has since been enabled, and a re-run of the same job passes unchanged. Secret scanning and push protection were enabled at the same time, which closes the part of #160 that no workflow could address:

```
$ gh api repos/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins \
    --jq '"secret_scanning=" + .security_and_analysis.secret_scanning.status \
        + " push_protection=" + .security_and_analysis.secret_scanning_push_protection.status'
secret_scanning=enabled push_protection=enabled
```

Worth knowing for the other repos: if `dependency-review` ever fails with that message again, the fix is the setting, not the workflow.

## Still not verified

- CodeQL's **first analysis of the default branch** only happens after merge, so `code-scanning/analyses` will keep returning 404 until then. The PR-triggered analyses above prove the workflow runs and the language packs resolve; they do not populate the default-branch alert list.
- `fail-on-severity: high` is deliberately not `low`, so this lands without stalling unrelated PRs on day one. Tighten it once a baseline exists.
