### PR TITLE
fix(skills): define MODEL_W/MODEL_B and correct the column_stack zero-copy claim

### DIFF
--- a/skills/aerospike-py-fastapi/reference/patterns.md
+++ b/skills/aerospike-py-fastapi/reference/patterns.md
@@ -42,6 +42,10 @@ import torch
 
 _FEATURE_DTYPE = np.dtype([("score", "f4"), ("count", "i4")])  # cache at module level
 
+# Load once at startup — a real app reads these from a checkpoint.
+MODEL_W = torch.zeros(len(_FEATURE_DTYPE.names), dtype=torch.float32)
+MODEL_B = torch.zeros(1, dtype=torch.float32)
+
 @app.post("/records:predict")
 async def predict(req: BatchReadReq, client: AsyncClient = Depends(get_client)):
     keys = [(NS, SET, k) for k in req.keys]
@@ -49,7 +53,23 @@ async def predict(req: BatchReadReq, client: AsyncClient = Depends(get_client)):
     np_batch = lazy_records.to_numpy(_FEATURE_DTYPE)    # GIL released during fill
     matrix = torch.from_numpy(np.column_stack([
         np_batch.batch_records[name] for name in _FEATURE_DTYPE.names
-    ]))                                                 # O(1) buffer share
+    ]))                                                 # column_stack COPIES (see note)
     scores = (matrix @ MODEL_W + MODEL_B).tolist()
     return {"scores": scores}
 ```
+
+**`np.column_stack` is not zero-copy.** `torch.from_numpy` shares the buffer, but the
+`column_stack` feeding it allocates a new contiguous array first, and it promotes mixed field
+dtypes to a common type — `f4` + `i4` becomes `float64`, doubling the memory and silently
+changing the precision the model sees:
+
+```python
+>>> dt = np.dtype([("score", "f4"), ("count", "i8")])
+>>> out = np.column_stack([a[n] for n in dt.names])
+>>> out.dtype, np.shares_memory(out, a)
+(dtype('float64'), False)
+```
+
+If the copy matters, build the matrix at the dtype you want and fill it column-wise
+(`np.empty((n, k), dtype=np.float32)` then assign each column), so the promotion happens once at
+a type you chose rather than implicitly at `float64`.


### PR DESCRIPTION
## Problem

Two defects in the `aerospike-py-fastapi` inference example (`reference/patterns.md`), both recorded in #94 and deliberately deferred from #101 to keep that PR one logical change.

**1. `NameError` — the snippet does not run.** `MODEL_W` and `MODEL_B` are used at `:53` but never defined anywhere in the example.

**2. The `# O(1) buffer share` comment is backwards.** It annotates the `np.column_stack(...)` call. `torch.from_numpy` genuinely shares the buffer, but the `column_stack` feeding it allocates a new contiguous array *and* promotes mixed field dtypes to a common type. Measured:

```
$ uv run --with numpy python -c "..."
column_stack result dtype : float64  (inputs were f4 and i8)
shares memory with input? : False
base is None (new alloc)? : True
```

So the documented "zero-copy chain" copies, doubles the memory, and silently changes the precision the model sees — in the one example whose entire purpose is avoiding copies. A reader optimising a hot inference path would trust this and get the opposite of what they wanted.

## Fix

- Define `MODEL_W` / `MODEL_B` at module level, with a note that a real app loads them from a checkpoint.
- Replace the misleading comment, add the measurement above so the claim is checkable, and give the alternative for callers who care: allocate at the dtype you want (`np.empty((n, k), dtype=np.float32)`) and fill column-wise, so promotion happens once at a type you chose rather than implicitly at `float64`.

## Verification

The dtype/copy behaviour is the measured output quoted above, run against real numpy. `claude plugin validate .` → `✔ Validation passed`.

**Not verified:** I did not execute the full handler — it needs `aerospike_py` and `torch`, neither installed here. The two claims being corrected are pure-numpy behaviour, which is what I measured.

## Risk

Very low — one markdown file, example code only.

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
