### PR TITLE
fix(skills): three sites call parameters dynamic that cold-restart the pods

### DIFF
--- a/skills/acko-config-reference/reference/parameters-8.md
+++ b/skills/acko-config-reference/reference/parameters-8.md
@@ -29,7 +29,7 @@ When `enableDynamicConfigUpdate: true` is set in the CR, the operator uses these
 ```bash
 # asinfo commands
 asinfo -v "set-config:context=service;batch-index-threads=16"
-asinfo -v "set-config:context=namespace;id=ns1;max-record-size=256K"
+asinfo -v "set-config:context=namespace;id=ns1;nsup-period=60"
 
 # asadm commands
 asadm -e 'enable; manage config service param proto-fd-max to 100000'

--- a/skills/acko-operations/SKILL.md
+++ b/skills/acko-operations/SKILL.md
@@ -36,7 +36,8 @@ Set `spec.enableDynamicConfigUpdate: true`, then patch the config value. The ope
 - **Removing** a key always forces a rolling restart (revert-to-default is not expressible as `set-config`). `replication-factor` (and legacy `memory-size`) are never dynamic — they cold-restart.
 - **ConfigDegraded** (apply AND rollback both failed): reconciliation **halts** with `ConfigDegradedSkip` Warning events (~60s requeue) until you intervene — revert the offending value, then cold-restart pods / reset the phase. Do NOT toggle `enableDynamicConfigUpdate`. Full recovery flow: `acko-debugging` skill.
 
-Common dynamic params: `proto-fd-max`, `max-record-size`, `stop-writes-sys-memory-pct`, `evict-used-pct`, `evict-tenths-pct`, `nsup-period`.
+Common dynamic params: `proto-fd-max`, `stop-writes-sys-memory-pct`, `nsup-period`, `batch-index-threads`, `migrate-threads`, `default-ttl`.
+NOT dynamic despite reading like tuning knobs: `max-record-size`, `evict-used-pct`, `evict-tenths-pct` — absent from the operator's allowlist (`internal/configdiff/dynamic_params.go`), so editing one cold-restarts the pods. Full list: `acko-config-reference` → `parameters-8.md`.
 
 ## 4. Warm / Cold Restart — spec.operations (ops ref §3)
 

--- a/skills/acko-operations/reference/operations.md
+++ b/skills/acko-operations/reference/operations.md
@@ -66,7 +66,7 @@ spec:
       proto-fd-max: 20000               # Dynamic parameter
     namespaces:
       - name: test
-        evict-used-pct: 70              # Dynamic parameter (CE 8.1)
+        evict-used-pct: 70              # NOT dynamic — editing this cold-restarts the pods
         stop-writes-sys-memory-pct: 90  # Dynamic parameter (CE 8.1)
 ```
 


### PR DESCRIPTION
Found while auditing whether the 34 issues closed on 2026-08-17/18 hold. #96 is closed, and one of its clusters — (e), the dynamic-parameter claims — is fixed in the reference table and wrong in three other places, including a `SKILL.md`.

`acko-config-reference/reference/parameters-8.md` already says it correctly:

| `max-record-size` | **1M** | No | … Absent from the operator's dynamic allowlist — editing it cold-restarts the pods |
| `evict-used-pct` | **70** | No | … Absent from the operator's dynamic allowlist — editing it cold-restarts the pods |
| `evict-tenths-pct` | **5** | No | … Absent from the operator's dynamic allowlist — editing it cold-restarts the pods |

## Checked against the operator, not against the other skills

Both the pinned checkout (`1612083e`) and current `main` carry an identical parameter set in `internal/configdiff/dynamic_params.go` — I diffed the two key sets and they match exactly:

```
max-record-size                       NOT IN dynamicParams
evict-used-pct                        NOT IN dynamicParams
evict-tenths-pct                      NOT IN dynamicParams
service.proto-fd-max                  :16  true
namespace.stop-writes-sys-memory-pct  :51  true
namespace.nsup-period                 :56  true
service.batch-index-threads           :19  true
service.migrate-threads               :25  true
namespace.default-ttl                 :47  true
```

## The three sites

**`acko-operations/SKILL.md:39`** listed all six as "Common dynamic params" — half of them wrong, in a `SKILL.md`, which is always loaded and least re-checked. Now lists six that are genuinely in the allowlist, plus an explicit *NOT dynamic despite reading like tuning knobs* line for the three, naming `internal/configdiff/dynamic_params.go` so the next reader can check instead of trust.

**`acko-operations/reference/operations.md:69`** annotated `evict-used-pct: 70` with `# Dynamic parameter (CE 8.1)`. The `stop-writes-sys-memory-pct` line directly under it is correct and stays — which is what made the wrong one plausible.

**`acko-config-reference/reference/parameters-8.md:32`** used `max-record-size=256K` as the worked example under `## Dynamic Config Change Commands`, introduced as *"the operator uses these commands internally"*. It does not, for that parameter — and the same file's table, 25 lines above, says so. Swapped for `nsup-period=60`.

## Why this one matters

It is #96's own stated production-impact case: *"Promising a dynamic update that actually triggers a rolling restart is a production-impact error."* Someone reading `SKILL.md:39` and patching `evict-used-pct` on a live cluster gets a cold restart they did not plan for.

## The checker cannot catch this

`scripts/verify_skill_claims.py` has no dynamic-param extractor, so a claim of this shape exits 0 either way. It still passes after this change — **425 claims, 0 drifted, exit 0** — which is the point: green there does not mean the skills are correct, exactly as `COVERAGE` at `:629-634` says.

Refs #96.