### PR TITLE
fix(release): open a PR when the manifest bump cannot reach main

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -84,6 +85,8 @@ jobs:
       - name: Sync plugin manifest version
         if: steps.changes.outputs.skip == 'false' && github.ref == 'refs/heads/main'
         continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # plugin.json records bare semver; git tags carry the 'v' prefix.
           MANIFEST_VERSION="${{ steps.version.outputs.next_version }}"
@@ -114,7 +117,43 @@ jobs:
             git rebase origin/main || { git rebase --abort || true; break; }
           done
 
-          echo "::warning::plugin.json not synced to ${MANIFEST_VERSION} (push to main failed). Releasing anyway; the next run retries."
+          # Reaching here means the push was refused for a reason a rebase does
+          # not fix. Since 2026-08-18 that reason is branch protection: the
+          # `protect-main` ruleset requires a pull request on the default branch
+          # and its only bypass actor is the admin repository role, which
+          # GITHUB_TOKEN does not hold. The retry loop above can therefore never
+          # succeed while that rule is active, and the old behaviour — warn and
+          # move on — let the manifest drift from the tag silently, which is the
+          # exact defect #88 was filed for.
+          #
+          # Fall back to a pull request. The branch name is fixed, so repeated
+          # releases force-update one PR in place rather than opening a new one
+          # every night. Only the default branch is protected, so this push is
+          # allowed. The release itself is still never blocked: every path here
+          # ends in `exit 0`.
+          BRANCH=chore/sync-plugin-manifest
+
+          if ! git push --force origin "HEAD:refs/heads/${BRANCH}"; then
+            echo "::warning::plugin.json not synced to ${MANIFEST_VERSION}: pushing ${BRANCH} failed too."
+            exit 0
+          fi
+
+          if gh pr view "${BRANCH}" --json number >/dev/null 2>&1; then
+            gh pr edit "${BRANCH}" --title "chore(release): sync plugin.json to ${MANIFEST_VERSION}" || true
+            echo "::warning::plugin.json on main is stale; updated the open ${BRANCH} PR to ${MANIFEST_VERSION}."
+          else
+            gh pr create --base main --head "${BRANCH}" \
+              --title "chore(release): sync plugin.json to ${MANIFEST_VERSION}" \
+              --body "$(printf '%s\n' \
+                "\`.claude-plugin/plugin.json\` records the plugin version that Claude Code reads at install time, so it has to match the release tag." \
+                "" \
+                "The daily release job used to commit this bump straight to \`main\`. Branch protection now requires a pull request there, and \`GITHUB_TOKEN\` is not a bypass actor, so the job opens this PR instead." \
+                "" \
+                "Merging it is the whole fix; the next release force-updates this same branch rather than opening another PR." \
+                "" \
+                "Refs #88.")" || true
+            echo "::warning::plugin.json on main is stale; opened a ${BRANCH} PR for ${MANIFEST_VERSION}."
+          fi
           exit 0
 
       - name: Generate release notes with Claude


### PR DESCRIPTION
## What breaks tonight without this

Enabling branch protection here (project-hub#159) silently reintroduced #88.

`daily-release.yml` bumps `.claude-plugin/plugin.json` and pushes the commit
straight to `main`. The `protect-main` ruleset now requires a pull request on the
default branch, and its only bypass actor is `RepositoryRole: 5` (admin), which
`GITHUB_TOKEN` does not hold:

```
$ gh api repos/aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins/rules/branches/main --jq '[.[].type]'
["deletion","non_fast_forward","pull_request"]

$ gh api .../rulesets/19100957 --jq '.bypass_actors'
[{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"always"}]
```

The step tolerates failure on purpose — three attempts, a rebase between each,
then `::warning::` and `exit 0` — because a stale manifest beats a missed
release. That was right when the failure was transient. It is not transient now:
**every** future run takes the give-up path, so `plugin.json` freezes at the
version it held when protection went on while the tags keep moving. That is
#88, restored, and the only signal is a workflow warning nobody reads.

The clock is real. The ruleset went active at `2026-08-18T05:42Z`; the last
successful manifest push was `2026-08-17T22:16Z`, before it. `main` is 12
`fix:`/`feat:` commits ahead of `v1.6.4`, so the next scheduled run cuts a new
version and drifts.

## The change

Rebasing cannot fix a rule violation, so after the retry loop the step
force-pushes to a fixed branch (`chore/sync-plugin-manifest`) and opens a PR.
Constant branch name, so consecutive releases update one PR in place rather than
opening one per night. Only the default branch is protected, so that push is
allowed. Also adds `pull-requests: write`, needed to open the PR.

## Verification

Ran the real step against a local bare repo whose `update` hook refuses
`refs/heads/main` exactly as GitHub does, with `gh` stubbed to record its calls:

| scenario | result |
| --- | --- |
| protected, no PR open | branch + PR created, `main` untouched, `exit 0` |
| protected, PR already open | same branch force-updated, **no second PR**, `exit 0` |
| **unprotected (happy path)** | **pushes to `main`, `gh` never invoked, no side branch** |
| version already in sync | no commit, no push, no PR |

The third row is the regression check: drop the rule and the old behaviour
returns byte for byte, with the fallback dormant. `shellcheck -S style` is clean
on the extracted step, and the diff `jq` produces on the real `plugin.json` is
one line:

```
3c3
<   "version": "1.6.4",
---
>   "version": "1.7.0",
```

## The alternative, if you would rather not merge this

Match the operator repo: drop `pull_request` from this repo's ruleset, leaving
`deletion` + `non_fast_forward`. ACKO is configured that way for this exact
reason — its `daily-release.yml` also pushes to `main`. That keeps releases
zero-touch at the cost of the protection you asked for on this repo. This PR
keeps the protection and costs one merge per release instead.

Refs #88, project-hub#159.